### PR TITLE
Add possibility to insert header between the actions #46

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/MapResult.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/MapResult.java
@@ -20,7 +20,7 @@
 package org.carapaceproxy;
 
 import java.util.List;
-import org.carapaceproxy.server.mapper.StandardEndpointMapper.CustomHeader;
+import org.carapaceproxy.server.mapper.CustomHeader;
 
 public class MapResult {
 

--- a/carapace-server/src/main/java/org/carapaceproxy/MapResult.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/MapResult.java
@@ -19,6 +19,8 @@
  */
 package org.carapaceproxy;
 
+import io.netty.handler.codec.http.HttpHeaders;
+
 public class MapResult {
 
     public static final String NO_ROUTE = "-";
@@ -29,20 +31,22 @@ public class MapResult {
     public final String routeid;
     public int errorcode;
     public String resource;
+    public final HttpHeaders responseHeaders;
 
-    public MapResult(String host, int port, Action action, String routeid) {
+    public MapResult(String host, int port, Action action, String routeid, HttpHeaders headers) {
         this.host = host;
         this.port = port;
         this.action = action;
         this.routeid = routeid;
+        this.responseHeaders = headers;
     }
 
     public static MapResult NOT_FOUND(String routeid) {
-        return new MapResult(null, 0, Action.NOTFOUND, routeid);
+        return new MapResult(null, 0, Action.NOTFOUND, routeid, null);
     }
 
     public static MapResult INTERNAL_ERROR(String routeid) {
-        return new MapResult(null, 0, Action.INTERNAL_ERROR, routeid);
+        return new MapResult(null, 0, Action.INTERNAL_ERROR, routeid, null);
     }
 
     public int getErrorcode() {
@@ -65,7 +69,7 @@ public class MapResult {
 
     @Override
     public String toString() {
-        return "MapResult{" + "host=" + host + ", port=" + port + ", action=" + action + ", errorcode=" + errorcode + ", resource=" + resource + '}';
+        return "MapResult{" + "host=" + host + ", port=" + port + ", action=" + action + ", routeid=" + routeid + ", errorcode=" + errorcode + ", resource=" + resource + ", responseHeaders=" + responseHeaders + '}';
     }
 
     public static enum Action {

--- a/carapace-server/src/main/java/org/carapaceproxy/MapResult.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/MapResult.java
@@ -19,7 +19,8 @@
  */
 package org.carapaceproxy;
 
-import io.netty.handler.codec.http.HttpHeaders;
+import java.util.List;
+import org.carapaceproxy.server.mapper.StandardEndpointMapper.CustomHeader;
 
 public class MapResult {
 
@@ -30,15 +31,15 @@ public class MapResult {
     public final Action action;
     public final String routeid;
     public int errorcode;
-    public String resource;
-    public final HttpHeaders responseHeaders;
+    public String resource;    
+    public final List<CustomHeader> customHeaders;
 
-    public MapResult(String host, int port, Action action, String routeid, HttpHeaders headers) {
+    public MapResult(String host, int port, Action action, String routeid, List<CustomHeader> customHeaders) {
         this.host = host;
         this.port = port;
         this.action = action;
         this.routeid = routeid;
-        this.responseHeaders = headers;
+        this.customHeaders = customHeaders;
     }
 
     public static MapResult NOT_FOUND(String routeid) {
@@ -69,7 +70,7 @@ public class MapResult {
 
     @Override
     public String toString() {
-        return "MapResult{" + "host=" + host + ", port=" + port + ", action=" + action + ", routeid=" + routeid + ", errorcode=" + errorcode + ", resource=" + resource + ", responseHeaders=" + responseHeaders + '}';
+        return "MapResult{" + "host=" + host + ", port=" + port + ", action=" + action + ", routeid=" + routeid + ", errorcode=" + errorcode + ", resource=" + resource + ", customHeaders=" + customHeaders + '}';
     }
 
     public static enum Action {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
@@ -558,6 +558,12 @@ public class RequestHandler {
                 cleanResponseForCachedData(httpMessage);
             }
         }
+
+        // Custom response Headers
+        if (msg instanceof HttpResponse && action != null && action.responseHeaders != null) {
+            ((HttpResponse) msg).headers().add(action.responseHeaders);
+        }
+
         channelToClient.writeAndFlush(msg).addListener((Future<? super Void> future) -> {
             boolean returnConnection = false;
             if (future.isSuccess()) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
@@ -63,9 +63,9 @@ import org.carapaceproxy.server.cache.ContentsCache;
 import org.carapaceproxy.server.filters.UrlEncodedQueryString;
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.StatsLogger;
-import static org.carapaceproxy.server.mapper.StandardEndpointMapper.HeaderMode.HEADER_MODE_ADD;
-import static org.carapaceproxy.server.mapper.StandardEndpointMapper.HeaderMode.HEADER_MODE_REMOVE;
-import static org.carapaceproxy.server.mapper.StandardEndpointMapper.HeaderMode.HEADER_MODE_SET;
+import static org.carapaceproxy.server.mapper.CustomHeader.HeaderMode.HEADER_MODE_ADD;
+import static org.carapaceproxy.server.mapper.CustomHeader.HeaderMode.HEADER_MODE_REMOVE;
+import static org.carapaceproxy.server.mapper.CustomHeader.HeaderMode.HEADER_MODE_SET;
 
 /**
  * Keeps state for a single HttpRequest.

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
@@ -21,6 +21,7 @@ package org.carapaceproxy.server.config;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.carapaceproxy.server.mapper.StandardEndpointMapper.CustomHeader;
 
 /**
  * Action
@@ -36,8 +37,8 @@ public class ActionConfiguration {
     private final String type;
     private final String file;
     private final String director;
-    private final int errorcode;
-    private final List<String> headers = new ArrayList();
+    private final int errorcode;    
+    private final List<CustomHeader> customHeaders = new ArrayList(); // it's a list to keep ordering
 
     public ActionConfiguration(String id, String type, String director, String file, int errorcode) {
         this.id = id;
@@ -67,20 +68,17 @@ public class ActionConfiguration {
         return type;
     }
 
-    public List<String> getHeaders() {
-        return headers;
+    public List<CustomHeader> getCustomHeaders() {
+        return customHeaders;
     }
 
-    public ActionConfiguration addHeader(String id) {
-        if (!headers.contains(id)) {
-            headers.add(id);
-        }
-        return this;
+    public void addCustomHeader(CustomHeader header) {
+        customHeaders.add(header);
     }
 
     @Override
     public String toString() {
-        return "ActionConfiguration{" + "id=" + id + ", type=" + type + ", file=" + file + ", director=" + director + ", errorcode=" + errorcode + ", headers=" + headers + '}';
+        return "ActionConfiguration{" + "id=" + id + ", type=" + type + ", file=" + file + ", director=" + director + ", errorcode=" + errorcode + ", customHeaders=" + customHeaders + '}';
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
@@ -21,7 +21,7 @@ package org.carapaceproxy.server.config;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.carapaceproxy.server.mapper.StandardEndpointMapper.CustomHeader;
+import org.carapaceproxy.server.mapper.CustomHeader;
 
 /**
  * Action

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
@@ -19,6 +19,9 @@
  */
 package org.carapaceproxy.server.config;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Action
  */
@@ -34,6 +37,7 @@ public class ActionConfiguration {
     private final String file;
     private final String director;
     private final int errorcode;
+    private final List<String> headers = new ArrayList();
 
     public ActionConfiguration(String id, String type, String director, String file, int errorcode) {
         this.id = id;
@@ -63,9 +67,20 @@ public class ActionConfiguration {
         return type;
     }
 
+    public List<String> getHeaders() {
+        return headers;
+    }
+
+    public ActionConfiguration addHeader(String id) {
+        if (!headers.contains(id)) {
+            headers.add(id);
+        }
+        return this;
+    }
+
     @Override
     public String toString() {
-        return "ActionConfiguration{" + "id=" + id + ", type=" + type + ", file=" + file + ", director=" + director + ", errorcode=" + errorcode + '}';
+        return "ActionConfiguration{" + "id=" + id + ", type=" + type + ", file=" + file + ", director=" + director + ", errorcode=" + errorcode + ", headers=" + headers + '}';
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/CustomHeader.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/CustomHeader.java
@@ -1,0 +1,58 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package org.carapaceproxy.server.mapper;
+
+/**
+ *
+ * Custom Header to add/set/remove in HttpResponses
+ * 
+ * @author paolo.venturi
+ */
+public final class CustomHeader {
+
+    // ADD: to append the header
+    // SET: to set the header as the only one
+    // REMOVE: to remove the header
+    public static enum HeaderMode {
+        HEADER_MODE_ADD, HEADER_MODE_SET, HEADER_MODE_REMOVE
+    }
+
+    private final String name;
+    private final String value;
+    private final HeaderMode mode;
+
+    public CustomHeader(String name, String value, HeaderMode mode) {
+        this.name = name;
+        this.value = value;
+        this.mode = mode;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public HeaderMode getMode() {
+        return mode;
+    }
+}

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -51,6 +51,7 @@ import org.carapaceproxy.server.config.RouteConfiguration;
 import org.carapaceproxy.server.config.RoutingKey;
 import org.carapaceproxy.server.config.URIRequestMatcher;
 import org.carapaceproxy.server.filters.UrlEncodedQueryString;
+import org.carapaceproxy.server.mapper.CustomHeader.HeaderMode;
 
 /**
  * Standard Endpoint mapping
@@ -140,7 +141,7 @@ public class StandardEndpointMapper extends EndpointMapper {
                     }
                 }
                 addAction(config);
-                LOG.info("configured action " + id + " type=" + action + " enabled:" + enabled);
+                LOG.info("configured action " + id + " type=" + action + " enabled:" + enabled + " headers:" + headersIds);
             }
         }
 
@@ -253,7 +254,7 @@ public class StandardEndpointMapper extends EndpointMapper {
                 _mode = HeaderMode.HEADER_MODE_REMOVE;
                 break;
             default:
-                throw new ConfigurationNotValidException("invalid value of mode for header " + id);
+                throw new ConfigurationNotValidException("invalid value of mode " + mode + " for header " + id);
         }
 
         if (headers.put(id, new CustomHeader(name, value, _mode)) != null) {
@@ -422,34 +423,5 @@ public class StandardEndpointMapper extends EndpointMapper {
     public String getForceBackendParameter() {
         return forceBackendParameter;
     }
-
-    public static enum HeaderMode {
-        HEADER_MODE_ADD, HEADER_MODE_SET, HEADER_MODE_REMOVE
-    }
-
-    public static final class CustomHeader {
-
-        private final String name;
-        private final String value;
-        private final HeaderMode mode;
-
-        public CustomHeader(String name, String value, HeaderMode mode) {
-            this.name = name;
-            this.value = value;
-            this.mode = mode;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public String getValue() {
-            return value;
-        }
-
-        public HeaderMode getMode() {
-            return mode;
-        }
-    }
-
+    
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/RequestsLoggerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/RequestsLoggerTest.java
@@ -179,7 +179,7 @@ public class RequestsLoggerTest {
             r1.startTs = "2018-10-23 10:10:10.000";
             r1.backendStartTs = "2018-10-23 10:10:10.542";
             r1.endTs = "2018-10-23 10:10:11.012";
-            r1.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1");
+            r1.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1", null);
             r1.userid = "uid_1";
             r1.sessionid = "sid_1";
 
@@ -212,7 +212,7 @@ public class RequestsLoggerTest {
             r2.startTs = "2018-10-23 11:10:10.000";
             r2.backendStartTs = "2018-10-23 11:10:10.142";
             r2.endTs = "2018-10-23 11:10:10.912";
-            r2.action = new MapResult("host2", 2222, MapResult.Action.PROXY, "routeid_2");
+            r2.action = new MapResult("host2", 2222, MapResult.Action.PROXY, "routeid_2", null);
             r2.userid = "uid_2";
             r2.sessionid = "sid_2";
 
@@ -264,7 +264,7 @@ public class RequestsLoggerTest {
             r1.startTs = "2018-10-23 10:10:10.000";
             r1.backendStartTs = "2018-10-23 10:10:10.542";
             r1.endTs = "2018-10-23 10:10:11.012";
-            r1.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1");
+            r1.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1", null);
             r1.userid = "uid_1";
             r1.sessionid = "sid_1";
 
@@ -293,7 +293,7 @@ public class RequestsLoggerTest {
             r2.startTs = "2018-10-23 10:10:10.000";
             r2.backendStartTs = "2018-10-23 10:10:10.542";
             r2.endTs = "2018-10-23 10:10:11.012";
-            r2.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1");
+            r2.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1", null);
             r2.userid = "uid_1";
             r2.sessionid = "sid_1";
 
@@ -334,7 +334,7 @@ public class RequestsLoggerTest {
             r1.startTs = "2018-10-23 11:10:10.000";
             r1.backendStartTs = "2018-10-23 11:10:10.542";
             r1.endTs = "2018-10-23 11:10:11.012";
-            r1.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1");
+            r1.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1", null);
             r1.userid = "uid_1";
             r1.sessionid = "sid_1";
 
@@ -360,7 +360,7 @@ public class RequestsLoggerTest {
             r2.startTs = "2018-10-23 11:10:10.000";
             r2.backendStartTs = "2018-10-23 11:10:10.542";
             r2.endTs = "2018-10-23 11:10:11.012";
-            r2.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1");
+            r2.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1", null);
             r2.userid = "uid_1";
             r2.sessionid = "sid_1";
 
@@ -375,7 +375,7 @@ public class RequestsLoggerTest {
             r3.startTs = "2018-10-23 11:10:10.000";
             r3.backendStartTs = "2018-10-23 11:10:10.542";
             r3.endTs = "2018-10-23 11:10:11.012";
-            r3.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1");
+            r3.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1", null);
             r3.userid = "uid_1";
             r3.sessionid = "sid_1";
 
@@ -423,7 +423,7 @@ public class RequestsLoggerTest {
             r1.startTs = "2018-10-23 10:10:10.000";
             r1.backendStartTs = "2018-10-23 10:10:10.542";
             r1.endTs = "2018-10-23 10:10:11.012";
-            r1.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1");
+            r1.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1", null);
             r1.userid = "uid_1";
             r1.sessionid = "sid_1";
 
@@ -443,7 +443,7 @@ public class RequestsLoggerTest {
             r2.startTs = "2018-10-23 10:10:10.000";
             r2.backendStartTs = "2018-10-23 10:10:10.542";
             r2.endTs = "2018-10-23 10:10:11.012";
-            r2.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1");
+            r2.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1", null);
             r2.userid = "uid_1";
             r2.sessionid = "sid_1";
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
@@ -43,6 +43,9 @@ import org.carapaceproxy.server.config.RouteConfiguration;
 import org.carapaceproxy.server.config.URIRequestMatcher;
 import org.carapaceproxy.utils.TestUtils;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import org.junit.Rule;
@@ -107,7 +110,7 @@ public class BasicStandardEndpointMapperTest {
         mapper.addRoute(new RouteConfiguration("route-3-error", "error-custom", true, new URIRequestMatcher(".*error.html.*")));
         mapper.addRoute(new RouteConfiguration("route-4-static", "static-custom", true, new URIRequestMatcher(".*static.html.*")));
         ConnectionsManagerStats stats;
-        try ( HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
             stats = server.getConnectionsManager().getStats();
@@ -289,8 +292,14 @@ public class BasicStandardEndpointMapperTest {
                         .withStatus(200)
                         .withHeader("Content-Type", "text/html")
                         .withBody("it <b>works</b> !!")));
-        
+
         stubFor(get(urlEqualTo("/index2.html"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/html")
+                        .withBody("it <b>works</b> !!")));
+
+        stubFor(get(urlEqualTo("/index3.html"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "text/html")
@@ -320,7 +329,7 @@ public class BasicStandardEndpointMapperTest {
             configuration.put("action.1.id", "addHeaders");
             configuration.put("action.1.enabled", "true");
             configuration.put("action.1.type", "cache");
-            configuration.put("action.1.headers", "h1,h2");
+            configuration.put("action.1.headers", "h1,h2,h5,h6");
 
             configuration.put("route.2.id", "r2");
             configuration.put("route.2.enabled", "true");
@@ -330,7 +339,19 @@ public class BasicStandardEndpointMapperTest {
             configuration.put("action.2.id", "addHeader2");
             configuration.put("action.2.enabled", "true");
             configuration.put("action.2.type", "proxy");
-            configuration.put("action.2.headers", "h2");
+            configuration.put("action.2.headers", "h2,h3,h4");
+
+            configuration.put("route.3.id", "r3");
+            configuration.put("route.3.enabled", "true");
+            configuration.put("route.3.match", "regexp .*index3\\.html");
+            configuration.put("route.3.action", "serve-static");
+
+            configuration.put("action.3.id", "serve-static");
+            configuration.put("action.3.enabled", "true");
+            configuration.put("action.3.type", "static");
+            configuration.put("action.3.file", CLASSPATH_RESOURCE + "/test-static-page.html");
+            configuration.put("action.3.code", "200");
+            configuration.put("action.3.headers", "h1");
 
             // Custom headers
             configuration.put("header.1.id", "h1");
@@ -339,6 +360,19 @@ public class BasicStandardEndpointMapperTest {
             configuration.put("header.2.id", "h2");
             configuration.put("header.2.name", "custom-header-2");
             configuration.put("header.2.value", "header-2-value");
+            configuration.put("header.3.id", "h3");
+            configuration.put("header.3.name", "custom-header-3"); // test headers merge (default add-mode)
+            configuration.put("header.3.value", "header-3-overridden-value");
+            configuration.put("header.4.id", "h4");
+            configuration.put("header.4.name", "custom-header-3"); // test headers merge
+            configuration.put("header.4.value", "header-4-overridden-value");
+            configuration.put("header.5.id", "h5");
+            configuration.put("header.5.name", "Content-Type"); // test reset headers
+            configuration.put("header.5.value", "text/custom-text");
+            configuration.put("header.5.mode", "set");
+            configuration.put("header.6.id", "h6");
+            configuration.put("header.6.name", "Transfer-Encoding"); // test remove headers
+            configuration.put("header.6.mode", "remove");
 
             PropertiesConfigurationStore config = new PropertiesConfigurationStore(configuration);
             server.configureAtBoot(config);
@@ -346,14 +380,31 @@ public class BasicStandardEndpointMapperTest {
 
             int port = server.getLocalPort();
             {
-                URLConnection conn = new URL("http://localhost:" + port + "/index.html").openConnection();                
+                URLConnection conn = new URL("http://localhost:" + port + "/index.html").openConnection();
                 assertEquals("header-1-value; header-1-value2;header-1-value3", conn.getHeaderField("custom-header-1"));
                 assertEquals("header-2-value", conn.getHeaderField("custom-header-2"));
+                // header mode-set
+                assertEquals("text/custom-text", conn.getHeaderField("Content-Type"));
+                assertFalse(conn.getHeaderFields().toString().contains("text/html"));
+                // header mode-remove: for this action doesn't exist
+                assertNull(conn.getHeaderField("Transfer-Encoding"));
             }
             {
-                URLConnection conn = new URL("http://localhost:" + port + "/index2.html").openConnection();                
-                assertEquals(null, conn.getHeaderField("custom-header-1"));
+                URLConnection conn = new URL("http://localhost:" + port + "/index2.html").openConnection();
+                System.out.println("HEADERS2: " + conn.getHeaderFields());
+                assertNull(conn.getHeaderField("custom-header-1"));
                 assertEquals("header-2-value", conn.getHeaderField("custom-header-2"));
+                // in this action is text/html as normal
+                assertTrue(conn.getHeaderFields().toString().contains("text/html"));
+                // custom-header-3 values have been merged (default mode-add)
+                assertTrue(conn.getHeaderFields().toString().contains("header-4-overridden-value"));
+                assertTrue(conn.getHeaderFields().toString().contains("header-3-overridden-value"));
+                // in this action still exists
+                assertNotNull(conn.getHeaderField("Transfer-Encoding"));
+            }
+            {
+                URLConnection conn = new URL("http://localhost:" + port + "/index3.html").openConnection();
+                assertEquals("header-1-value; header-1-value2;header-1-value3", conn.getHeaderField("custom-header-1"));
             }
         }
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/TestEndpointMapper.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/TestEndpointMapper.java
@@ -64,11 +64,11 @@ public class TestEndpointMapper extends EndpointMapper {
         if (uri.contains("not-found")) {
             return MapResult.NOT_FOUND(MapResult.NO_ROUTE);
         } else if (uri.contains("debug")) {
-            return new MapResult(null, 0, MapResult.Action.SYSTEM, MapResult.NO_ROUTE);
+            return new MapResult(null, 0, MapResult.Action.SYSTEM, MapResult.NO_ROUTE,null);
         } else if (cacheAll) {
-            return new MapResult(host, port, MapResult.Action.CACHE, MapResult.NO_ROUTE);
+            return new MapResult(host, port, MapResult.Action.CACHE, MapResult.NO_ROUTE, null);
         } else {
-            return new MapResult(host, port, MapResult.Action.PROXY, MapResult.NO_ROUTE);
+            return new MapResult(host, port, MapResult.Action.PROXY, MapResult.NO_ROUTE, null);
         }
     }
 


### PR DESCRIPTION
Now it's possible to define http-response-headers to add/set/remove (default add) for the actions (of any type):
```
action.1.director=director_name
action.1.enabled=true
action.1.id=action_id
action.1.type=cache
action.1.headers=h1,h2

/* custom headers */

header.id=h1
header.name=Strict-Transport-Security
header.mode= remove

header.id=h2
header.name=MyHeader
header.value=MyHeaderValue
header.mode=add | set
```