### PR TITLE
Option to add a debug header to see which route/action/director/backe…

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
@@ -20,6 +20,7 @@
 package org.carapaceproxy.server.config;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.carapaceproxy.server.mapper.CustomHeader;
 
@@ -69,7 +70,7 @@ public class ActionConfiguration {
     }
 
     public List<CustomHeader> getCustomHeaders() {
-        return customHeaders;
+        return Collections.unmodifiableList(customHeaders);
     }
 
     public void addCustomHeader(CustomHeader header) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
@@ -39,15 +39,17 @@ public class ActionConfiguration {
     private final String file;
     private final String director;
     private final int errorcode;    
-    private final List<CustomHeader> customHeaders = new ArrayList(); // it's a list to keep ordering
+    private final List<CustomHeader> customHeaders; // it's a list to keep ordering
 
-    public ActionConfiguration(String id, String type, String director, String file, int errorcode) {
+    public ActionConfiguration(String id, String type, String director, String file, int errorcode, List<CustomHeader> customHeaders) {
         this.id = id;
         this.type = type;
         this.director = director;
         this.file = file;
-        this.errorcode = errorcode;
+        this.errorcode = errorcode;        
+        this.customHeaders = Collections.unmodifiableList(customHeaders == null ? new ArrayList() : customHeaders);
     }
+
 
     public String getDirector() {
         return director;
@@ -70,11 +72,7 @@ public class ActionConfiguration {
     }
 
     public List<CustomHeader> getCustomHeaders() {
-        return Collections.unmodifiableList(customHeaders);
-    }
-
-    public void addCustomHeader(CustomHeader header) {
-        customHeaders.add(header);
+        return customHeaders;
     }
 
     @Override

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -87,13 +87,23 @@ public class StandardEndpointMapper extends EndpointMapper {
     @Override
     public void configure(ConfigurationStore properties) throws ConfigurationNotValidException {
 
-        addAction(new ActionConfiguration("proxy-all", ActionConfiguration.TYPE_PROXY, DirectorConfiguration.DEFAULT, null, -1));
-        addAction(new ActionConfiguration("cache-if-possible", ActionConfiguration.TYPE_CACHE, DirectorConfiguration.DEFAULT, null, -1));
-        addAction(new ActionConfiguration("not-found", ActionConfiguration.TYPE_STATIC, null, DEFAULT_NOT_FOUND, 404));
-        addAction(new ActionConfiguration("internal-error", ActionConfiguration.TYPE_STATIC, null, DEFAULT_INTERNAL_SERVER_ERROR, 500));
+        addAction(new ActionConfiguration(
+                "proxy-all", ActionConfiguration.TYPE_PROXY, DirectorConfiguration.DEFAULT, null, -1, Collections.emptyList()
+        ));
+        addAction(new ActionConfiguration(
+                "cache-if-possible", ActionConfiguration.TYPE_CACHE, DirectorConfiguration.DEFAULT, null, -1, Collections.emptyList()
+        ));
+        addAction(new ActionConfiguration(
+                "not-found", ActionConfiguration.TYPE_STATIC, null, DEFAULT_NOT_FOUND, 404, Collections.emptyList()
+        ));
+        addAction(new ActionConfiguration(
+                "internal-error", ActionConfiguration.TYPE_STATIC, null, DEFAULT_INTERNAL_SERVER_ERROR, 500, Collections.emptyList()
+        ));
 
         // Route+Action configuration for Let's Encrypt ACME challenging
-        addAction(new ActionConfiguration("acme-challenge", ActionConfiguration.TYPE_ACME_CHALLENGE, null, null, HttpResponseStatus.OK.code()));
+        addAction(new ActionConfiguration(
+                "acme-challenge", ActionConfiguration.TYPE_ACME_CHALLENGE, null, null, HttpResponseStatus.OK.code(), Collections.emptyList()
+        ));
         addRoute(new RouteConfiguration("acme-challenge", "acme-challenge", true, new URIRequestMatcher(".*" + ACME_CHALLENGE_URI_PATTERN + ".*")));
 
         this.defaultNotFoundAction = properties.getProperty("default.action.notfound", "not-found");
@@ -131,8 +141,8 @@ public class StandardEndpointMapper extends EndpointMapper {
                 String file = properties.getProperty(prefix + "file", "");
                 String director = properties.getProperty(prefix + "director", DirectorConfiguration.DEFAULT);
                 int code = Integer.parseInt(properties.getProperty(prefix + "code", "-1"));
-                ActionConfiguration config = new ActionConfiguration(id, action, director, file, code);
                 String headersIds = properties.getProperty(prefix + "headers", "").trim();
+                List<CustomHeader> customHeaders = new ArrayList();
                 if (!headersIds.isEmpty()) {
                     String[] _headersIds = headersIds.split(",");
                     Set<String> usedIds = new HashSet();
@@ -143,14 +153,14 @@ public class StandardEndpointMapper extends EndpointMapper {
                             usedIds.add(headerId);
                             CustomHeader header = headers.get(headerId);
                             if (header != null) {
-                                config.addCustomHeader(header);
+                                customHeaders.add(header);
                             } else {
                                 throw new ConfigurationNotValidException("while configuring action '" + id + "': header '" + headerId + "' does not exist");
                             }
                         }
                     }
                 }
-                addAction(config);
+                addAction(new ActionConfiguration(id, action, director, file, code, customHeaders));
                 LOG.info("configured action " + id + " type=" + action + " enabled:" + enabled + " headers:" + headersIds);
             }
         }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -76,7 +76,7 @@ public class StandardEndpointMapper extends EndpointMapper {
     private static final String ACME_CHALLENGE_URI_PATTERN = "/\\.well-known/acme-challenge/";
     private DynamicCertificatesManager dynamicCertificateManger;
 
-    public static final String DEBUGGING_HEADER_DEFAULT_NAME = "Routing-Path";
+    public static final String DEBUGGING_HEADER_DEFAULT_NAME = "X-Proxy-Path";
     private String debuggingHeaderName = DEBUGGING_HEADER_DEFAULT_NAME;
     private boolean debuggingHeaderEnabled = false;
 
@@ -107,7 +107,7 @@ public class StandardEndpointMapper extends EndpointMapper {
         // To add custom debugging header for request choosen mapping-path
         this.debuggingHeaderEnabled = Boolean.parseBoolean(properties.getProperty("mapper.debug", "false"));
         LOG.info("configured mapper.debug=" + debuggingHeaderEnabled);
-        this.debuggingHeaderName = "X-" + properties.getProperty("mapper.debug.name", DEBUGGING_HEADER_DEFAULT_NAME);
+        this.debuggingHeaderName = properties.getProperty("mapper.debug.name", DEBUGGING_HEADER_DEFAULT_NAME);
         LOG.info("configured mapper.debug.name=" + debuggingHeaderName);
 
         for (int i = 0; i < MAX_IDS; i++) {
@@ -394,8 +394,9 @@ public class StandardEndpointMapper extends EndpointMapper {
 
                     BackendConfiguration backend = this.backends.get(backendId);
                     if (backend != null && backendHealthManager.isAvailable(backendId)) {
-                        List<CustomHeader> customHeaders = new ArrayList(action.getCustomHeaders());
+                        List<CustomHeader> customHeaders = action.getCustomHeaders();
                         if (this.debuggingHeaderEnabled) {
+                            customHeaders = new ArrayList(customHeaders);
                             String routingPath = route.getId() + ";"
                                     + action.getId() + ";"
                                     + action.getDirector() + ";"

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
@@ -41,7 +41,6 @@ import org.carapaceproxy.server.config.BackendConfiguration;
 import org.carapaceproxy.server.config.DirectorConfiguration;
 import org.carapaceproxy.server.config.RouteConfiguration;
 import org.carapaceproxy.server.config.URIRequestMatcher;
-import static org.carapaceproxy.server.mapper.StandardEndpointMapper.DEBUGGING_HEADER_ROUTING_PATH;
 import org.carapaceproxy.utils.TestUtils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -385,7 +384,8 @@ public class BasicStandardEndpointMapperTest {
             configuration.put("header.6.mode", "remove");
 
             // To enable debugging header "Mapping-Path"
-            configuration.put("mapper.debuggingheader.enable", "true");
+            configuration.put("mapper.debug", "true");
+            configuration.put("mapper.debug.name", "DebugHeaderCustomName");
 
             PropertiesConfigurationStore config = new PropertiesConfigurationStore(configuration);
             server.configureAtBoot(config);
@@ -403,10 +403,7 @@ public class BasicStandardEndpointMapperTest {
                 assertNull(conn.getHeaderField("Transfer-Encoding"));
 
                 // debugging header "Routing-Path"
-                assertEquals(
-                        "Route-id: r1; Action-id: addHeaders; Director-id: d1; Backend-id: b1",
-                        conn.getHeaderField(DEBUGGING_HEADER_ROUTING_PATH)
-                );
+                assertEquals("r1;addHeaders;d1;b1", conn.getHeaderField("X-DebugHeaderCustomName"));
             }
             {
                 URLConnection conn = new URL("http://localhost:" + port + "/index2.html").openConnection();
@@ -421,10 +418,7 @@ public class BasicStandardEndpointMapperTest {
                 assertNotNull(conn.getHeaderField("Transfer-Encoding"));
 
                 // debugging header "Routing-Path"
-                assertEquals(
-                        "Route-id: r2; Action-id: addHeader2; Director-id: d2; Backend-id: b2",
-                        conn.getHeaderField(DEBUGGING_HEADER_ROUTING_PATH)
-                );
+                assertEquals("r2;addHeader2;d2;b2", conn.getHeaderField("X-DebugHeaderCustomName"));
             }
             {
                 URLConnection conn = new URL("http://localhost:" + port + "/index3.html").openConnection();

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
@@ -403,7 +403,7 @@ public class BasicStandardEndpointMapperTest {
                 assertNull(conn.getHeaderField("Transfer-Encoding"));
 
                 // debugging header "Routing-Path"
-                assertEquals("r1;addHeaders;d1;b1", conn.getHeaderField("X-DebugHeaderCustomName"));
+                assertEquals("r1;addHeaders;d1;b1", conn.getHeaderField("DebugHeaderCustomName"));
             }
             {
                 URLConnection conn = new URL("http://localhost:" + port + "/index2.html").openConnection();
@@ -418,7 +418,7 @@ public class BasicStandardEndpointMapperTest {
                 assertNotNull(conn.getHeaderField("Transfer-Encoding"));
 
                 // debugging header "Routing-Path"
-                assertEquals("r2;addHeader2;d2;b2", conn.getHeaderField("X-DebugHeaderCustomName"));
+                assertEquals("r2;addHeader2;d2;b2", conn.getHeaderField("DebugHeaderCustomName"));
             }
             {
                 URLConnection conn = new URL("http://localhost:" + port + "/index3.html").openConnection();

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
@@ -28,6 +28,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Collections;
 import java.util.Properties;
 import org.apache.commons.io.IOUtils;
 import org.carapaceproxy.client.ConnectionsManagerStats;
@@ -95,13 +96,25 @@ public class BasicStandardEndpointMapperTest {
         mapper.addDirector(new DirectorConfiguration("director-1").addBackend("backend-a"));
         mapper.addDirector(new DirectorConfiguration("director-2").addBackend("backend-b"));
         mapper.addDirector(new DirectorConfiguration("director-all").addBackend("*")); // all of the known backends
-        mapper.addAction(new ActionConfiguration("proxy-1", ActionConfiguration.TYPE_PROXY, "director-1", null, -1));
-        mapper.addAction(new ActionConfiguration("cache-1", ActionConfiguration.TYPE_CACHE, "director-2", null, -1));
-        mapper.addAction(new ActionConfiguration("all-1", ActionConfiguration.TYPE_CACHE, "director-all", null, -1));
+        mapper.addAction(new ActionConfiguration(
+                "proxy-1", ActionConfiguration.TYPE_PROXY, "director-1", null, -1, Collections.emptyList()
+        ));
+        mapper.addAction(new ActionConfiguration(
+                "cache-1", ActionConfiguration.TYPE_CACHE, "director-2", null, -1, Collections.emptyList()
+        ));
+        mapper.addAction(new ActionConfiguration(
+                "all-1", ActionConfiguration.TYPE_CACHE, "director-all", null, -1, Collections.emptyList()
+        ));
 
-        mapper.addAction(new ActionConfiguration("not-found-custom", ActionConfiguration.TYPE_STATIC, null, StaticContentsManager.DEFAULT_NOT_FOUND, 404));
-        mapper.addAction(new ActionConfiguration("error-custom", ActionConfiguration.TYPE_STATIC, null, StaticContentsManager.DEFAULT_INTERNAL_SERVER_ERROR, 500));
-        mapper.addAction(new ActionConfiguration("static-custom", ActionConfiguration.TYPE_STATIC, null, CLASSPATH_RESOURCE + "/test-static-page.html", 200));
+        mapper.addAction(new ActionConfiguration(
+                "not-found-custom", ActionConfiguration.TYPE_STATIC, null, StaticContentsManager.DEFAULT_NOT_FOUND, 404, Collections.emptyList()
+        ));
+        mapper.addAction(new ActionConfiguration(
+                "error-custom", ActionConfiguration.TYPE_STATIC, null, StaticContentsManager.DEFAULT_INTERNAL_SERVER_ERROR, 500, Collections.emptyList()
+        ));
+        mapper.addAction(new ActionConfiguration(
+                "static-custom", ActionConfiguration.TYPE_STATIC, null, CLASSPATH_RESOURCE + "/test-static-page.html", 200, Collections.emptyList()
+        ));
 
         mapper.addRoute(new RouteConfiguration("route-1", "proxy-1", true, new URIRequestMatcher(".*index.html.*")));
         mapper.addRoute(new RouteConfiguration("route-1b", "cache-1", true, new URIRequestMatcher(".*index2.html.*")));

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/ForceBackendTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/ForceBackendTest.java
@@ -25,6 +25,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.net.URL;
+import java.util.Collections;
 import java.util.Properties;
 import org.apache.commons.io.IOUtils;
 import org.carapaceproxy.client.ConnectionsManagerStats;
@@ -81,7 +82,7 @@ public class ForceBackendTest {
         mapper.addDirector(new DirectorConfiguration("director-1").addBackend("backend-a"));
         mapper.addDirector(new DirectorConfiguration("director-2").addBackend("backend-b"));
 
-        mapper.addAction(new ActionConfiguration("proxy-1", ActionConfiguration.TYPE_PROXY, "director-1", null, -1));
+        mapper.addAction(new ActionConfiguration("proxy-1", ActionConfiguration.TYPE_PROXY, "director-1", null, -1, Collections.emptyList()));
 
         mapper.addRoute(new RouteConfiguration("route-1", "proxy-1", true, new URIRequestMatcher(".*index.html.*")));
 


### PR DESCRIPTION
Now, in the configuration can be setup **mapper.debug=true|false** (default false) and **mapper.debug.name=header-name** (default Routing-Path) to add a custom header **X-header-name: id_selected_route;id_selected_action;id_selected_director;id_selected_backend** to HttpResponses for actions of type *cache* and *proxy*