### PR TITLE
Upgrade Wiremock and use wiremock-jre8 which supports better jdk11

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -67,8 +67,8 @@
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
-            <version>2.18.0</version>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.21.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
See https://github.com/tomakehurst/wiremock/issues/970