### PR TITLE
EndpointMapper: Backends availability cheked according to backendid instead of host:port #78

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/api/BackendsResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/BackendsResource.java
@@ -32,7 +32,6 @@ import org.carapaceproxy.server.HttpProxyServer;
 import org.carapaceproxy.server.backends.BackendHealthCheck;
 import org.carapaceproxy.server.backends.BackendHealthManager;
 import org.carapaceproxy.server.backends.BackendHealthStatus;
-import org.carapaceproxy.utils.StringUtils;
 
 /**
  * Access to backends status

--- a/carapace-server/src/main/java/org/carapaceproxy/api/ListenersResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/ListenersResource.java
@@ -109,8 +109,8 @@ public class ListenersResource {
                     listener.getDefaultCertificate(),
                     server.getMainLogger().getCounter("listener_" + listener.getHost() + "_" + port +"_requests").get()
             );
-            EndpointKey ek = EndpointKey.make(listener.getHost(), listener.getPort());
-            res.put(ek.toBackendId(), lisBean);
+            EndpointKey key = EndpointKey.make(listener.getHost(), listener.getPort());
+            res.put(key.getHostPort(), lisBean);
         }
 
         return res;

--- a/carapace-server/src/main/java/org/carapaceproxy/client/EndpointKey.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/EndpointKey.java
@@ -30,6 +30,7 @@ public final class EndpointKey {
 
     private final String host;
     private final int port;
+    private final String hostPort;
 
     public static EndpointKey make(String host, int port) {
         return new EndpointKey(host, port);
@@ -49,6 +50,7 @@ public final class EndpointKey {
     public EndpointKey(String host, int port) {
         this.host = host;
         this.port = port;
+        this.hostPort = host + ":" + port;
     }
 
     public String getHost() {
@@ -88,8 +90,8 @@ public final class EndpointKey {
         return true;
     }
 
-    public String toBackendId() {
-        return host + ":" + port;
+    public String getHostPort() {
+        return hostPort;
     }
 
     @Override

--- a/carapace-server/src/main/java/org/carapaceproxy/client/impl/ConnectionsManagerImpl.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/impl/ConnectionsManagerImpl.java
@@ -155,7 +155,7 @@ public class ConnectionsManagerImpl implements ConnectionsManager, AutoCloseable
                     EndpointConnection connectionToEndpoint = requestHandler.getConnectionToEndpoint();
                     if (connectionToEndpoint != null) {
                         backendHealthManager.reportBackendUnreachable(
-                            connectionToEndpoint.getKey().toBackendId(), now, 
+                            connectionToEndpoint.getKey().getHostPort(), now, 
                             "a request to " + requestHandler.getUri() + " for user " + requestHandler.getUserId() + " appears stuck");
                     }
                     stuckRequestsStat.inc();

--- a/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
@@ -136,7 +136,7 @@ public class EndpointConnectionImpl implements EndpointConnection {
             } else {
                 connectionStats.registerFailedEvent(System.nanoTime() - now, TimeUnit.NANOSECONDS);
                 LOG.log(Level.INFO, "connect failed to " + key, future.cause());
-                parent.backendHealthManager.reportBackendUnreachable(key.toBackendId(), System.currentTimeMillis(), "connection failed");
+                parent.backendHealthManager.reportBackendUnreachable(key.getHostPort(), System.currentTimeMillis(), "connection failed");
             }
         });
         try {
@@ -359,7 +359,7 @@ public class EndpointConnectionImpl implements EndpointConnection {
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             LOG.log(Level.SEVERE, "I/O error on endpoint " + key, cause);
-            parent.backendHealthManager.reportBackendUnreachable(key.toBackendId(), System.currentTimeMillis(), "I/O error: " + cause);
+            parent.backendHealthManager.reportBackendUnreachable(key.getHostPort(), System.currentTimeMillis(), "I/O error: " + cause);
             RequestHandler _clientSidePeerHandler = clientSidePeerHandler;
 
             if (_clientSidePeerHandler != null) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthStatus.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthStatus.java
@@ -31,19 +31,19 @@ public class BackendHealthStatus {
 
     private static final Logger LOG = Logger.getLogger(BackendHealthStatus.class.getName());
 
-    private final String id;
+    private final String hostPort;
 
     private volatile boolean reportedAsUnreachable;
     private long reportedAsUnreachableTs;
 
     private BackendHealthCheck lastProbe;
 
-    public BackendHealthStatus(String id) {
-        this.id = id;
+    public BackendHealthStatus(String hostPort) {
+        this.hostPort = hostPort;
     }
 
-    public String getId() {
-        return id;
+    public String getHostPort() {
+        return hostPort;
     }
 
     public BackendHealthCheck getLastProbe() {
@@ -71,7 +71,7 @@ public class BackendHealthStatus {
     }
 
     void reportAsUnreachable(long timestamp) {
-        LOG.log(Level.INFO, "{0}: reportAsUnreachable {1}", new Object[]{id, new java.sql.Timestamp(timestamp)});
+        LOG.log(Level.INFO, "{0}: reportAsUnreachable {1}", new Object[]{hostPort, new java.sql.Timestamp(timestamp)});
         reportedAsUnreachableTs = timestamp;
         reportedAsUnreachable = true;
     }
@@ -87,7 +87,7 @@ public class BackendHealthStatus {
 
     @Override
     public String toString() {
-        return "BackendHealthStatus{" + "id=" + id + ", reportedAsUnreachable=" + reportedAsUnreachable + ", reportedAsUnreachableTs=" + reportedAsUnreachableTs + '}';
+        return "BackendHealthStatus{" + "hostPort=" + hostPort + ", reportedAsUnreachable=" + reportedAsUnreachable + ", reportedAsUnreachableTs=" + reportedAsUnreachableTs + '}';
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -414,7 +414,7 @@ public class StandardEndpointMapper extends EndpointMapper {
                     }
 
                     BackendConfiguration backend = this.backends.get(backendId);
-                    if (backend != null && backendHealthManager.isAvailable(backendId)) {
+                    if (backend != null && backendHealthManager.isAvailable(backend.getHostPort())) {
                         List<CustomHeader> customHeaders = action.getCustomHeaders();
                         if (this.debuggingHeaderEnabled) {
                             customHeaders = new ArrayList(customHeaders);

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendTest.java
@@ -36,6 +36,7 @@ import org.carapaceproxy.client.impl.ConnectionsManagerImpl;
 import org.carapaceproxy.configstore.PropertiesConfigurationStore;
 import org.carapaceproxy.server.HttpProxyServer;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
+import org.carapaceproxy.server.mapper.StandardEndpointMapper;
 import org.carapaceproxy.utils.RawHttpClient;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -104,7 +105,7 @@ public class UnreachableBackendTest {
             TestUtils.waitForCondition(TestUtils.ALL_CONNECTIONS_CLOSED(stats), 100);
 
         }
-    }
+    }   
 
     @Test
     public void testEmptyResponse() throws Exception {
@@ -179,7 +180,7 @@ public class UnreachableBackendTest {
                         + "    </body>        \n"
                         + "</html>\n", resp.getBodyString());
             }
-            assertFalse(server.getBackendHealthManager().isAvailable(key.toBackendId()));
+            assertFalse(server.getBackendHealthManager().isAvailable(key.getHostPort()));
             TestUtils.waitForCondition(TestUtils.ALL_CONNECTIONS_CLOSED(stats), 100);
 
         }
@@ -220,7 +221,7 @@ public class UnreachableBackendTest {
                         + "    </body>        \n"
                         + "</html>\n", resp.getBodyString());
             }
-            assertFalse(server.getBackendHealthManager().isAvailable(key.toBackendId()));
+            assertFalse(server.getBackendHealthManager().isAvailable(key.getHostPort()));
             TestUtils.waitForCondition(TestUtils.ALL_CONNECTIONS_CLOSED(stats), 100);
 
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/HealthCheckTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/HealthCheckTest.java
@@ -91,7 +91,7 @@ public class HealthCheckTest {
 
             BackendHealthStatus _status = status.get(b1conf.getHostPort());
             assertThat(_status, is(not(nullValue())));
-            assertThat(_status.getId(), is(b1conf.getHostPort()));
+            assertThat(_status.getHostPort(), is(b1conf.getHostPort()));
             assertThat(_status.isAvailable(), is(true));
             assertThat(_status.isReportedAsUnreachable(), is(false));
             assertThat(_status.getReportedAsUnreachableTs(), is(0L));
@@ -129,7 +129,7 @@ public class HealthCheckTest {
 
             BackendHealthStatus _status = status.get(b1conf.getHostPort());
             assertThat(_status, is(not(nullValue())));
-            assertThat(_status.getId(), is(b1conf.getHostPort()));
+            assertThat(_status.getHostPort(), is(b1conf.getHostPort()));
             assertThat(_status.isAvailable(), is(false));
             assertThat(_status.isReportedAsUnreachable(), is(true));
             assertThat(_status.getReportedAsUnreachableTs() >= startTs, is(true));
@@ -170,7 +170,7 @@ public class HealthCheckTest {
 
             BackendHealthStatus _status = status.get(b1conf.getHostPort());
             assertThat(_status, is(not(nullValue())));
-            assertThat(_status.getId(), is(b1conf.getHostPort()));
+            assertThat(_status.getHostPort(), is(b1conf.getHostPort()));
             assertThat(_status.isAvailable(), is(false));
             assertThat(_status.isReportedAsUnreachable(), is(true));
             assertThat(_status.getReportedAsUnreachableTs(), is(reportedAsUnreachableTs));
@@ -209,7 +209,7 @@ public class HealthCheckTest {
 
             BackendHealthStatus _status = status.get(b1conf.getHostPort());
             assertThat(_status, is(not(nullValue())));
-            assertThat(_status.getId(), is(b1conf.getHostPort()));
+            assertThat(_status.getHostPort(), is(b1conf.getHostPort()));
             assertThat(_status.isAvailable(), is(true));
             assertThat(_status.isReportedAsUnreachable(), is(false));
             assertThat(_status.getReportedAsUnreachableTs(), is(0L));


### PR DESCRIPTION
In StandardEndpoinMapper backendHealthManager.isAvailable() is called with backendId instead of hostname:port as expected by BackendHealthManager.