### PR TITLE
77 UI: Fix Request matcher description

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/requestmatcher/AndRequestMatcher.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/requestmatcher/AndRequestMatcher.java
@@ -25,11 +25,11 @@ import java.util.stream.Collectors;
 /**
  *
  * Matcher for composing AND expressions with other matchers.
- * 
+ *
  * @author paolo.venturi
  */
 public class AndRequestMatcher implements RequestMatcher {
-   
+
     private final List<RequestMatcher> matchers;
 
     public AndRequestMatcher(List<RequestMatcher> matchers) {
@@ -38,7 +38,7 @@ public class AndRequestMatcher implements RequestMatcher {
 
     @Override
     public boolean matches(MatchingContext context) {
-        for (RequestMatcher matcher: matchers) {            
+        for (RequestMatcher matcher : matchers) {
             if (!matcher.matches(context)) {
                 return false;
             }
@@ -48,10 +48,9 @@ public class AndRequestMatcher implements RequestMatcher {
 
     @Override
     public String getDescription() {
-        return "(" + matchers.stream()
-                    .map(RequestMatcher::getDescription)
-                    .collect(Collectors.joining(" and "))
-                + ")";
+        return matchers.stream()
+                .map(RequestMatcher::getDescription)
+                .collect(Collectors.joining(" and "));
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/requestmatcher/EqualsRequestMatcher.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/requestmatcher/EqualsRequestMatcher.java
@@ -40,7 +40,7 @@ public class EqualsRequestMatcher implements RequestMatcher {
     }
 
     public String getDescription() {
-        return "(" + name + " = " + value + ")";
+        return name + " = " + value;
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/requestmatcher/MatchAllRequestMatcher.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/requestmatcher/MatchAllRequestMatcher.java
@@ -33,7 +33,7 @@ public class MatchAllRequestMatcher implements RequestMatcher {
 
     @Override
     public String getDescription() {
-        return "Matching to all requests";
+        return "all requests";
     }
 
     @Override

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/requestmatcher/OrRequestMatcher.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/requestmatcher/OrRequestMatcher.java
@@ -31,9 +31,11 @@ import java.util.stream.Collectors;
 public class OrRequestMatcher implements RequestMatcher {
 
     private final List<RequestMatcher> matchers;
+    private final boolean wrap;
 
-    public OrRequestMatcher(List<RequestMatcher> matchers) {
+    public OrRequestMatcher(List<RequestMatcher> matchers, boolean wrap) {
         this.matchers = matchers;
+        this.wrap = wrap;
     }
 
     @Override
@@ -48,10 +50,13 @@ public class OrRequestMatcher implements RequestMatcher {
 
     @Override
     public String getDescription() {
-        return "(" + matchers.stream()
+        String desc = wrap ? "(" : "";
+        desc += matchers.stream()
                     .map(RequestMatcher::getDescription)
-                    .collect(Collectors.joining(" or "))
-                + ")";
+                    .collect(Collectors.joining(" or "));
+        desc += wrap ? ")" : "";
+        
+        return desc;
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/requestmatcher/RegexpRequestMatcher.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/requestmatcher/RegexpRequestMatcher.java
@@ -49,7 +49,7 @@ public class RegexpRequestMatcher implements RequestMatcher {
 
     @Override
     public String getDescription() {
-        return "Matchig by RegEx: " + this.expression.toString();
+        return name + " ~ \"" + this.expression.toString() + "\"";
     }
 
     @Override

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/requestmatcher/SecureRequestMatcher.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/requestmatcher/SecureRequestMatcher.java
@@ -34,7 +34,7 @@ public class SecureRequestMatcher implements RequestMatcher {
 
     @Override
     public String getDescription() {
-        return "Secure request";
+        return "secure request";
     }
 
 }

--- a/carapace-server/src/main/javacc/RequestMatchParser.jj
+++ b/carapace-server/src/main/javacc/RequestMatchParser.jj
@@ -77,10 +77,10 @@ RequestMatcher parse() throws ConfigurationNotValidException:
 }
 {
     <ALL> <EOF> { return new MatchAllRequestMatcher(); } |                
-    { return orExpression(); }
+    { return orExpression(false); }
 }
 
-RequestMatcher orExpression() throws ConfigurationNotValidException:
+RequestMatcher orExpression(boolean wrap) throws ConfigurationNotValidException:
 {    
     List<RequestMatcher> matchers = new ArrayList();
 }
@@ -89,7 +89,7 @@ RequestMatcher orExpression() throws ConfigurationNotValidException:
     (
             <OR> { matchers.add(andExpression()); }
     )*
-    { return new OrRequestMatcher(matchers); }    
+    { return new OrRequestMatcher(matchers, wrap); }
 }
 
 RequestMatcher andExpression() throws ConfigurationNotValidException:
@@ -112,7 +112,7 @@ RequestMatcher basicExpression() throws ConfigurationNotValidException:
     (
         <NOT> basicMatcher = basicExpression() { return new NotRequestMatcher(basicMatcher); } |
     
-        <O_BRACKET> basicMatcher = orExpression() <C_BRACKET> |
+        <O_BRACKET> basicMatcher = orExpression(true) <C_BRACKET> |
     
         basicMatcher = basicMatcher()
     )

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/requestmatcher/RequestMatcherTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/requestmatcher/RequestMatcherTest.java
@@ -30,6 +30,7 @@ import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.mapper.requestmatcher.parser.ParseException;
 import org.carapaceproxy.server.mapper.requestmatcher.parser.RequestMatchParser;
 import org.carapaceproxy.server.mapper.requestmatcher.parser.TokenMgrError;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
@@ -55,87 +56,119 @@ public class RequestMatcherTest {
         {
             RequestMatcher matcher = new RequestMatchParser("all").parse();
             assertTrue(matcher.matches(handler));
+            assertEquals("all requests", matcher.getDescription());
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~ \".*test.*\"").parse();
             assertTrue(matcher.matches(handler));
+            assertEquals("request.uri ~ \".*test.*\"", matcher.getDescription());
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~ \".*testio.*\"").parse();
             assertFalse(matcher.matches(handler));
+            assertEquals("request.uri ~ \".*testio.*\"", matcher.getDescription());
         }
         {
             RequestMatcher matcher = new RequestMatchParser("secure").parse();
             assertTrue(matcher.matches(handler));
+            assertEquals("secure request", matcher.getDescription());
         }
         {
             RequestMatcher matcher = new RequestMatchParser("not secure").parse();
             assertFalse(matcher.matches(handler));
+            assertEquals("not secure request", matcher.getDescription());
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~ \".*test\\.html\" and secure").parse();
             assertTrue(matcher.matches(handler));
+            assertEquals("request.uri ~ \".*test\\.html\" and secure request", matcher.getDescription());
         }
         {
             // spaces ignored
             RequestMatcher matcher = new RequestMatchParser("request.uri   ~   \".*test.*\" and not secure").parse();
             assertFalse(matcher.matches(handler));
+            assertEquals("request.uri ~ \".*test.*\" and not secure request", matcher.getDescription());
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" or not secure").parse();
             assertTrue(matcher.matches(handler));
+            assertEquals("request.uri ~ \".*test.*\" or not secure request", matcher.getDescription());
         }
         {
             RequestMatcher matcher = new RequestMatchParser("not secure or request.uri ~\".*test.*\"").parse();
             assertTrue(matcher.matches(handler));
+            assertEquals("not secure request or request.uri ~ \".*test.*\"", matcher.getDescription());
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" and (not secure or secure)").parse();
             assertTrue(matcher.matches(handler));
+            assertEquals("request.uri ~ \".*test.*\" and (not secure request or secure request)", matcher.getDescription());
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" and (not secure or not secure)").parse();
             assertFalse(matcher.matches(handler));
+            assertEquals("request.uri ~ \".*test.*\" and (not secure request or not secure request)", matcher.getDescription());
         }
         {
             RequestMatcher matcher = new RequestMatchParser("not (not secure or not secure) and request.uri ~\".*test.*\"").parse();
             assertTrue(matcher.matches(handler));
+            assertEquals("not (not secure request or not secure request) and request.uri ~ \".*test.*\"", matcher.getDescription());
         }
         {
-            RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" and (not (not secure or not secure) or (not secure or not secure))").parse();
+            RequestMatcher matcher = new RequestMatchParser(
+                    "request.uri ~\".*test.*\" and (not (not secure or not secure) or (not secure or not secure))"
+            ).parse();
             assertTrue(matcher.matches(handler));
+            assertEquals(
+                    "request.uri ~ \".*test.*\" and (not (not secure request or not secure request) or "
+                    + "(not secure request or not secure request))", matcher.getDescription()
+            );
         }
         {
-            RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" and (not (not secure or not secure) and (not secure or not secure)) and request.uri ~\".*test.html\"").parse();
+            RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" and (not (not secure or not secure) "
+                    + "and (not secure or not secure)) and request.uri ~\".*test.html\"").parse();
             assertFalse(matcher.matches(handler));
+            assertEquals("request.uri ~ \".*test.*\" and (not (not secure request or not secure request) "
+                    + "and (not secure request or not secure request)) and request.uri ~ \".*test.html\"", matcher.getDescription()
+            );
         }
         {
-            RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" and (not (not secure or not secure) and (not secure or not secure)) or not request.uri ~\".*\\.css\"").parse();
+            RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" and (not (not secure or not secure) "
+                    + "and (not secure or not secure)) or not request.uri ~\".*\\.css\"").parse();
             assertTrue(matcher.matches(handler));
+            assertEquals("request.uri ~ \".*test.*\" and (not (not secure request or not secure request) "
+                    + "and (not secure request or not secure request)) or not request.uri ~ \".*\\.css\"", matcher.getDescription()
+            );
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*\\.css*\" or request.uri ~\".*\\.html\"").parse();
             assertTrue(matcher.matches(handler));
+            assertEquals("request.uri ~ \".*\\.css*\" or request.uri ~ \".*\\.html\"", matcher.getDescription());
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*\\.css*\" and request.uri ~\".*\\.html\"").parse();
             assertFalse(matcher.matches(handler));
+            assertEquals("request.uri ~ \".*\\.css*\" and request.uri ~ \".*\\.html\"", matcher.getDescription());
         }
         {
             RequestMatcher matcher = new RequestMatchParser("not (not request.uri ~\".*\\.html\")").parse();
             assertTrue(matcher.matches(handler));
+            assertEquals("not (not request.uri ~ \".*\\.html\")", matcher.getDescription());
         }
         {
             RequestMatcher matcher = new RequestMatchParser("not request.uri ~\".*\\.css*\" and not (not request.uri ~\".*\\.html\")").parse();
             assertTrue(matcher.matches(handler));
+            assertEquals("not request.uri ~ \".*\\.css*\" and not (not request.uri ~ \".*\\.html\")", matcher.getDescription());
         }
 
         // property name does not exist -> empty
         {
             RequestMatcher matcher = new RequestMatchParser("request.notex ~\".*test.*\"").parse();
             assertFalse(matcher.matches(handler));
+            assertEquals("request.notex ~ \".*test.*\"", matcher.getDescription());
             matcher = new RequestMatchParser("request.notex = \"\"").parse();
             assertTrue(matcher.matches(handler));
+            assertEquals("request.notex = ", matcher.getDescription());
         }
         // Broken one: invalid regexp syntax
         TestUtils.assertThrows(TokenMgrError.class, () -> {
@@ -168,9 +201,21 @@ public class RequestMatcherTest {
         });
 
         // Fist one condition considered
-        assertFalse(new RequestMatchParser("not secure all").parse().matches(handler));
-        assertFalse(new RequestMatchParser("not secure request.uri ~\".*test.*\"").parse().matches(handler));
-        assertTrue(new RequestMatchParser("request.uri ~\".*test.*\" all").parse().matches(handler));
+        {
+            RequestMatcher matcher = new RequestMatchParser("not secure all").parse();
+            assertFalse(matcher.matches(handler));
+            assertEquals("not secure request", matcher.getDescription());
+        }
+        {            
+            RequestMatcher matcher = new RequestMatchParser("not secure request.uri ~\".*test.*\"").parse();
+            assertFalse(matcher.matches(handler));
+            assertEquals("not secure request", matcher.getDescription());
+        }
+        {            
+            RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" all").parse();
+            assertTrue(matcher.matches(handler));
+            assertEquals("request.uri ~ \".*test.*\"", matcher.getDescription());
+        }        
     }
 
     @Test


### PR DESCRIPTION
* Description for RegexpMatcher fixed: from *RegExp REGEXP* to *property ~ "REGEXP"*
* Now brackets are shown only when actualy used
