### PR TITLE
Implement Cluster Configuration

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/api/ConfigResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/ConfigResource.java
@@ -115,7 +115,7 @@ public class ConfigResource {
         try {
             PropertiesConfigurationStore simpleStore = buildStore(newConfiguration);
             dumpAndValidateInputConfiguration(simpleStore);
-            server.applyDynamicConfiguration(simpleStore);
+            server.applyDynamicConfigurationFromAPI(simpleStore);
             return ConfigurationChangeResult.OK;
         } catch (ConfigurationNotValidException
                 | ConfigurationChangeInProgressException

--- a/carapace-server/src/main/java/org/carapaceproxy/cluster/GroupMembershipHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/cluster/GroupMembershipHandler.java
@@ -81,5 +81,10 @@ public interface GroupMembershipHandler {
          * @param eventId
          */
         void eventFired(String eventId);
+
+        /**
+         * Called whenever ZK connection has been re-established.
+         */
+        void reconnected();
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/ApplyConfigurationTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/ApplyConfigurationTest.java
@@ -414,7 +414,7 @@ public class ApplyConfigurationTest {
 
     private void reloadConfiguration(Properties configuration, final HttpProxyServer server) throws ConfigurationNotValidException, ConfigurationChangeInProgressException, InterruptedException {
         PropertiesConfigurationStore config = new PropertiesConfigurationStore(configuration);
-        server.applyDynamicConfiguration(config);
+        server.applyDynamicConfigurationFromAPI(config);
     }
 
     private void testIt(int port, boolean ok) throws URISyntaxException, IOException {

--- a/carapace-server/src/test/java/org/carapaceproxy/BigUploadTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/BigUploadTest.java
@@ -181,7 +181,7 @@ public class BigUploadTest {
             int size = 20_000_000;
 
             ConnectionsManagerStats stats;
-            try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+            try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
                 server.start();
                 int port = server.getLocalPort();
                 URL url = new URL("http://localhost:" + port + "/index.html");
@@ -237,7 +237,7 @@ public class BigUploadTest {
             EndpointKey key = new EndpointKey("localhost", mockServer.getPort());
 
             ConnectionsManagerStats stats;
-            try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+            try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
                 server.start();
                 int port = server.getLocalPort();
                 URL url = new URL("http://localhost:" + port + "/index.html");

--- a/carapace-server/src/test/java/org/carapaceproxy/ConcurrentClientsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/ConcurrentClientsTest.java
@@ -72,7 +72,7 @@ public class ConcurrentClientsTest {
         int size = 100;
         int concurrentClients = 4;
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 

--- a/carapace-server/src/test/java/org/carapaceproxy/ConnectionPoolTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/ConnectionPoolTest.java
@@ -37,28 +37,31 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class ConnectionPoolTest {
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(0);
 
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
+
     @Test
-//    @Ignore
     public void test() throws Exception {
 
         stubFor(get(urlEqualTo("/index.html"))
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "text/html")
-                .withHeader("Content-Length", "2")
-                .withBody("ok")));
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/html")
+                        .withHeader("Content-Length", "2")
+                        .withBody("ok")));
 
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.port());
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
             stats = server.getConnectionsManager().getStats();

--- a/carapace-server/src/test/java/org/carapaceproxy/DatabaseConfigurationTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/DatabaseConfigurationTest.java
@@ -79,7 +79,7 @@ public class DatabaseConfigurationTest {
 
             Properties newConfig = new Properties();
             newConfig.put("filter.1.type", "add-x-forwarded-for");
-            server.applyDynamicConfiguration(new PropertiesConfigurationStore(newConfig));
+            server.applyDynamicConfigurationFromAPI(new PropertiesConfigurationStore(newConfig));
 
             assertThat(server.getDynamicConfigurationStore(), instanceOf(HerdDBConfigurationStore.class));
             assertEquals(1, server.getFilters().size());
@@ -89,7 +89,7 @@ public class DatabaseConfigurationTest {
             Properties configuration = new Properties();
             configuration.put("filter.1.type", "add-x-forwarded-for");
             configuration.put("filter.2.type", "match-user-regexp");
-            server.applyDynamicConfiguration(new PropertiesConfigurationStore(configuration));
+            server.applyDynamicConfigurationFromAPI(new PropertiesConfigurationStore(configuration));
 
             // verify configuration is applied
             assertEquals(2, server.getFilters().size());
@@ -113,7 +113,7 @@ public class DatabaseConfigurationTest {
             // remove one filter
             Properties configuration = new Properties();
             configuration.put("filter.2.type", "match-user-regexp");
-            server.applyDynamicConfiguration(new PropertiesConfigurationStore(configuration));
+            server.applyDynamicConfigurationFromAPI(new PropertiesConfigurationStore(configuration));
 
         }
         // reboot, new configuration MUST be kept

--- a/carapace-server/src/test/java/org/carapaceproxy/RawClientTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/RawClientTest.java
@@ -66,7 +66,7 @@ public class RawClientTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -98,7 +98,7 @@ public class RawClientTest {
         EndpointKey key = new EndpointKey("localhost", 1111);
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -142,7 +142,7 @@ public class RawClientTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -185,7 +185,7 @@ public class RawClientTest {
         EndpointKey key = new EndpointKey("localhost", 1111);
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -239,7 +239,7 @@ public class RawClientTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -307,7 +307,7 @@ public class RawClientTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 

--- a/carapace-server/src/test/java/org/carapaceproxy/SimpleHTTPProxyTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/SimpleHTTPProxyTest.java
@@ -69,7 +69,7 @@ public class SimpleHTTPProxyTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -183,7 +183,7 @@ public class SimpleHTTPProxyTest {
         EndpointKey key = new EndpointKey("localhost", badPort);
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 

--- a/carapace-server/src/test/java/org/carapaceproxy/api/ClusterReconfigTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/ClusterReconfigTest.java
@@ -38,6 +38,7 @@ public class ClusterReconfigTest extends UseAdminServer {
             configuration.put("config.type", "database");
             configuration.put("mode", "cluster");
             configuration.put("zkAddress", testingServer.getConnectString());
+            configuration.put("db.bookie.allowLoopback", "true");
 
             startServer(configuration);
 

--- a/carapace-server/src/test/java/org/carapaceproxy/api/ClusterReconfigTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/ClusterReconfigTest.java
@@ -1,0 +1,95 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package org.carapaceproxy.api;
+
+import java.util.Properties;
+import org.apache.curator.test.TestingServer;
+import org.carapaceproxy.client.impl.ConnectionsManagerImpl;
+import org.carapaceproxy.utils.RawHttpClient;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class ClusterReconfigTest extends UseAdminServer {
+
+    @Test
+    public void testReconfigInClusterMode() throws Exception {
+        try (TestingServer testingServer = new TestingServer(2229, tmpDir.newFolder());) {
+            testingServer.start();
+            Properties configuration = new Properties();
+
+            configuration.put("config.type", "database");
+            configuration.put("mode", "cluster");
+            configuration.put("zkAddress", testingServer.getConnectString());
+
+            startServer(configuration);
+
+            try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
+                String body = "connectionsmanager.connecttimeout=8000\n"
+                        + "healthmanager.period=25";
+                RawHttpClient.HttpResponse resp = client.executeRequest("POST /api/config/apply HTTP/1.1\r\n"
+                        + "Host: localhost\r\n"
+                        + "Content-Type: text/plain\r\n"
+                        + "Content-Length: " + body.length() + "\r\n"
+                        + "Authorization: Basic " + credentials.toBase64() + "\r\n"
+                        + "\r\n"
+                        + body);
+                String s = resp.getBodyString();
+                System.out.println("s:" + s);
+                assertTrue(s.equals("{\"ok\":true,\"error\":\"\"}"));
+
+            }
+
+            // restart, same "static" configuration
+            stopServer();
+            buildNewServer();
+            startServer(configuration);
+            ConnectionsManagerImpl impl = (ConnectionsManagerImpl) server.getConnectionsManager();
+            assertEquals(8000, impl.getConnectTimeout());
+            assertEquals(25, server.getBackendHealthManager().getPeriod());
+            System.out.println("QUIIIIIIIIII");
+            try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
+                String body = "connectionsmanager.connecttimeout=9000\n"
+                        + "healthmanager.period=30";
+                RawHttpClient.HttpResponse resp = client.executeRequest("POST /api/config/apply HTTP/1.1\r\n"
+                        + "Host: localhost\r\n"
+                        + "Content-Type: text/plain\r\n"
+                        + "Content-Length: " + body.length() + "\r\n"
+                        + "Authorization: Basic " + credentials.toBase64() + "\r\n"
+                        + "\r\n"
+                        + body);
+                String s = resp.getBodyString();
+                System.out.println("s:" + s);
+                assertTrue(s.equals("{\"ok\":true,\"error\":\"\"}"));
+
+            }
+            assertEquals(9000, impl.getConnectTimeout());
+            assertEquals(30, server.getBackendHealthManager().getPeriod());
+            // restart, same "static" confguration
+            stopServer();
+            buildNewServer();
+            startServer(configuration);
+            impl = (ConnectionsManagerImpl) server.getConnectionsManager();
+            assertEquals(9000, impl.getConnectTimeout());
+            assertEquals(30, server.getBackendHealthManager().getPeriod());
+
+        }
+    }
+}

--- a/carapace-server/src/test/java/org/carapaceproxy/api/ClusterReconfigTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/ClusterReconfigTest.java
@@ -64,7 +64,6 @@ public class ClusterReconfigTest extends UseAdminServer {
             ConnectionsManagerImpl impl = (ConnectionsManagerImpl) server.getConnectionsManager();
             assertEquals(8000, impl.getConnectTimeout());
             assertEquals(25, server.getBackendHealthManager().getPeriod());
-            System.out.println("QUIIIIIIIIII");
             try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
                 String body = "connectionsmanager.connecttimeout=9000\n"
                         + "healthmanager.period=30";

--- a/carapace-server/src/test/java/org/carapaceproxy/api/ConfigResourceTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/ConfigResourceTest.java
@@ -38,9 +38,6 @@ import org.junit.rules.TemporaryFolder;
  */
 public class ConfigResourceTest extends UseAdminServer {
 
-    @Rule
-    public TemporaryFolder tmpDir = new TemporaryFolder();
-
     @Test
     // 0) Dumping of start-up configuration
     // 1) applying of dynamic configuration
@@ -55,7 +52,7 @@ public class ConfigResourceTest extends UseAdminServer {
         configuration.put("dynamiccertificatesmanager.period", 25); // will be ignore due to db-mode
         startServer(configuration);
 
-        try ( RawHttpClient client = new RawHttpClient("localhost", 8761)) {
+        try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             // 0) Dumping + check
             String dumpedToReApply;
             RawHttpClient.HttpResponse resp = client.get("/api/config", credentials);
@@ -124,7 +121,7 @@ public class ConfigResourceTest extends UseAdminServer {
         configuration.put("db.server.base.dir", tmpDir.newFolder().getAbsolutePath());
         startServer(configuration);
 
-        try ( RawHttpClient client = new RawHttpClient("localhost", 8761)) {
+        try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             String body = "connectionsmanager.connecttimeout=8000\n"
                     + "healthmanager.period=25";
             RawHttpClient.HttpResponse resp = client.executeRequest("POST /api/config/apply HTTP/1.1\r\n"
@@ -148,7 +145,7 @@ public class ConfigResourceTest extends UseAdminServer {
         assertEquals(8000, impl.getConnectTimeout());
         assertEquals(25, server.getBackendHealthManager().getPeriod());
 
-        try ( RawHttpClient client = new RawHttpClient("localhost", 8761)) {
+        try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             String body = "connectionsmanager.connecttimeout=9000\n"
                     + "healthmanager.period=30";
             RawHttpClient.HttpResponse resp = client.executeRequest("POST /api/config/apply HTTP/1.1\r\n"

--- a/carapace-server/src/test/java/org/carapaceproxy/api/UseAdminServer.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/UseAdminServer.java
@@ -19,6 +19,7 @@
  */
 package org.carapaceproxy.api;
 
+import java.io.File;
 import java.util.Properties;
 import org.carapaceproxy.configstore.PropertiesConfigurationStore;
 import org.carapaceproxy.server.HttpProxyServer;
@@ -30,6 +31,8 @@ import org.carapaceproxy.utils.TestEndpointMapper;
 import org.junit.After;
 import static org.junit.Assert.assertNull;
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 /**
  *
@@ -40,6 +43,9 @@ public class UseAdminServer {
     public static final String DEFAULT_USERNAME = "admin";
     public static final String DEFAULT_PASSWORD = "admin";
 
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
+
     public HttpProxyServer server;
     public RawHttpClient.BasicAuthCredentials credentials;
 
@@ -47,7 +53,8 @@ public class UseAdminServer {
     public void buildNewServer() throws Exception {
         assertNull(server);
         credentials = new RawHttpClient.BasicAuthCredentials(DEFAULT_USERNAME, DEFAULT_PASSWORD);
-        server = buildForTests("localhost", 0, new TestEndpointMapper("localhost", 0));
+        File serverRoot = tmpDir.getRoot(); // at every reboot we must keep the same directory
+        server = buildForTests("localhost", 0, new TestEndpointMapper("localhost", 0), serverRoot);
     }
 
     @After
@@ -84,7 +91,7 @@ public class UseAdminServer {
     public void changeDynamicConfiguration(Properties configuration) throws ConfigurationNotValidException, ConfigurationChangeInProgressException, InterruptedException {
         if (server != null) {
             PropertiesConfigurationStore config = new PropertiesConfigurationStore(configuration);
-            server.applyDynamicConfiguration(config);
+            server.applyDynamicConfigurationFromAPI(config);
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/ChunckedEncodingRequestsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/ChunckedEncodingRequestsTest.java
@@ -77,7 +77,7 @@ public class ChunckedEncodingRequestsTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -121,7 +121,7 @@ public class ChunckedEncodingRequestsTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/ChunkedEncodingResponseTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/ChunkedEncodingResponseTest.java
@@ -62,7 +62,7 @@ public class ChunkedEncodingResponseTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -122,7 +122,7 @@ public class ChunkedEncodingResponseTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/RestartEndpointTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/RestartEndpointTest.java
@@ -78,7 +78,7 @@ public class RestartEndpointTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -120,7 +120,7 @@ public class RestartEndpointTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -167,7 +167,7 @@ public class RestartEndpointTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendTest.java
@@ -85,7 +85,7 @@ public class UnreachableBackendTest {
         EndpointKey key = new EndpointKey("localhost", dummyport);
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             stats = server.getConnectionsManager().getStats();
             int port = server.getLocalPort();
@@ -163,7 +163,7 @@ public class UnreachableBackendTest {
         EndpointKey key = new EndpointKey("localhost", dummyport);
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             stats = server.getConnectionsManager().getStats();
             int port = server.getLocalPort();

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreTest.java
@@ -23,6 +23,7 @@ import java.security.KeyPair;
 import java.util.Properties;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.apache.bookkeeper.stats.NullStatsLogger;
 import static org.carapaceproxy.server.certiticates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import static org.carapaceproxy.utils.TestUtils.assertEqualsKey;
@@ -35,7 +36,8 @@ import org.junit.runner.RunWith;
 import org.shredzone.acme4j.util.KeyPairUtils;
 
 /**
- * Test for {@link PropertiesConfigurationStore} and {@link HerdDBConfigurationStore}.
+ * Test for {@link PropertiesConfigurationStore} and
+ * {@link HerdDBConfigurationStore}.
  *
  * @author paolo.venturi
  */
@@ -66,11 +68,10 @@ public class ConfigurationStoreTest {
         props.setProperty("certificate.1.hostname", d2);
         props.setProperty("certificate.1.dynamic", "true");
         props.put("db.jdbc.url", "jdbc:herddb:localhost");
-        props.put("db.server.base.dir", tmpDir.getRoot().getAbsolutePath());
 
         store = new PropertiesConfigurationStore(props);
         if (type.equals("db")) {
-            store = new HerdDBConfigurationStore(store);
+            store = new HerdDBConfigurationStore(store, false, null, tmpDir.getRoot(), NullStatsLogger.INSTANCE);
         }
 
         testKeyPairOperations();
@@ -120,10 +121,10 @@ public class ConfigurationStoreTest {
         props.setProperty("certificate.1.hostname", d2);
         props.setProperty("certificate.1.dynamic", "true");
         props.put("db.jdbc.url", "jdbc:herddb:localhost");
-        props.put("db.server.base.dir", tmpDir.getRoot().getAbsolutePath());
+
         PropertiesConfigurationStore propertiesConfigurationStore = new PropertiesConfigurationStore(props);
 
-        store = new HerdDBConfigurationStore(propertiesConfigurationStore);
+        store = new HerdDBConfigurationStore(propertiesConfigurationStore, false, null, tmpDir.getRoot(), NullStatsLogger.INSTANCE);
 
         // Check applied configuration (loaded from empty db NB: passed configuration is ignored)
         assertEquals("", store.getProperty("certificate.0.hostname", ""));
@@ -158,9 +159,8 @@ public class ConfigurationStoreTest {
         // Loading stored configuration
         props = new Properties();
         props.put("db.jdbc.url", "jdbc:herddb:localhost");
-        props.put("db.server.base.dir", tmpDir.getRoot().getAbsolutePath());
         propertiesConfigurationStore = new PropertiesConfigurationStore(props);
-        store = new HerdDBConfigurationStore(propertiesConfigurationStore);
+        store = new HerdDBConfigurationStore(propertiesConfigurationStore, false, null, tmpDir.getRoot(), NullStatsLogger.INSTANCE);
         checkConfiguration();
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/listeners/MultiListeningEndpointTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/listeners/MultiListeningEndpointTest.java
@@ -32,6 +32,7 @@ import org.carapaceproxy.utils.TestEndpointMapper;
 import static org.junit.Assert.assertEquals;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  *
@@ -41,6 +42,9 @@ public class MultiListeningEndpointTest {
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(0);
+
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
 
     @Test
     public void test() throws Exception {
@@ -55,7 +59,7 @@ public class MultiListeningEndpointTest {
         int port2 = 1235;
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.port());
 
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", port, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", port, mapper, tmpDir.newFolder());) {
             server.addListener(new NetworkListenerConfiguration("localhost", port2));
             server.start();
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/RequestsLoggerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/RequestsLoggerTest.java
@@ -485,7 +485,7 @@ public class RequestsLoggerTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.getCurrentConfiguration().setAccessLogPath(tmpDir.getRoot().getAbsolutePath()+"/access.log");
             server.start();
             int port = server.getLocalPort();

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheContentLengthLimitTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheContentLengthLimitTest.java
@@ -115,7 +115,7 @@ public class CacheContentLengthLimitTest {
         {
             ConnectionsManagerStats stats;
 
-            try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+            try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
                 server.getCurrentConfiguration().setCacheMaxFileSize(0);
                 server.getCache().reloadConfiguration(server.getCurrentConfiguration());
                 server.start();
@@ -143,7 +143,7 @@ public class CacheContentLengthLimitTest {
         {
             ConnectionsManagerStats stats;
 
-            try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+            try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
                 server.getCurrentConfiguration().setCacheMaxFileSize(body.length());
                 server.getCache().reloadConfiguration(server.getCurrentConfiguration());
                 server.start();
@@ -171,7 +171,7 @@ public class CacheContentLengthLimitTest {
         {
             ConnectionsManagerStats stats;
 
-            try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+            try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
                 server.getCurrentConfiguration().setCacheMaxFileSize(body.length() - 1);
                 server.getCache().reloadConfiguration(server.getCurrentConfiguration());
                 server.start();

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheExpireTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheExpireTest.java
@@ -75,7 +75,7 @@ public class CacheExpireTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -137,7 +137,7 @@ public class CacheExpireTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -203,7 +203,7 @@ public class CacheExpireTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -255,7 +255,7 @@ public class CacheExpireTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -328,7 +328,7 @@ public class CacheExpireTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
             server.getCache().getInnerCache().setVerbose(true);

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheTest.java
@@ -68,7 +68,7 @@ public class CacheTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -149,7 +149,7 @@ public class CacheTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -312,7 +312,7 @@ public class CacheTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -382,7 +382,7 @@ public class CacheTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -452,7 +452,7 @@ public class CacheTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
@@ -499,7 +499,7 @@ public class CacheTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/NotModifiedTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/NotModifiedTest.java
@@ -64,7 +64,7 @@ public class NotModifiedTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/filters/XForwardedForFilterTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/filters/XForwardedForFilterTest.java
@@ -67,7 +67,7 @@ public class XForwardedForFilterTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.addRequestFilter(new RequestFilterConfiguration(XForwardedForRequestFilter.TYPE, Collections.emptyMap()));
             server.start();
             int port = server.getLocalPort();
@@ -122,7 +122,7 @@ public class XForwardedForFilterTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
@@ -106,7 +106,7 @@ public class BasicStandardEndpointMapperTest {
         mapper.addRoute(new RouteConfiguration("route-3-error", "error-custom", true, new URIRequestMatcher(".*error.html.*")));
         mapper.addRoute(new RouteConfiguration("route-4-static", "static-custom", true, new URIRequestMatcher(".*static.html.*")));
         ConnectionsManagerStats stats;
-        try ( HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try ( HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
             stats = server.getConnectionsManager().getStats();

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/ForceBackendTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/ForceBackendTest.java
@@ -39,12 +39,16 @@ import org.carapaceproxy.utils.TestUtils;
 import static org.junit.Assert.assertEquals;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  *
  * @author enrico.olivelli
  */
 public class ForceBackendTest {
+
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
 
     @Rule
     public WireMockRule backend1 = new WireMockRule(0);
@@ -82,7 +86,7 @@ public class ForceBackendTest {
         mapper.addRoute(new RouteConfiguration("route-1", "proxy-1", true, new URIRequestMatcher(".*index.html.*")));
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
             stats = server.getConnectionsManager().getStats();

--- a/carapace-server/src/test/java/org/carapaceproxy/toolbox/ProxyLocalTomcat.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/toolbox/ProxyLocalTomcat.java
@@ -48,7 +48,7 @@ public class ProxyLocalTomcat {
         EndpointKey key = new EndpointKey("localhost", 8086);
 
         ConnectionsManagerStats stats;
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper);) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 

--- a/carapace-server/src/test/java/org/carapaceproxy/users/FileUserRealmTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/users/FileUserRealmTest.java
@@ -64,7 +64,7 @@ public class FileUserRealmTest {
 
     @Test
     public void testFileUserRealm() throws Exception {
-        try (HttpProxyServer server = buildForTests("localhost", 0, new TestEndpointMapper("localhost", 0))) {
+        try (HttpProxyServer server = buildForTests("localhost", 0, new TestEndpointMapper("localhost", 0), tmpDir.newFolder())) {
             Properties prop = new Properties();
             prop.setProperty("http.admin.enabled", "true");
             prop.setProperty("http.admin.port", "8761");
@@ -103,7 +103,7 @@ public class FileUserRealmTest {
 
     @Test
     public void testFileUserRealmRefresh() throws Exception {
-        try (HttpProxyServer server = buildForTests("localhost", 0, new TestEndpointMapper("localhost", 0))) {
+        try (HttpProxyServer server = buildForTests("localhost", 0, new TestEndpointMapper("localhost", 0), tmpDir.newFolder())) {
             Map<String, String> users = new HashMap<>();
             users.put("test1", "pass1");
 
@@ -137,7 +137,7 @@ public class FileUserRealmTest {
             newProperties.setProperty("userrealm.path", newUserFile.getPath());
 
             ConfigurationStore newConfigStore = new PropertiesConfigurationStore(newProperties);
-            server.applyDynamicConfiguration(newConfigStore);
+            server.applyDynamicConfigurationFromAPI(newConfigStore);
 
             userRealm = server.getRealm();
             resultUsers = userRealm.listUsers();
@@ -147,7 +147,7 @@ public class FileUserRealmTest {
 
     @Test
     public void testFileRelativePath() throws Exception {
-        try (HttpProxyServer server = buildForTests("localhost", 0, new TestEndpointMapper("localhost", 0))) {
+        try (HttpProxyServer server = buildForTests("localhost", 0, new TestEndpointMapper("localhost", 0), tmpDir.newFolder())) {
             Properties prop = new Properties();
             prop.setProperty("http.admin.enabled", "true");
             prop.setProperty("http.admin.port", "8761");

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,23 @@
         <libs.javaxactivation.api>1.2.0</libs.javaxactivation.api>
         <libs.slf4j>1.7.25</libs.slf4j>
         <libs.stringtemplate>4.0.8</libs.stringtemplate>
-        <libs.herddb>0.8.1</libs.herddb>
+        <libs.herddb>0.10.0-SNAPSHOT</libs.herddb>
     </properties>
+     <repositories>
+        <repository>
+            <id>apache-snapshots</id>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <url>https://repository.apache.org/snapshots/</url>
+        </repository>
+        <repository>
+            <id>dev.majordodo.org.snapshots</id>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <url>https://dev.majordodo.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
 </project>


### PR DESCRIPTION
- Introduce "reconnect" event in GroupMembershipListener
- Prevent receiption of events originated by the same node in GroupMembershipListener
- Auto configure HerdDBEmbeddedDataSource in order to start HerdDB in cluster mode
- Use HerdDB 0.10.0-SNAPSHOT
- Add a minimal test about reconfig in cluster mode: boot the server + herddb + bookie + zookeeper and use the API, then perform a series of restarts
