### PR TITLE
48 Ability to force https connections on given URIs: error and/or red…

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/MapResult.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/MapResult.java
@@ -31,24 +31,26 @@ public class MapResult {
     public final Action action;
     public final String routeid;
     public int errorcode;
-    public String resource;    
-    public final List<CustomHeader> customHeaders;
+    public String resource;
+    public List<CustomHeader> customHeaders;
+    public String redirectLocation;
+    public String redirectProto;
+    public String redirectPath;
 
-    public MapResult(String host, int port, Action action, String routeid, List<CustomHeader> customHeaders) {
+    public MapResult(String host, int port, Action action, String routeid) {
         this.host = host;
         this.port = port;
         this.action = action;
         this.routeid = routeid;
-        this.customHeaders = customHeaders;
     }
 
     public static MapResult NOT_FOUND(String routeid) {
-        return new MapResult(null, 0, Action.NOTFOUND, routeid, null);
+        return new MapResult(null, 0, Action.NOTFOUND, routeid);
     }
 
     public static MapResult INTERNAL_ERROR(String routeid) {
-        return new MapResult(null, 0, Action.INTERNAL_ERROR, routeid, null);
-    }
+        return new MapResult(null, 0, Action.INTERNAL_ERROR, routeid);
+    }    
 
     public int getErrorcode() {
         return errorcode;
@@ -68,9 +70,29 @@ public class MapResult {
         return this;
     }
 
+    public MapResult setCustomHeaders(List<CustomHeader> customHeaders) {
+        this.customHeaders = customHeaders;
+        return this;
+    }
+
+    public MapResult setRedirectLocation(String redirectLocation) {
+        this.redirectLocation = redirectLocation;
+        return this;
+    }
+
+    public MapResult setRedirectProto(String proto) {
+        this.redirectProto = proto;
+        return this;
+    }
+    
+    public MapResult setRedirectPath(String path) {
+        this.redirectPath = path;
+        return this;
+    }    
+
     @Override
     public String toString() {
-        return "MapResult{" + "host=" + host + ", port=" + port + ", action=" + action + ", routeid=" + routeid + ", errorcode=" + errorcode + ", resource=" + resource + ", customHeaders=" + customHeaders + '}';
+        return "MapResult{" + "host=" + host + ", port=" + port + ", action=" + action + ", routeid=" + routeid + ", errorcode=" + errorcode + ", resource=" + resource + ", customHeaders=" + customHeaders + ", redirectLocation=" + redirectLocation + ", redirectProto=" + redirectProto + ", redirectPath=" + redirectPath + '}';
     }
 
     public static enum Action {
@@ -101,7 +123,11 @@ public class MapResult {
         /**
          * Answer for ACME challenge verification
          */
-        ACME_CHALLENGE
+        ACME_CHALLENGE,
+        /**
+         * Redirect the request
+         */
+        REDIRECT
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
@@ -63,6 +63,8 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
     volatile boolean refuseOtherRequests;
     private final List<RequestHandler> pendingRequests = new CopyOnWriteArrayList<>();
     final Runnable onClientDisconnected;
+    private final String listenerHost;
+    private final int listenerPort;
 
     public ClientConnectionHandler(
             StatsLogger mainLogger,
@@ -91,10 +93,20 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
         this.onClientDisconnected = onClientDisconnected;
         this.backendHealthManager = backendHealthManager;
         this.requestsLogger = requestsLogger;
+        this.listenerHost = listenerHost;
+        this.listenerPort = listenerPort;
     }
 
     public SocketAddress getClientAddress() {
         return clientAddress;
+    }
+
+    public String getListenerHost() {
+        return listenerHost;
+    }
+
+    public int getListenerPort() {
+        return listenerPort;
     }
 
     @Override

--- a/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
@@ -62,9 +62,7 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
     volatile Boolean keepAlive;
     volatile boolean refuseOtherRequests;
     private final List<RequestHandler> pendingRequests = new CopyOnWriteArrayList<>();
-    final Runnable onClientDisconnected;
-    private final String listenerHost;
-    private final int listenerPort;
+    final Runnable onClientDisconnected;  
 
     public ClientConnectionHandler(
             StatsLogger mainLogger,
@@ -92,21 +90,11 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
         this.connectionStartsTs = System.nanoTime();
         this.onClientDisconnected = onClientDisconnected;
         this.backendHealthManager = backendHealthManager;
-        this.requestsLogger = requestsLogger;
-        this.listenerHost = listenerHost;
-        this.listenerPort = listenerPort;
+        this.requestsLogger = requestsLogger; 
     }
 
     public SocketAddress getClientAddress() {
         return clientAddress;
-    }
-
-    public String getListenerHost() {
-        return listenerHost;
-    }
-
-    public int getListenerPort() {
-        return listenerPort;
     }
 
     @Override

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
@@ -40,6 +40,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpStatusClass.SUCCESS;
 import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.CharsetUtil;
@@ -203,6 +204,7 @@ public class RequestHandler {
             case SYSTEM:
             case STATIC:
             case ACME_CHALLENGE:
+            case REDIRECT:
                 return;
             case PROXY:
                 try {
@@ -254,6 +256,7 @@ public class RequestHandler {
             case ACME_CHALLENGE:
             case INTERNAL_ERROR:
             case NOTFOUND:
+            case REDIRECT:
                 break;
             case SYSTEM:
                 continueDebugMessage(httpContent, httpContent);
@@ -319,6 +322,9 @@ public class RequestHandler {
                 }
                 break;
             }
+            case REDIRECT:
+                serveRedirect();
+                break;
             default:
                 throw new IllegalStateException("not yet implemented");
         }
@@ -341,7 +347,7 @@ public class RequestHandler {
             code = 404;
         }
 
-        FullHttpResponse response = connectionToClient.staticContentsManager.buildResponse(code, resource);        
+        FullHttpResponse response = connectionToClient.staticContentsManager.buildResponse(code, resource);
         if (!writeSimpleResponse(response)) {
             forceCloseChannelToClient();
         }
@@ -384,6 +390,42 @@ public class RequestHandler {
             // If keep-alive is off, close the connection once the content is fully written.
             forceCloseChannelToClient();
         }
+    }
+
+    private void serveRedirect() {
+        DefaultFullHttpResponse res = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1,
+                HttpResponseStatus.valueOf(action.errorcode < 0 ? 302 : action.errorcode) // redirect: 3XX
+        );
+        addCustomResponseHeaders(res);
+        res.headers().set(HttpHeaderNames.CACHE_CONTROL, "no-cache");
+
+        String location = action.redirectLocation;
+        String host = this.connectionToClient.getListenerHost();
+        int port = this.connectionToClient.getListenerPort();
+        String path = this.uri;
+        if (location == null || location.isEmpty()) {
+            if (!action.host.isEmpty()) {
+                host = action.host;
+            }           
+            if (action.port > 0) {
+                port = action.port;
+            } else if ("https".equals(action.redirectProto)) {
+                port = 443;
+            }
+            if (!action.redirectPath.isEmpty()) {
+                path = action.redirectPath;
+            }
+            location = host + ":" + port + path; // - custom redirection
+        } else if (location.startsWith("/")) {
+            location = host + ":" + port + location; // - relative redirection
+        } // else: implicit absolute redirection
+
+        // - redirect to https
+        location = ("https".equals(action.redirectProto) ? "https://" : "http://") + location.replaceFirst("http.?:\\/\\/", "");
+
+        res.headers().set(HttpHeaderNames.LOCATION, location);
+        writeSimpleResponse(res);
     }
 
     private void serveDebugMessage(HttpContent httpContent, Object msg, LastHttpContent trailer) {
@@ -609,12 +651,12 @@ public class RequestHandler {
         if (msg instanceof HttpResponse && action != null && action.customHeaders != null) {
             HttpHeaders headers = ((HttpResponse) msg).headers();
             action.customHeaders.forEach(customHeader -> {
-                if (HEADER_MODE_SET.equals(customHeader.getMode()) ||
-                        HEADER_MODE_REMOVE.equals(customHeader.getMode())) {
+                if (HEADER_MODE_SET.equals(customHeader.getMode())
+                        || HEADER_MODE_REMOVE.equals(customHeader.getMode())) {
                     headers.remove(customHeader.getName());
                 }
-                if (HEADER_MODE_SET.equals(customHeader.getMode()) ||
-                        HEADER_MODE_ADD.equals(customHeader.getMode())) {
+                if (HEADER_MODE_SET.equals(customHeader.getMode())
+                        || HEADER_MODE_ADD.equals(customHeader.getMode())) {
                     headers.add(customHeader.getName(), customHeader.getValue());
                 }
             });

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
@@ -76,8 +76,7 @@ public class RequestHandler {
     private static final Logger LOG = Logger.getLogger(RequestHandler.class.getName());
     private static final AtomicLong TIME_TRACKER = new AtomicLong();
     private static final String PROTO_HTTPS = "https";
-    private static final String PROTO_HTTP = "http";
-    private static final String PROTO_HTTP_DEFAULT_PORT = "443";
+    private static final String PROTO_HTTP = "http";    
     private final long id;
     private final HttpRequest request;
     private final List<RequestFilter> filters;
@@ -416,7 +415,7 @@ public class RequestHandler {
             if (action.port > 0) {
                 port = ":" + action.port;
             } else if (PROTO_HTTPS.equals(action.redirectProto)) {
-                port = ":" + PROTO_HTTP_DEFAULT_PORT;
+                port = ""; // default https port
             }
             if (!action.redirectPath.isEmpty()) {
                 path = action.redirectPath;

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
@@ -40,7 +40,7 @@ public class ActionConfiguration {
     private final String director;
     private final String file;
     private final int errorcode;
-    private List<CustomHeader> customHeaders = Collections.unmodifiableList(new ArrayList()); // it's a list to keep ordering
+    private List<CustomHeader> customHeaders = Collections.emptyList(); // it's a list to keep ordering
     private String redirectLocation;
     private String redirectProto;
     private String redirectHost;

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
@@ -33,23 +33,28 @@ public class ActionConfiguration {
     public static final String TYPE_CACHE = "cache";
     public static final String TYPE_STATIC = "static";
     public static final String TYPE_ACME_CHALLENGE = "acme-challenge";
+    public static final String TYPE_REDIRECT = "redirect";
 
     private final String id;
     private final String type;
-    private final String file;
     private final String director;
-    private final int errorcode;    
-    private final List<CustomHeader> customHeaders; // it's a list to keep ordering
+    private final String file;
+    private final int errorcode;
+    private List<CustomHeader> customHeaders = Collections.unmodifiableList(new ArrayList()); // it's a list to keep ordering
+    private String redirectLocation;
+    private String redirectProto;
+    private String redirectHost;
+    private int redirectPort;
+    private String redirectPath;
 
-    public ActionConfiguration(String id, String type, String director, String file, int errorcode, List<CustomHeader> customHeaders) {
+
+    public ActionConfiguration(String id, String type, String director, String file, int errorcode) {
         this.id = id;
         this.type = type;
         this.director = director;
         this.file = file;
-        this.errorcode = errorcode;        
-        this.customHeaders = Collections.unmodifiableList(customHeaders == null ? new ArrayList() : customHeaders);
+        this.errorcode = errorcode;
     }
-
 
     public String getDirector() {
         return director;
@@ -71,13 +76,63 @@ public class ActionConfiguration {
         return type;
     }
 
+    public ActionConfiguration setCustomHeaders(List<CustomHeader> customHeaders) {
+        this.customHeaders = Collections.unmodifiableList(customHeaders == null ? new ArrayList() : customHeaders);
+        return this;
+    }
+
     public List<CustomHeader> getCustomHeaders() {
         return customHeaders;
     }
 
+    public ActionConfiguration setRedirectLocation(String redirectLocation) {
+        this.redirectLocation = redirectLocation;
+        return this;
+    }
+
+    public String getRedirectLocation() {
+        return redirectLocation;
+    }
+
+    public ActionConfiguration setRedirectProto(String redirectProto) {
+        this.redirectProto = redirectProto;
+        return this;
+    }
+
+    public String getRedirectProto() {
+        return redirectProto;
+    }
+
+    public ActionConfiguration setRedirectHost(String redirectHost) {
+        this.redirectHost = redirectHost;
+        return this;
+    }
+
+    public String getRedirectHost() {
+        return redirectHost;
+    }
+
+    public ActionConfiguration setRedirectPort(int redirectPort) {
+        this.redirectPort = redirectPort;
+        return this;
+    }
+
+    public int getRedirectPort() {
+        return redirectPort;
+    }
+
+    public ActionConfiguration setRedirectPath(String redirectPath) {
+        this.redirectPath = redirectPath;
+        return this;
+    }
+
+    public String getRedirectPath() {
+        return redirectPath;
+    }
+
     @Override
     public String toString() {
-        return "ActionConfiguration{" + "id=" + id + ", type=" + type + ", file=" + file + ", director=" + director + ", errorcode=" + errorcode + ", customHeaders=" + customHeaders + '}';
+        return "ActionConfiguration{" + "id=" + id + ", type=" + type + ", director=" + director + ", file=" + file + ", errorcode=" + errorcode + ", customHeaders=" + customHeaders + ", redirectLocation=" + redirectLocation + ", redirectProto=" + redirectProto + ", redirectHost=" + redirectHost + ", redirectPort=" + redirectPort + ", redirectPath=" + redirectPath + '}';
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -160,6 +160,12 @@ public class StandardEndpointMapper extends EndpointMapper {
                     _action.setRedirectHost(properties.getProperty(prefix + "redirect.host", ""));
                     _action.setRedirectPort(Integer.parseInt(properties.getProperty(prefix + "redirect.port", "-1")));
                     _action.setRedirectPath(properties.getProperty(prefix + "redirect.path", ""));
+                    if (action.equals("redirect") && _action.getRedirectProto().isEmpty() && _action.getRedirectHost().isEmpty()
+                            && _action.getRedirectPort() == -1 && _action.getRedirectPath().isEmpty()) {
+                        throw new ConfigurationNotValidException("while configuring action '" + id
+                                + "': at least redirect.location or redirect.proto|.host|.port|.path have to be defined"
+                        );
+                    }
                 }
 
                 addAction(_action);

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -87,23 +87,13 @@ public class StandardEndpointMapper extends EndpointMapper {
     @Override
     public void configure(ConfigurationStore properties) throws ConfigurationNotValidException {
 
-        addAction(new ActionConfiguration(
-                "proxy-all", ActionConfiguration.TYPE_PROXY, DirectorConfiguration.DEFAULT, null, -1, Collections.emptyList()
-        ));
-        addAction(new ActionConfiguration(
-                "cache-if-possible", ActionConfiguration.TYPE_CACHE, DirectorConfiguration.DEFAULT, null, -1, Collections.emptyList()
-        ));
-        addAction(new ActionConfiguration(
-                "not-found", ActionConfiguration.TYPE_STATIC, null, DEFAULT_NOT_FOUND, 404, Collections.emptyList()
-        ));
-        addAction(new ActionConfiguration(
-                "internal-error", ActionConfiguration.TYPE_STATIC, null, DEFAULT_INTERNAL_SERVER_ERROR, 500, Collections.emptyList()
-        ));
+        addAction(new ActionConfiguration("proxy-all", ActionConfiguration.TYPE_PROXY, DirectorConfiguration.DEFAULT, null, -1));
+        addAction(new ActionConfiguration("cache-if-possible", ActionConfiguration.TYPE_CACHE, DirectorConfiguration.DEFAULT, null, -1));
+        addAction(new ActionConfiguration("not-found", ActionConfiguration.TYPE_STATIC, null, DEFAULT_NOT_FOUND, 404));
+        addAction(new ActionConfiguration("internal-error", ActionConfiguration.TYPE_STATIC, null, DEFAULT_INTERNAL_SERVER_ERROR, 500));
 
         // Route+Action configuration for Let's Encrypt ACME challenging
-        addAction(new ActionConfiguration(
-                "acme-challenge", ActionConfiguration.TYPE_ACME_CHALLENGE, null, null, HttpResponseStatus.OK.code(), Collections.emptyList()
-        ));
+        addAction(new ActionConfiguration("acme-challenge", ActionConfiguration.TYPE_ACME_CHALLENGE, null, null, HttpResponseStatus.OK.code()));
         addRoute(new RouteConfiguration("acme-challenge", "acme-challenge", true, new URIRequestMatcher(".*" + ACME_CHALLENGE_URI_PATTERN + ".*")));
 
         this.defaultNotFoundAction = properties.getProperty("default.action.notfound", "not-found");
@@ -160,8 +150,24 @@ public class StandardEndpointMapper extends EndpointMapper {
                         }
                     }
                 }
-                addAction(new ActionConfiguration(id, action, director, file, code, customHeaders));
-                LOG.info("configured action " + id + " type=" + action + " enabled:" + enabled + " headers:" + headersIds);
+
+                ActionConfiguration _action = new ActionConfiguration(id, action, director, file, code)
+                        .setCustomHeaders(customHeaders);
+                String redirectLocation = properties.getProperty(prefix + "redirect.location", "");
+                _action.setRedirectLocation(redirectLocation);
+                if (redirectLocation.isEmpty()) {
+                    _action.setRedirectProto(properties.getProperty(prefix + "redirect.proto", ""));
+                    _action.setRedirectHost(properties.getProperty(prefix + "redirect.host", ""));
+                    _action.setRedirectPort(Integer.parseInt(properties.getProperty(prefix + "redirect.port", "-1")));
+                    _action.setRedirectPath(properties.getProperty(prefix + "redirect.path", ""));
+                }
+
+                addAction(_action);
+                LOG.info("configured action " + id + " type=" + action + " enabled:" + enabled + " headers:" + headersIds
+                        + " redirect location:" + redirectLocation + " redirect proto:" + _action.getRedirectProto()
+                        + " redirect host:" + _action.getRedirectHost() + " redirect port:" + _action.getRedirectPort()
+                        + " redirect path:" + _action.getRedirectPath()
+                );
             }
         }
 
@@ -351,10 +357,19 @@ public class StandardEndpointMapper extends EndpointMapper {
                     return MapResult.NOT_FOUND(route.getId());
                 }
 
+                if (ActionConfiguration.TYPE_REDIRECT.equals(action.getType())) {
+                    return new MapResult(action.getRedirectHost(), action.getRedirectPort(), MapResult.Action.REDIRECT, route.getId())
+                            .setRedirectLocation(action.getRedirectLocation())
+                            .setRedirectProto(action.getRedirectProto())
+                            .setRedirectPath(action.getRedirectPath())
+                            .setErrorcode(action.getErrorcode())
+                            .setCustomHeaders(action.getCustomHeaders());
+                }
                 if (ActionConfiguration.TYPE_STATIC.equals(action.getType())) {
-                    return new MapResult(null, -1, MapResult.Action.STATIC, route.getId(), action.getCustomHeaders())
+                    return new MapResult(null, -1, MapResult.Action.STATIC, route.getId())
                             .setResource(action.getFile())
-                            .setErrorcode(action.getErrorcode());
+                            .setErrorcode(action.getErrorcode())
+                            .setCustomHeaders(action.getCustomHeaders());
                 }
                 if (ActionConfiguration.TYPE_ACME_CHALLENGE.equals(action.getType())) {
                     if (this.dynamicCertificateManger != null) {
@@ -363,7 +378,7 @@ public class StandardEndpointMapper extends EndpointMapper {
                         if (tokenData == null) {
                             return MapResult.NOT_FOUND(route.getId());
                         }
-                        return new MapResult(null, -1, MapResult.Action.ACME_CHALLENGE, route.getId(), null)
+                        return new MapResult(null, -1, MapResult.Action.ACME_CHALLENGE, route.getId())
                                 .setResource(IN_MEMORY_RESOURCE + tokenData)
                                 .setErrorcode(action.getErrorcode());
                     } else {
@@ -413,13 +428,8 @@ public class StandardEndpointMapper extends EndpointMapper {
                                     + backendId;
                             customHeaders.add(new CustomHeader(debuggingHeaderName, routingPath, HeaderMode.HEADER_MODE_ADD));
                         }
-                        return new MapResult(
-                                backend.getHost(),
-                                backend.getPort(),
-                                selectedAction,
-                                route.getId(),
-                                customHeaders
-                        );
+                        return new MapResult(backend.getHost(), backend.getPort(), selectedAction, route.getId())
+                                .setCustomHeaders(customHeaders);
                     }
                 }
             }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -127,7 +127,7 @@ public class StandardEndpointMapper extends EndpointMapper {
             String id = properties.getProperty(prefix + "id", "");
             boolean enabled = Boolean.parseBoolean(properties.getProperty(prefix + "enabled", "false"));
             if (!id.isEmpty() && enabled) {
-                String action = properties.getProperty(prefix + "type", "proxy");
+                String action = properties.getProperty(prefix + "type", ActionConfiguration.TYPE_PROXY);
                 String file = properties.getProperty(prefix + "file", "");
                 String director = properties.getProperty(prefix + "director", DirectorConfiguration.DEFAULT);
                 int code = Integer.parseInt(properties.getProperty(prefix + "code", "-1"));
@@ -160,7 +160,7 @@ public class StandardEndpointMapper extends EndpointMapper {
                     _action.setRedirectHost(properties.getProperty(prefix + "redirect.host", ""));
                     _action.setRedirectPort(Integer.parseInt(properties.getProperty(prefix + "redirect.port", "-1")));
                     _action.setRedirectPath(properties.getProperty(prefix + "redirect.path", ""));
-                    if (action.equals("redirect") && _action.getRedirectProto().isEmpty() && _action.getRedirectHost().isEmpty()
+                    if (action.equals(ActionConfiguration.TYPE_REDIRECT) && _action.getRedirectProto().isEmpty() && _action.getRedirectHost().isEmpty()
                             && _action.getRedirectPort() == -1 && _action.getRedirectPath().isEmpty()) {
                         throw new ConfigurationNotValidException("while configuring action '" + id
                                 + "': at least redirect.location or redirect.proto|.host|.port|.path have to be defined"

--- a/carapace-server/src/test/java/org/carapaceproxy/server/RequestsLoggerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/RequestsLoggerTest.java
@@ -179,7 +179,7 @@ public class RequestsLoggerTest {
             r1.startTs = "2018-10-23 10:10:10.000";
             r1.backendStartTs = "2018-10-23 10:10:10.542";
             r1.endTs = "2018-10-23 10:10:11.012";
-            r1.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1", null);
+            r1.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1");
             r1.userid = "uid_1";
             r1.sessionid = "sid_1";
 
@@ -212,7 +212,7 @@ public class RequestsLoggerTest {
             r2.startTs = "2018-10-23 11:10:10.000";
             r2.backendStartTs = "2018-10-23 11:10:10.142";
             r2.endTs = "2018-10-23 11:10:10.912";
-            r2.action = new MapResult("host2", 2222, MapResult.Action.PROXY, "routeid_2", null);
+            r2.action = new MapResult("host2", 2222, MapResult.Action.PROXY, "routeid_2");
             r2.userid = "uid_2";
             r2.sessionid = "sid_2";
 
@@ -264,7 +264,7 @@ public class RequestsLoggerTest {
             r1.startTs = "2018-10-23 10:10:10.000";
             r1.backendStartTs = "2018-10-23 10:10:10.542";
             r1.endTs = "2018-10-23 10:10:11.012";
-            r1.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1", null);
+            r1.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1");
             r1.userid = "uid_1";
             r1.sessionid = "sid_1";
 
@@ -293,7 +293,7 @@ public class RequestsLoggerTest {
             r2.startTs = "2018-10-23 10:10:10.000";
             r2.backendStartTs = "2018-10-23 10:10:10.542";
             r2.endTs = "2018-10-23 10:10:11.012";
-            r2.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1", null);
+            r2.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1");
             r2.userid = "uid_1";
             r2.sessionid = "sid_1";
 
@@ -334,7 +334,7 @@ public class RequestsLoggerTest {
             r1.startTs = "2018-10-23 11:10:10.000";
             r1.backendStartTs = "2018-10-23 11:10:10.542";
             r1.endTs = "2018-10-23 11:10:11.012";
-            r1.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1", null);
+            r1.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1");
             r1.userid = "uid_1";
             r1.sessionid = "sid_1";
 
@@ -360,7 +360,7 @@ public class RequestsLoggerTest {
             r2.startTs = "2018-10-23 11:10:10.000";
             r2.backendStartTs = "2018-10-23 11:10:10.542";
             r2.endTs = "2018-10-23 11:10:11.012";
-            r2.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1", null);
+            r2.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1");
             r2.userid = "uid_1";
             r2.sessionid = "sid_1";
 
@@ -375,7 +375,7 @@ public class RequestsLoggerTest {
             r3.startTs = "2018-10-23 11:10:10.000";
             r3.backendStartTs = "2018-10-23 11:10:10.542";
             r3.endTs = "2018-10-23 11:10:11.012";
-            r3.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1", null);
+            r3.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1");
             r3.userid = "uid_1";
             r3.sessionid = "sid_1";
 
@@ -423,7 +423,7 @@ public class RequestsLoggerTest {
             r1.startTs = "2018-10-23 10:10:10.000";
             r1.backendStartTs = "2018-10-23 10:10:10.542";
             r1.endTs = "2018-10-23 10:10:11.012";
-            r1.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1", null);
+            r1.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1");
             r1.userid = "uid_1";
             r1.sessionid = "sid_1";
 
@@ -443,7 +443,7 @@ public class RequestsLoggerTest {
             r2.startTs = "2018-10-23 10:10:10.000";
             r2.backendStartTs = "2018-10-23 10:10:10.542";
             r2.endTs = "2018-10-23 10:10:11.012";
-            r2.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1", null);
+            r2.action = new MapResult("host", 1111, MapResult.Action.CACHE, "routeid_1");
             r2.userid = "uid_1";
             r2.sessionid = "sid_1";
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
@@ -494,7 +494,7 @@ public class BasicStandardEndpointMapperTest {
                 // redirect to same host/uri but with https (default port)
                 HttpURLConnection conn = (HttpURLConnection) new URL("http://localhost:" + port + "/index.html").openConnection();
                 conn.setInstanceFollowRedirects(false);
-                assertEquals("https://localhost:443/index.html", conn.getHeaderField("Location"));
+                assertEquals("https://localhost/index.html", conn.getHeaderField("Location"));
                 assertTrue(conn.getHeaderFields().toString().contains("301 Moved Permanently"));
             }
             {
@@ -518,6 +518,6 @@ public class BasicStandardEndpointMapperTest {
                 assertEquals("https://192.0.0.1:1234/indexX.html", conn.getHeaderField("Location"));
                 assertTrue(conn.getHeaderFields().toString().contains("307 Temporary Redirect"));
             }
+            }
         }
     }
-}

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
@@ -494,31 +494,27 @@ public class BasicStandardEndpointMapperTest {
                 // redirect to same host/uri but with https (default port)
                 HttpURLConnection conn = (HttpURLConnection) new URL("http://localhost:" + port + "/index.html").openConnection();
                 conn.setInstanceFollowRedirects(false);
-                assertEquals("https://0.0.0.0:443/index.html", conn.getHeaderField("Location"));
+                assertEquals("https://localhost:443/index.html", conn.getHeaderField("Location"));
                 assertTrue(conn.getHeaderFields().toString().contains("301 Moved Permanently"));
             }
-
             {
                 // redirect to absolute host:port/uri
                 HttpURLConnection conn = (HttpURLConnection) new URL("http://localhost:" + port + "/index2.html").openConnection();
-                conn.setInstanceFollowRedirects(false);
-                System.out.println("HEADERS: " + conn.getHeaderFields().toString());
+                conn.setInstanceFollowRedirects(false);               
                 assertEquals("http://foo/index0.html", conn.getHeaderField("Location"));
                 assertTrue(conn.getHeaderFields().toString().contains("302 Found"));
             }
             {
                 // relative redirect (same host:port, different uri)
                 HttpURLConnection conn = (HttpURLConnection) new URL("http://localhost:" + port + "/index3.html").openConnection();
-                conn.setInstanceFollowRedirects(false);
-                System.out.println("HEADERS: " + conn.getHeaderFields().toString());
-                assertEquals("http://0.0.0.0:" + port + "/index0.html", conn.getHeaderField("Location"));
+                conn.setInstanceFollowRedirects(false);                
+                assertEquals("http://localhost:" + port + "/index0.html", conn.getHeaderField("Location"));
                 assertTrue(conn.getHeaderFields().toString().contains("303 See Other"));
             }
             {
                 // redirect custom
                 HttpURLConnection conn = (HttpURLConnection) new URL("http://localhost:" + port + "/index4.html").openConnection();
-                conn.setInstanceFollowRedirects(false);
-                System.out.println("HEADERS: " + conn.getHeaderFields().toString());
+                conn.setInstanceFollowRedirects(false);                
                 assertEquals("https://192.0.0.1:1234/indexX.html", conn.getHeaderField("Location"));
                 assertTrue(conn.getHeaderFields().toString().contains("307 Temporary Redirect"));
             }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/ForceBackendTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/ForceBackendTest.java
@@ -25,7 +25,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.net.URL;
-import java.util.Collections;
 import java.util.Properties;
 import org.apache.commons.io.IOUtils;
 import org.carapaceproxy.client.ConnectionsManagerStats;
@@ -82,7 +81,7 @@ public class ForceBackendTest {
         mapper.addDirector(new DirectorConfiguration("director-1").addBackend("backend-a"));
         mapper.addDirector(new DirectorConfiguration("director-2").addBackend("backend-b"));
 
-        mapper.addAction(new ActionConfiguration("proxy-1", ActionConfiguration.TYPE_PROXY, "director-1", null, -1, Collections.emptyList()));
+        mapper.addAction(new ActionConfiguration("proxy-1", ActionConfiguration.TYPE_PROXY, "director-1", null, -1));
 
         mapper.addRoute(new RouteConfiguration("route-1", "proxy-1", true, new URIRequestMatcher(".*index.html.*")));
 

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/TestEndpointMapper.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/TestEndpointMapper.java
@@ -64,11 +64,11 @@ public class TestEndpointMapper extends EndpointMapper {
         if (uri.contains("not-found")) {
             return MapResult.NOT_FOUND(MapResult.NO_ROUTE);
         } else if (uri.contains("debug")) {
-            return new MapResult(null, 0, MapResult.Action.SYSTEM, MapResult.NO_ROUTE,null);
+            return new MapResult(null, 0, MapResult.Action.SYSTEM, MapResult.NO_ROUTE);
         } else if (cacheAll) {
-            return new MapResult(host, port, MapResult.Action.CACHE, MapResult.NO_ROUTE, null);
+            return new MapResult(host, port, MapResult.Action.CACHE, MapResult.NO_ROUTE);
         } else {
-            return new MapResult(host, port, MapResult.Action.PROXY, MapResult.NO_ROUTE, null);
+            return new MapResult(host, port, MapResult.Action.PROXY, MapResult.NO_ROUTE);
         }
     }
 


### PR DESCRIPTION
**New Redirect Action:**
```
action.1.type=redirect    # new type of action
action.1.code=307    # http redirect code
action.1.redirect.location=https://localhost:1234/index.html    # for absolute/relative redirection s
action.1.redirect.proto=https    # 'https' for redirect to https (default http is used)
action.1.redirect.host=192.0.0.1    # redirection host
action.1.redirect.port=1234    # redirection port
action.1.redirect.path=/indexX.html    # redirection path
```
Two way to use it:
* with redirec.location: to specify realive/absolute redirections
* with redirect.proto/host/port/path: to customize a particular part of the redirection path (header Location)
