### PR TITLE
UI: list of cluster peers #62

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/api/ApplicationConfig.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/ApplicationConfig.java
@@ -46,6 +46,7 @@ public class ApplicationConfig extends Application {
         resources.add(RequestFiltersResource.class);
         resources.add(UserRealmResource.class);
         resources.add(MetricsResource.class);
+        resources.add(ClusterResource.class);
         return resources;
     }
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/api/ClusterResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/ClusterResource.java
@@ -1,0 +1,103 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package org.carapaceproxy.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.servlet.ServletContext;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import org.carapaceproxy.cluster.GroupMembershipHandler;
+import org.carapaceproxy.server.HttpProxyServer;
+
+/**
+ * Access to configured actions
+ *
+ * @author paolo.venturi
+ */
+@Path("/cluster")
+@Produces("application/json")
+public class ClusterResource {
+
+    @javax.ws.rs.core.Context
+    ServletContext context;
+
+    public static final class PeerBean {
+
+        private final String id;
+        private final String description;
+        private final Map<String, String> info;
+
+        public PeerBean(String id, String descrption, Map<String, String> info) {
+            this.id = id;
+            this.description = descrption;
+            this.info = info;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getDescrption() {
+            return description;
+        }
+
+        public Map<String, String> getInfo() {
+            return info;
+        }
+    }
+
+    private PeerBean getPeer(String peerId, GroupMembershipHandler handler) {
+        return new PeerBean(peerId, handler.describePeer(peerId), handler.loadInfoForPeer(peerId));
+    }
+
+    @GET
+    @Path("peers")
+    public List<PeerBean> getAll() {
+        final List<PeerBean> peers = new ArrayList();
+        HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
+        GroupMembershipHandler handler = server.getGroupMembershipHandler();
+        handler.getPeers().forEach(p-> peers.add(getPeer(p, handler)));
+
+        return peers;
+    }
+
+    @GET
+    @Path("peers/current")
+    public PeerBean getCurrentPeer() {
+        HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
+        GroupMembershipHandler handler = server.getGroupMembershipHandler();
+
+        return getPeer(handler.getCurrentPeer(), handler);
+    }
+
+    @GET
+    @Path("peers/{peerId}")
+    public PeerBean getPeer(@PathParam("peerId") String peerId) {
+        HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
+        GroupMembershipHandler handler = server.getGroupMembershipHandler();
+
+        return getPeer(peerId, handler);
+    }
+
+}

--- a/carapace-server/src/main/java/org/carapaceproxy/api/ClusterResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/ClusterResource.java
@@ -48,9 +48,9 @@ public class ClusterResource {
         private final String description;
         private final Map<String, String> info;
 
-        public PeerBean(String id, String descrption, Map<String, String> info) {
+        public PeerBean(String id, String description, Map<String, String> info) {
             this.id = id;
-            this.description = descrption;
+            this.description = description;
             this.info = info;
         }
 
@@ -58,7 +58,7 @@ public class ClusterResource {
             return id;
         }
 
-        public String getDescrption() {
+        public String getDescription() {
             return description;
         }
 
@@ -68,7 +68,20 @@ public class ClusterResource {
     }
 
     private PeerBean getPeer(String peerId, GroupMembershipHandler handler) {
-        return new PeerBean(peerId, handler.describePeer(peerId), handler.loadInfoForPeer(peerId));
+        Map<String, String> info = handler.loadInfoForPeer(peerId);
+        if (info != null) {
+            return new PeerBean(peerId, handler.describePeer(peerId), info);
+        }
+        return null;
+    }
+
+    @GET
+    @Path("localpeer")
+    public PeerBean getLocalPeer() {
+        HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
+        GroupMembershipHandler handler = server.getGroupMembershipHandler();
+
+        return getPeer(handler.getLocalPeer(), handler);
     }
 
     @GET
@@ -80,15 +93,6 @@ public class ClusterResource {
         handler.getPeers().forEach(p-> peers.add(getPeer(p, handler)));
 
         return peers;
-    }
-
-    @GET
-    @Path("peers/current")
-    public PeerBean getCurrentPeer() {
-        HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
-        GroupMembershipHandler handler = server.getGroupMembershipHandler();
-
-        return getPeer(handler.getCurrentPeer(), handler);
     }
 
     @GET

--- a/carapace-server/src/main/java/org/carapaceproxy/cluster/GroupMembershipHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/cluster/GroupMembershipHandler.java
@@ -19,7 +19,11 @@
  */
 package org.carapaceproxy.cluster;
 
+import java.io.ByteArrayInputStream;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
 
 /**
  * Handle group membership: peer discovery and configuration changes.
@@ -36,6 +40,11 @@ public interface GroupMembershipHandler {
     void start();
 
     /**
+     * Unregister from the network, events won't be notified anymore.
+     */
+    void stop();
+
+    /**
      * Register a callback to be called when a particular event is fired.
      *
      * @param eventId
@@ -49,6 +58,22 @@ public interface GroupMembershipHandler {
      * @param eventId
      */
     void fireEvent(String eventId);
+
+     /**
+     * To execute code in mutual exclusion to other peers.
+     *
+     * Whether the peer fails to acquire/release the mutex code passed will be skipped and no exceptions will be thrown.
+     *
+     * @param lockId
+     * @param runnable
+     */
+    void executeInMutex(String lockId, int acquireTimeout, Runnable runnable);
+
+    /**
+     *
+     * @return id of the current peer.
+     */
+    String getCurrentPeer();
 
     /**
      * List current peers
@@ -65,20 +90,20 @@ public interface GroupMembershipHandler {
      */
     String describePeer(String peerId);
 
-    /**
-     * Unregister from the network, events won't be notified anymore.
-     */
-    void stop();
 
     /**
-     * To execute code in mutual exclusion to other peers.
-     *
-     * Whether the peer fails to acquire/release the mutex code passed will be skipped and no exceptions will be thrown.
-     *
-     * @param lockId
-     * @param runnable
+     * To store some key-value info for a peer.
+     * @param id
+     * @param info properties of the peer.
      */
-    void executeInMutex(String lockId, int acquireTimeout, Runnable runnable);
+    void storeInfoForPeer(String id, Map<String, String> info);
+
+    /**
+     * To load info associated to the peer.
+     * @param id
+     * @return properties of the peer
+     */
+    Map<String, String> loadInfoForPeer(String id);
 
     interface EventCallback {
 

--- a/carapace-server/src/main/java/org/carapaceproxy/cluster/GroupMembershipHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/cluster/GroupMembershipHandler.java
@@ -19,11 +19,8 @@
  */
 package org.carapaceproxy.cluster;
 
-import java.io.ByteArrayInputStream;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 
 /**
  * Handle group membership: peer discovery and configuration changes.
@@ -71,9 +68,9 @@ public interface GroupMembershipHandler {
 
     /**
      *
-     * @return id of the current peer.
+     * @return id of the local peer.
      */
-    String getCurrentPeer();
+    String getLocalPeer();
 
     /**
      * List current peers
@@ -92,11 +89,10 @@ public interface GroupMembershipHandler {
 
 
     /**
-     * To store some key-value info for a peer.
-     * @param id
+     * To store some key-value info for the local peer.     
      * @param info properties of the peer.
      */
-    void storeInfoForPeer(String id, Map<String, String> info);
+    void storeLocalPeerInfo(Map<String, String> info);
 
     /**
      * To load info associated to the peer.

--- a/carapace-server/src/main/java/org/carapaceproxy/cluster/impl/NullGroupMembershipHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/cluster/impl/NullGroupMembershipHandler.java
@@ -20,6 +20,7 @@
 package org.carapaceproxy.cluster.impl;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.carapaceproxy.cluster.GroupMembershipHandler;
@@ -31,7 +32,8 @@ import org.carapaceproxy.cluster.GroupMembershipHandler;
  */
 public class NullGroupMembershipHandler implements GroupMembershipHandler {
 
-    private Map<String, String> peerInfo;
+    private Map<String, String> peerInfo = Map.of("address", "localhost");
+    private final String peerId = "local";
 
     @Override
     public void start() {
@@ -53,8 +55,11 @@ public class NullGroupMembershipHandler implements GroupMembershipHandler {
     }
 
     @Override
-    public String describePeer(String peerId) {
-        return "";
+    public String describePeer(String id) {
+       if (peerId.equals(id)) {
+            return peerId;
+        }
+        return null;
     }
 
     @Override
@@ -67,18 +72,21 @@ public class NullGroupMembershipHandler implements GroupMembershipHandler {
     }
 
     @Override
-    public String getCurrentPeer() {
-        return "only-one";
+    public String getLocalPeer() {
+        return peerId;
     }
 
     @Override
-    public void storeInfoForPeer(String id, Map<String, String> info) {
-        peerInfo = info;
+    public void storeLocalPeerInfo(Map<String, String> info) {
+        peerInfo = new HashMap(info);
     }
 
     @Override
     public Map<String, String> loadInfoForPeer(String id) {
-        return peerInfo;
+        if (peerId.equals(id)) {
+            return peerInfo;
+        }
+        return null;
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/cluster/impl/NullGroupMembershipHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/cluster/impl/NullGroupMembershipHandler.java
@@ -21,6 +21,7 @@ package org.carapaceproxy.cluster.impl;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.carapaceproxy.cluster.GroupMembershipHandler;
 
 /**
@@ -29,6 +30,8 @@ import org.carapaceproxy.cluster.GroupMembershipHandler;
  * @author eolivelli
  */
 public class NullGroupMembershipHandler implements GroupMembershipHandler {
+
+    private Map<String, String> peerInfo;
 
     @Override
     public void start() {
@@ -61,6 +64,21 @@ public class NullGroupMembershipHandler implements GroupMembershipHandler {
     @Override
     public void executeInMutex(String lockId, int timeout, Runnable runnable) {
         runnable.run();
+    }
+
+    @Override
+    public String getCurrentPeer() {
+        return "only-one";
+    }
+
+    @Override
+    public void storeInfoForPeer(String id, Map<String, String> info) {
+        peerInfo = info;
+    }
+
+    @Override
+    public Map<String, String> loadInfoForPeer(String id) {
+        return peerInfo;
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandler.java
@@ -57,16 +57,20 @@ import org.carapaceproxy.cluster.GroupMembershipHandler;
  */
 public class ZooKeeperGroupMembershipHandler implements GroupMembershipHandler, AutoCloseable {
 
+    public static final String PROPERTY_PEER_ADMIN_SERVER_HOST = "peer_admin_server_host"; // host of the Admin UI/API
+    public static final String PROPERTY_PEER_ADMIN_SERVER_PORT = "peer_admin_server_port"; // port of the Admin UI/API
+
     private static final Logger LOG = Logger.getLogger(ZooKeeperGroupMembershipHandler.class.getName());
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final CuratorFramework client;
     private final String peerId;
+    private final Map<String, String> peerInfo;
     private final CopyOnWriteArrayList<PathChildrenCache> watchedEvents = new CopyOnWriteArrayList<>();
     private final ConcurrentHashMap<String, InterProcessMutex> mutexes = new ConcurrentHashMap<>();
     private final ExecutorService callbacksExecutor = Executors.newSingleThreadExecutor();
 
-    public ZooKeeperGroupMembershipHandler(String zkAddress, int zkTimeout, String peerId) {
+    public ZooKeeperGroupMembershipHandler(String zkAddress, int zkTimeout, String peerId, Map<String, String> peerInfo) {
         client = CuratorFrameworkFactory
                 .builder()
                 .sessionTimeoutMs(zkTimeout)
@@ -75,6 +79,7 @@ public class ZooKeeperGroupMembershipHandler implements GroupMembershipHandler, 
                 .ensembleProvider(new FixedEnsembleProvider(zkAddress, true))
                 .build();
         this.peerId = peerId;
+        this.peerInfo = peerInfo;
     }
 
     @Override
@@ -91,6 +96,8 @@ public class ZooKeeperGroupMembershipHandler implements GroupMembershipHandler, 
                             .withMode(CreateMode.EPHEMERAL) // auto delete on close
                             .forPath("/proxy/peers/" + peerId);
                 }
+                // Setting up peer info
+                storeInfoForPeer(peerId, peerInfo);
             }
             {
                 final String path = "/proxy/events";
@@ -106,6 +113,37 @@ public class ZooKeeperGroupMembershipHandler implements GroupMembershipHandler, 
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
+    }
+
+    @Override
+    public void storeInfoForPeer(String id, Map<String, String> info) {
+        try {
+            String path = "/proxy/peers/" + id;
+            Stat exists = client.checkExists().creatingParentsIfNeeded().forPath(path);
+            if (info != null && exists != null) {
+                byte[] data = MAPPER.writeValueAsBytes(info);
+                client.setData().forPath(path, data);
+            }
+        } catch (Exception ex) {
+            LOG.log(Level.SEVERE, "Cannot store info for peer " + id, ex);
+        }
+    }
+
+    @Override
+    public Map<String, String> loadInfoForPeer(String id) {
+        try {
+            String path = "/proxy/peers/" + id;
+            Stat exists = client.checkExists().creatingParentsIfNeeded().forPath(path);
+            if (exists != null) {
+                byte[] data = client.getData().forPath(path);
+                if (data != null) {
+                    return MAPPER.readValue(new ByteArrayInputStream(data), Map.class);
+                }
+            }
+        } catch (Exception ex) {
+            LOG.log(Level.SEVERE, "Cannot load info for peer " + id, ex);
+        }
+        return Collections.EMPTY_MAP;
     }
 
     @Override
@@ -182,7 +220,8 @@ public class ZooKeeperGroupMembershipHandler implements GroupMembershipHandler, 
 
     @Override
     public String describePeer(String peerId) {
-        return peerId;
+        Map<String, String> info = loadInfoForPeer(peerId);
+        return peerId + " at: " + info.getOrDefault(PROPERTY_PEER_ADMIN_SERVER_HOST, "");
     }
 
     @Override
@@ -218,6 +257,11 @@ public class ZooKeeperGroupMembershipHandler implements GroupMembershipHandler, 
     public void close() {
         stop();
         mutexes.clear();
+    }
+
+    @Override
+    public String getCurrentPeer() {
+        return peerId;
     }
 
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandlerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandlerTest.java
@@ -23,8 +23,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.curator.test.TestingServer;
 import org.carapaceproxy.cluster.GroupMembershipHandler;
@@ -186,36 +184,31 @@ public class ZooKeeperGroupMembershipHandlerTest {
                     info = peer1.loadInfoForPeer(peerId2);
                     assertEquals("peer2", info.get("name"));
 
-                    peer1.storeInfoForPeer(peerId1, Map.of("name", "newpeer1", "address", "localhost"));
-                    peer1.storeInfoForPeer(peerId2, Map.of("name", "newpeer2", "address", "localhost:8080"));
-
+                    peer1.storeLocalPeerInfo(Map.of("name", "newpeer1", "address", "localhost"));
                     info = peer1.loadInfoForPeer(peerId1);
                     assertEquals("newpeer1", info.get("name"));
-                    assertEquals("localhost", info.get("address"));
-                    info = peer1.loadInfoForPeer(peerId2);
-                    assertEquals("newpeer2", info.get("name"));
-                    assertEquals("localhost:8080", info.get("address"));
+                    assertEquals("localhost", info.get("address"));                    
 
-                    peer1.storeInfoForPeer(peerId1, Collections.EMPTY_MAP);
-                    peer1.storeInfoForPeer(peerId2, Map.of("port", "8080"));
+                    peer1.storeLocalPeerInfo(Collections.EMPTY_MAP);
                     info = peer1.loadInfoForPeer(peerId1);
                     assertTrue(info.isEmpty());
-                    info = peer1.loadInfoForPeer(peerId2);
+                    peer1.storeLocalPeerInfo(Map.of("port", "8080"));
+                    info = peer1.loadInfoForPeer(peerId1);
                     assertNull(info.get("name"));
+                    peer1.storeLocalPeerInfo(null); // discarded
+                    info = peer1.loadInfoForPeer(peerId1);
+                    assertNull(info);
                 }
 
                 // OP on peer2
                 {
-                    peer2.storeInfoForPeer(peerId2, Map.of("name", "peer2", "address", "localhost:8080"));
-                    peer2.storeInfoForPeer(peerId1, Map.of("name", "peer1", "address", "localhost"));
-
+                    peer2.storeLocalPeerInfo(Map.of("name", "peer2", "address", "localhost:8080"));
                     Map<String, String> info = peer2.loadInfoForPeer(peerId2);
                     assertEquals("peer2", info.get("name"));
                     assertEquals("localhost:8080", info.get("address"));
                     info = peer2.loadInfoForPeer(peerId1);
-                    assertEquals("peer1", info.get("name"));
-                    assertEquals("localhost", info.get("address"));
-                }
+                    assertNull(info);
+                }              
             }
         }
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandlerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandlerTest.java
@@ -20,13 +20,16 @@
 package org.carapaceproxy.cluster.impl;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.curator.test.TestingServer;
 import org.carapaceproxy.cluster.GroupMembershipHandler;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,12 +45,12 @@ public class ZooKeeperGroupMembershipHandlerTest {
 
     @Test
     public void testPeerDiscovery() throws Exception {
-        try (TestingServer testingServer = new TestingServer(2229, tmpDir.newFolder());) {
+        try (TestingServer testingServer = new TestingServer(2229, tmpDir.newFolder())) {
             testingServer.start();
             try (ZooKeeperGroupMembershipHandler peer1 = new ZooKeeperGroupMembershipHandler(testingServer.getConnectString(),
-                    6000, peerId1);
+                    6000, peerId1, Collections.EMPTY_MAP);
                     ZooKeeperGroupMembershipHandler peer2 = new ZooKeeperGroupMembershipHandler(testingServer.getConnectString(),
-                            6000, peerId2);) {
+                    6000, peerId2, Collections.EMPTY_MAP)) {
                 peer1.start();
                 peer2.start();
                 List<String> peersFrom1 = peer1.getPeers();
@@ -56,7 +59,7 @@ public class ZooKeeperGroupMembershipHandlerTest {
                 assertEquals(Arrays.asList(peerId1, peerId2), peersFrom2);
 
                 try (ZooKeeperGroupMembershipHandler peer3 = new ZooKeeperGroupMembershipHandler(testingServer.getConnectString(),
-                        6000, peerId3);) {
+                        6000, peerId3, Collections.EMPTY_MAP)) {
                     peer3.start();
                     peersFrom1 = peer1.getPeers();
                     peersFrom2 = peer2.getPeers();
@@ -81,9 +84,9 @@ public class ZooKeeperGroupMembershipHandlerTest {
         try (TestingServer testingServer = new TestingServer(2229, tmpDir.newFolder());) {
             testingServer.start();
             try (ZooKeeperGroupMembershipHandler peer1 = new ZooKeeperGroupMembershipHandler(testingServer.getConnectString(),
-                    6000, peerId1);
+                    6000, peerId1, Collections.EMPTY_MAP);
                     ZooKeeperGroupMembershipHandler peer2 = new ZooKeeperGroupMembershipHandler(testingServer.getConnectString(),
-                            6000, peerId2);) {
+                    6000, peerId2, Collections.EMPTY_MAP)) {
                 peer1.start();
                 peer2.start();
                 List<String> peersFrom1 = peer1.getPeers();
@@ -116,7 +119,7 @@ public class ZooKeeperGroupMembershipHandlerTest {
                 eventFired2.set(0);
 
                 try (ZooKeeperGroupMembershipHandler peer3 = new ZooKeeperGroupMembershipHandler(testingServer.getConnectString(),
-                        6000, peerId3);) {
+                        6000, peerId3, Collections.EMPTY_MAP)) {
                     peer3.start();
 
                     AtomicInteger eventFired3 = new AtomicInteger();
@@ -161,6 +164,58 @@ public class ZooKeeperGroupMembershipHandlerTest {
 
                 }
 
+            }
+        }
+    }
+
+    @Test
+    public void testPeerInfo() throws Exception {
+        try (TestingServer testingServer = new TestingServer(2229, tmpDir.newFolder());) {
+            testingServer.start();
+            try (ZooKeeperGroupMembershipHandler peer1 = new ZooKeeperGroupMembershipHandler(testingServer.getConnectString(),
+                    6000, peerId1, Map.of("name", "peer1"));
+                    ZooKeeperGroupMembershipHandler peer2 = new ZooKeeperGroupMembershipHandler(testingServer.getConnectString(),
+                    6000, peerId2, Map.of("name", "peer2"))) {
+                peer1.start();
+                peer2.start();
+
+                // OP on peer1
+                {
+                    Map<String, String> info = peer1.loadInfoForPeer(peerId1);
+                    assertEquals("peer1", info.get("name"));
+                    info = peer1.loadInfoForPeer(peerId2);
+                    assertEquals("peer2", info.get("name"));
+
+                    peer1.storeInfoForPeer(peerId1, Map.of("name", "newpeer1", "address", "localhost"));
+                    peer1.storeInfoForPeer(peerId2, Map.of("name", "newpeer2", "address", "localhost:8080"));
+
+                    info = peer1.loadInfoForPeer(peerId1);
+                    assertEquals("newpeer1", info.get("name"));
+                    assertEquals("localhost", info.get("address"));
+                    info = peer1.loadInfoForPeer(peerId2);
+                    assertEquals("newpeer2", info.get("name"));
+                    assertEquals("localhost:8080", info.get("address"));
+
+                    peer1.storeInfoForPeer(peerId1, Collections.EMPTY_MAP);
+                    peer1.storeInfoForPeer(peerId2, Map.of("port", "8080"));
+                    info = peer1.loadInfoForPeer(peerId1);
+                    assertTrue(info.isEmpty());
+                    info = peer1.loadInfoForPeer(peerId2);
+                    assertNull(info.get("name"));
+                }
+
+                // OP on peer2
+                {
+                    peer2.storeInfoForPeer(peerId2, Map.of("name", "peer2", "address", "localhost:8080"));
+                    peer2.storeInfoForPeer(peerId1, Map.of("name", "peer1", "address", "localhost"));
+
+                    Map<String, String> info = peer2.loadInfoForPeer(peerId2);
+                    assertEquals("peer2", info.get("name"));
+                    assertEquals("localhost:8080", info.get("address"));
+                    info = peer2.loadInfoForPeer(peerId1);
+                    assertEquals("peer1", info.get("name"));
+                    assertEquals("localhost", info.get("address"));
+                }
             }
         }
     }

--- a/carapace-ui/pom.xml
+++ b/carapace-ui/pom.xml
@@ -111,6 +111,9 @@
                                 <goals>
                                     <goal>yarn</goal>
                                 </goals>
+                                <configuration>
+                                    <arguments>install</arguments>
+                                </configuration>
                             </execution>
                             <execution>
                                 <id>yarn build</id>
@@ -118,6 +121,9 @@
                                 <goals>
                                     <goal>yarn</goal>
                                 </goals>
+                                <configuration>
+                                    <arguments>build</arguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/carapace-ui/src/main/webapp/public/index.html
+++ b/carapace-ui/src/main/webapp/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <title>Http Proxy UI</title>
+    <title>Carapace Admin</title>
   </head>
   <body>
     <noscript>

--- a/carapace-ui/src/main/webapp/src/App.vue
+++ b/carapace-ui/src/main/webapp/src/App.vue
@@ -6,7 +6,7 @@
                 <ul class="sidebar-nav">
                     <li class="sidebar-brand">
                         <a href="#">
-                            Http Proxy
+                            Carapace ({{peerId}})
                         </a>
                     </li>
                     <li>
@@ -46,6 +46,9 @@
                     <li>
                     <router-link to="/metrics">Prometheus Metrics</router-link>
                     </li>
+                    <li>
+                    <router-link to="/peers">Cluster peers</router-link>
+                    </li>
 
                     <hr>
 
@@ -66,6 +69,19 @@
 <script>
     export default {
         name: 'app',
+        data: function () {
+            return {
+                peerId: ""
+            }
+        },
+        created: function () {
+            var url = "/api/cluster/peers/current"
+            var d = this
+            doGet(url, response => {
+                d.peerId = response.id;
+            })
+
+        },
     }
 </script>
 

--- a/carapace-ui/src/main/webapp/src/App.vue
+++ b/carapace-ui/src/main/webapp/src/App.vue
@@ -6,7 +6,7 @@
                 <ul class="sidebar-nav">
                     <li class="sidebar-brand">
                         <a href="#">
-                            Carapace ({{peerId}})
+                            Carapace Admin ({{peerId}})
                         </a>
                     </li>
                     <li>
@@ -67,6 +67,7 @@
 </template>
 
 <script>
+    import { doGet } from './mockserver'
     export default {
         name: 'app',
         data: function () {
@@ -75,12 +76,12 @@
             }
         },
         created: function () {
-            var url = "/api/cluster/peers/current"
+            var url = "/api/cluster/localpeer"
             var d = this
-            doGet(url, response => {
-                d.peerId = response.id;
+            doGet(url, response => {            
+                d.peerId = response.id
+                document.title += ' (' + d.peerId + ')'
             })
-
         },
     }
 </script>

--- a/carapace-ui/src/main/webapp/src/components/Peers.vue
+++ b/carapace-ui/src/main/webapp/src/components/Peers.vue
@@ -20,18 +20,14 @@
                         <div class="label">
                             {{item.description}}
                         </div>
-                    </td>
+                    </td>                    
                     <td>
                         <div class="label">
-                            {{item.info['peer_admin_server_host']}}:{{item.info['peer_admin_server_port']}}
+                            <a :href="'http://' + item.info['peer_admin_server_host'] + ':' + item.info['peer_admin_server_port'] + '/ui/#/'" >
+                                {{item.info['peer_admin_server_host']}} : {{item.info['peer_admin_server_port']}}
+                            </a>
                         </div>
                     </td>
-<!--                    <td>
-                        <div class="label">
-                            <b>{{item.httpResponse}}</b><br>
-                            <a href="#" @click="openDetail(item.httpBody)">Open probe page</a>
-                        </div>
-                    </td>-->
                 </tr>
             </tbody>
         </table>
@@ -48,7 +44,7 @@
             }
         },
         created: function () {
-            var url = "/api/peers"
+            var url = "/api/cluster/peers"
             var d = this
             doGet(url, response => {
                 d.peers = [];
@@ -61,31 +57,5 @@
     }
 </script>
 
-<style scoped>
-    table th,
-    table tr td .label {
-        font-size: 13px;
-    }
-    table tr td .label-error{
-        background-color: #f44336;
-        border-radius: 2px;
-
-        text-transform: uppercase;
-        text-align: center;
-        font-weight: bold;
-        color: white;
-
-        padding: 10px;
-    }
-    table tr td .label-success{
-        background-color: #4CAF50;
-        border-radius: 2px;
-
-        text-transform: uppercase;
-        font-weight: bold;
-        text-align: center;
-        color: white;
-
-        padding: 10px;
-    }
+<style scoped>   
 </style>

--- a/carapace-ui/src/main/webapp/src/components/Peers.vue
+++ b/carapace-ui/src/main/webapp/src/components/Peers.vue
@@ -1,0 +1,91 @@
+<template>
+    <div>
+        <h2>Peers</h2>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th scope="col">Id</th>
+                    <th scope="col">Description</th>
+                    <th scope="col">Admin Server UI</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr v-for="item of peers" :key="item.id">
+                    <td>
+                        <div class="label">
+                            {{item.id}}
+                        </div>
+                    </td>
+                    <td>
+                        <div class="label">
+                            {{item.description}}
+                        </div>
+                    </td>
+                    <td>
+                        <div class="label">
+                            {{item.info['peer_admin_server_host']}}:{{item.info['peer_admin_server_port']}}
+                        </div>
+                    </td>
+<!--                    <td>
+                        <div class="label">
+                            <b>{{item.httpResponse}}</b><br>
+                            <a href="#" @click="openDetail(item.httpBody)">Open probe page</a>
+                        </div>
+                    </td>-->
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</template>
+
+<script>
+    import { doGet } from './../mockserver'
+    export default {
+        name: 'Peers',
+        data: function () {
+            return {
+                peers: []
+            }
+        },
+        created: function () {
+            var url = "/api/peers"
+            var d = this
+            doGet(url, response => {
+                d.peers = [];
+                Object.keys(response).forEach(function (key) {
+                    d.peers.push(response[key])
+                })
+            })
+
+        }
+    }
+</script>
+
+<style scoped>
+    table th,
+    table tr td .label {
+        font-size: 13px;
+    }
+    table tr td .label-error{
+        background-color: #f44336;
+        border-radius: 2px;
+
+        text-transform: uppercase;
+        text-align: center;
+        font-weight: bold;
+        color: white;
+
+        padding: 10px;
+    }
+    table tr td .label-success{
+        background-color: #4CAF50;
+        border-radius: 2px;
+
+        text-transform: uppercase;
+        font-weight: bold;
+        text-align: center;
+        color: white;
+
+        padding: 10px;
+    }
+</style>

--- a/carapace-ui/src/main/webapp/src/router.js
+++ b/carapace-ui/src/main/webapp/src/router.js
@@ -14,6 +14,7 @@ import Certificate from './components/Certificate'
 import DatatableList from './components/DatatableList'
 import Configuration from './components/Configuration'
 import Metrics from './components/Metrics'
+import Peers from './components/Peers'
 
 Vue.component('backends-status', Backends)
 Vue.component('routes', Routes)
@@ -27,6 +28,7 @@ Vue.component('certificates-status', CertificatesStatus)
 Vue.component('datatable-list', DatatableList)
 Vue.component('configuration', Configuration)
 Vue.component('metrics', Metrics)
+Vue.component('peers', Peers)
 
 Vue.use(Router)
 
@@ -91,6 +93,11 @@ export default new Router({
         path: '/metrics',
         name: 'Metrics',
         component: Metrics
+    },
+    {
+        path: '/peers',
+        name: 'Peers',
+        component: Peers
     }
   ]
 })


### PR DESCRIPTION
Improvements:
- UI now has a dedicated section with list of Cluster peers
- API now allows to query peers
- Now it's possible to store and load some properties (Map<String,String> info) for peers