### PR TITLE
Fix/73 refactor prometheus metrics

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -34,11 +34,6 @@
             <version>${commons.lang3}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.bookkeeper.stats</groupId>
-            <artifactId>bookkeeper-stats-api</artifactId>
-            <version>${bookkeeper.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
             <version>${zookkeeper.version}</version>
@@ -73,9 +68,19 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.bookkeeper.stats</groupId>
-            <artifactId>prometheus-metrics-provider</artifactId>
-            <version>${bookkeeper.version}</version>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>${libs.prometheus}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_hotspot</artifactId>
+            <version>${libs.prometheus}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_servlet</artifactId>
+            <version>${libs.prometheus}</version>
         </dependency>
         <dependency>
             <groupId>org.herddb</groupId>

--- a/carapace-server/src/main/java/org/carapaceproxy/api/ListenersResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/ListenersResource.java
@@ -19,13 +19,19 @@
  */
 package org.carapaceproxy.api;
 
+import io.prometheus.client.Collector.MetricFamilySamples;
+import io.prometheus.client.CollectorRegistry;
+import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import javax.servlet.ServletContext;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import org.carapaceproxy.client.EndpointKey;
+import org.carapaceproxy.server.ClientConnectionHandler;
 import org.carapaceproxy.server.HttpProxyServer;
 import org.carapaceproxy.server.RuntimeServerConfiguration;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
@@ -98,8 +104,30 @@ public class ListenersResource {
         RuntimeServerConfiguration conf = server.getCurrentConfiguration();
 
         Map<String, ListenerBean> res = new HashMap<>();
+//        PrometheusUtils.createCounter("requests", "totalrequests",
+//            "total requests", "host").register();
+
+        Map<String, Long> metricValues = new HashMap<>();
+
+        Set<String> names = new HashSet<>();
+        names.add("requests_totalrequests");
+        Enumeration<MetricFamilySamples> metrics = CollectorRegistry.defaultRegistry.filteredMetricFamilySamples(names);
+        if (metrics.hasMoreElements()) {
+            MetricFamilySamples metric = metrics.nextElement();
+            for (MetricFamilySamples.Sample sample : metric.samples) {
+                int i = sample.labelNames.indexOf("host");
+                if (i >= 0) {
+                    metricValues.put(sample.labelValues.get(i), (long) sample.value);
+                }
+            }
+        }
+
         for (NetworkListenerConfiguration listener : conf.getListeners()) {
             int port = listener.getPort() + server.getListenersOffsetPort();
+            ClientConnectionHandler handler = server.getListeners().getListenerHandler(listener.getKey());
+            long totalRequests = handler == null
+                    ? 0
+                    : handler.getTotalRequestsCount();
             ListenerBean lisBean = new ListenerBean(
                     listener.getHost(),
                     port,
@@ -107,7 +135,7 @@ public class ListenersResource {
                     listener.isOcps(),
                     listener.getSslCiphers(),
                     listener.getDefaultCertificate(),
-                    server.getMainLogger().getCounter("listener_" + listener.getHost() + "_" + port +"_requests").get()
+                    totalRequests
             );
             EndpointKey key = EndpointKey.make(listener.getHost(), listener.getPort());
             res.put(key.getHostPort(), lisBean);

--- a/carapace-server/src/main/java/org/carapaceproxy/api/ListenersResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/ListenersResource.java
@@ -52,9 +52,9 @@ public class ListenersResource {
         private final boolean ocps;
         private final String sslCiphers;
         private final String defaultCertificate;
-        private final long totalRequests;
+        private final int totalRequests;
 
-        public ListenerBean(String host, int port, boolean ssl, boolean ocps, String sslCiphers, String defaultCertificate, long totalRequests) {
+        public ListenerBean(String host, int port, boolean ssl, boolean ocps, String sslCiphers, String defaultCertificate, int totalRequests) {
             this.host = host;
             this.port = port;
             this.ssl = ssl;
@@ -88,7 +88,7 @@ public class ListenersResource {
             return defaultCertificate;
         }
 
-        public long getTotalRequests() {
+        public int getTotalRequests() {
             return totalRequests;
         }
 
@@ -104,7 +104,7 @@ public class ListenersResource {
         for (NetworkListenerConfiguration listener : conf.getListeners()) {
             int port = listener.getPort() + server.getListenersOffsetPort();
             ClientConnectionHandler handler = listeners.getListenerHandler(listener.getKey());
-            long totalRequests = handler == null
+            int totalRequests = handler == null
                     ? 0
                     : handler.getTotalRequestsCount();
 

--- a/carapace-server/src/main/java/org/carapaceproxy/client/impl/ConnectionsManagerImpl.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/impl/ConnectionsManagerImpl.java
@@ -82,7 +82,7 @@ public class ConnectionsManagerImpl implements ConnectionsManager, AutoCloseable
     static final Counter stuckRequestsStat = Counter.build()
             .namespace("outbound")
             .name("stuckrequests")
-            .help("stuck requests, this request will be killed")
+            .help("stuck requests, this requests will be killed")
             .register();
 
     void returnConnection(EndpointConnectionImpl con) {

--- a/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
@@ -63,6 +63,7 @@ public class EndpointConnectionImpl implements EndpointConnection {
     private static final AtomicLong IDGENERATOR = new AtomicLong();
 
     private static final String METRIC_LABEL_RESULT = "result";
+    private static final String METRIC_LABEL_HOST = "host";
     private static final String METRIC_LABEL_RESULT_SUCCESS = "success";
     private static final String METRIC_LABEL_RESULT_FAILURE = "failure";
 
@@ -80,31 +81,31 @@ public class EndpointConnectionImpl implements EndpointConnection {
     private volatile boolean valid;
     private volatile RequestHandler clientSidePeerHandler;
 
-    // stats        
+    // stats
     private static final Summary connectionStats = Summary.build()
-                .namespace("connections")
-                .name("connections")
-                .quantile(0.5, 0.05) // Add 50th percentile (= median) with 5% tolerated error
-                .quantile(0.9, 0.01) // Add 90th percentile with 1% tolerated error
-                .quantile(0.99, 0.001) // Add 99th percentile with 0.1% tolerated error
-                .labelNames(METRIC_LABEL_RESULT)
-                .help("connections")
-                .register();
-    private final Gauge openConnectionsStats = Gauge.build()
-                .namespace("connections")
-                .name("open")
-                .help("open connections")
-                .register();
-    private final Gauge activeConnectionsStats = Gauge.build()
-                .namespace("connections")
-                .name("active")
-                .help("active connections")
-                .register();
-    private final Counter requestsStats = Counter.build()
-                .namespace("connections")
-                .name("total")
-                .help("requests")
-                .register();
+        .namespace("connections")
+        .name("backendConnection")
+        .quantile(0.5, 0.05) // Add 50th percentile (= median) with 5% tolerated error
+        .quantile(0.9, 0.01) // Add 90th percentile with 1% tolerated error
+        .quantile(0.99, 0.001) // Add 99th percentile with 0.1% tolerated error
+        .labelNames(METRIC_LABEL_RESULT, METRIC_LABEL_HOST)
+        .help("backend connections")
+        .register();
+    private static final Gauge openConnectionsStats = Gauge.build()
+        .namespace("connections")
+        .name("currentOpenConnections")
+        .help("currently open backend connections")
+        .register();
+    private static final Gauge activeConnectionsStats = Gauge.build()
+        .namespace("connections")
+        .name("currentActiveConnections")
+        .help("currently active backend connections")
+        .register();
+    private static final Counter requestsStats = Counter.build()
+        .namespace("connections")
+        .name("sentRequests")
+        .help("sent requests")
+        .register();
 
     private static enum ConnectionState {
         IDLE,
@@ -113,7 +114,8 @@ public class EndpointConnectionImpl implements EndpointConnection {
     }
 
     /**
-     * Creates and return always a "CONNECTED" connection. This constructor will block until the backend is connected
+     * Creates and return always a "CONNECTED" connection. This constructor will
+     * block until the backend is connected
      *
      * @param key
      * @param parent
@@ -121,8 +123,6 @@ public class EndpointConnectionImpl implements EndpointConnection {
      * @throws IOException
      */
     public EndpointConnectionImpl(EndpointKey key, ConnectionsManagerImpl parent, EndpointStats endpointstats) throws IOException {
-        String metricsNamespace = key.getHost() + "_" + key.getPort();
-
         this.key = key;
         this.parent = parent;
         this.valid = true;
@@ -132,28 +132,31 @@ public class EndpointConnectionImpl implements EndpointConnection {
         long startTime = System.nanoTime();
         Bootstrap b = new Bootstrap();
         b.group(parent.getGroup())
-                .channel(Epoll.isAvailable() ? EpollSocketChannel.class : NioSocketChannel.class)
-                .option(ChannelOption.SO_KEEPALIVE, true)
-                .handler(new ChannelInitializer<SocketChannel>() {
-                    @Override
-                    public void initChannel(SocketChannel ch) throws Exception {
-                        ch.pipeline().addLast("readTimeoutHandler", new ReadTimeoutHandler(idleTimeout / 2));
-                        ch.pipeline().addLast("writeTimeoutHandler", new WriteTimeoutHandler(idleTimeout / 2));
-                        ch.pipeline().addLast("client-codec", new HttpClientCodec());
-                        ch.pipeline().addLast(new ReadEndpointResponseHandler());
-                    }
-                });
+            .channel(Epoll.isAvailable() ? EpollSocketChannel.class : NioSocketChannel.class)
+            .option(ChannelOption.SO_KEEPALIVE, true)
+            .handler(new ChannelInitializer<SocketChannel>() {
+                @Override
+                public void initChannel(SocketChannel ch) throws Exception {
+                    ch.pipeline().addLast("readTimeoutHandler", new ReadTimeoutHandler(idleTimeout / 2));
+                    ch.pipeline().addLast("writeTimeoutHandler", new WriteTimeoutHandler(idleTimeout / 2));
+                    ch.pipeline().addLast("client-codec", new HttpClientCodec());
+                    ch.pipeline().addLast(new ReadEndpointResponseHandler());
+                }
+            });
 
         final ChannelFuture connectFuture = b.connect(key.getHost(), key.getPort());
 
+        String labelHost = key.getHost() + "_" + key.getPort();
         connectFuture.addListener((Future<Void> future) -> {
             if (future.isSuccess()) {
                 endpointstats.getTotalConnections().incrementAndGet();
                 endpointstats.getOpenConnections().incrementAndGet();
                 openConnectionsStats.inc();
-                connectionStats.labels(METRIC_LABEL_RESULT_SUCCESS).observe(System.nanoTime() - startTime);
+                connectionStats.labels(METRIC_LABEL_RESULT_SUCCESS, labelHost)
+                    .observe(System.nanoTime() - startTime);
             } else {
-                connectionStats.labels(METRIC_LABEL_RESULT_FAILURE).observe(System.nanoTime() - startTime);
+                connectionStats.labels(METRIC_LABEL_RESULT_FAILURE, labelHost)
+                    .observe(System.nanoTime() - startTime);
                 LOG.log(Level.INFO, "connect failed to " + key, future.cause());
                 parent.backendHealthManager.reportBackendUnreachable(key.getHostPort(), System.currentTimeMillis(), "connection failed");
             }
@@ -179,12 +182,12 @@ public class EndpointConnectionImpl implements EndpointConnection {
 
         channelToEndpoint = connectFuture.channel();
         channelToEndpoint
-                .closeFuture()
-                .addListener((Future<? super Void> future) -> {
-                    LOG.log(Level.FINE, "channel closed to {0}", key);
-                    endpointstats.getOpenConnections().decrementAndGet();
-                    openConnectionsStats.dec();
-                });
+            .closeFuture()
+            .addListener((Future<? super Void> future) -> {
+                LOG.log(Level.FINE, "channel closed to {0}", key);
+                endpointstats.getOpenConnections().decrementAndGet();
+                openConnectionsStats.dec();
+            });
 
     }
 
@@ -219,18 +222,18 @@ public class EndpointConnectionImpl implements EndpointConnection {
         clientSidePeerHandler.messageSentToBackend(EndpointConnectionImpl.this);
         activityDone();
         channelToEndpoint
-                .writeAndFlush(request)
-                .addListener((Future<? super Void> future) -> {
-                    // BEWARE THAT THE RESPONSE MAY ALREADY HAVE BEEN
-                    // RECEIVED
-                    RequestHandler _clientSidePeerHandler = clientSidePeerHandler;
-                    if (!future.isSuccess()) {
-                        LOG.log(Level.INFO, this + " sendRequest " + request.getClass() + " failed", future.cause());
-                        state.compareAndSet(ConnectionState.REQUEST_SENT, ConnectionState.RELEASABLE);
-                        _clientSidePeerHandler.errorSendingRequest(EndpointConnectionImpl.this, future.cause());
-                        invalidate();
-                    }
-                });
+            .writeAndFlush(request)
+            .addListener((Future<? super Void> future) -> {
+                // BEWARE THAT THE RESPONSE MAY ALREADY HAVE BEEN
+                // RECEIVED
+                RequestHandler _clientSidePeerHandler = clientSidePeerHandler;
+                if (!future.isSuccess()) {
+                    LOG.log(Level.INFO, this + " sendRequest " + request.getClass() + " failed", future.cause());
+                    state.compareAndSet(ConnectionState.REQUEST_SENT, ConnectionState.RELEASABLE);
+                    _clientSidePeerHandler.errorSendingRequest(EndpointConnectionImpl.this, future.cause());
+                    invalidate();
+                }
+            });
     }
 
     @Override
@@ -250,17 +253,17 @@ public class EndpointConnectionImpl implements EndpointConnection {
         clientSidePeerHandler.messageSentToBackend(EndpointConnectionImpl.this);
         activityDone();
         channelToEndpoint
-                .writeAndFlush(msg)
-                .addListener((Future<? super Void> future) -> {
-                    if (!future.isSuccess()) {
-                        state.compareAndSet(ConnectionState.REQUEST_SENT, ConnectionState.RELEASABLE);
-                        boolean done = clientSidePeerHandler.errorSendingRequest(EndpointConnectionImpl.this, future.cause());
-                        if (done) {
-                            LOG.log(Level.SEVERE, this + " continueRequest " + msg.getClass() + " failed", future.cause());
-                            invalidate();
-                        }
+            .writeAndFlush(msg)
+            .addListener((Future<? super Void> future) -> {
+                if (!future.isSuccess()) {
+                    state.compareAndSet(ConnectionState.REQUEST_SENT, ConnectionState.RELEASABLE);
+                    boolean done = clientSidePeerHandler.errorSendingRequest(EndpointConnectionImpl.this, future.cause());
+                    if (done) {
+                        LOG.log(Level.SEVERE, this + " continueRequest " + msg.getClass() + " failed", future.cause());
+                        invalidate();
                     }
-                });
+                }
+            });
     }
 
     @Override
@@ -279,21 +282,21 @@ public class EndpointConnectionImpl implements EndpointConnection {
         // may have already been received !
         activityDone();
         channelToEndpoint
-                .writeAndFlush(msg)
-                .addListener((Future<? super Void> future) -> {
-                    if (!future.isSuccess()) {
-                        LOG.log(Level.INFO, "sendLastHttpContent failed " + msg, future.cause());
-                        state.compareAndSet(ConnectionState.REQUEST_SENT, ConnectionState.RELEASABLE);
-                        clientSidePeerHandler.errorSendingRequest(EndpointConnectionImpl.this, future.cause());
-                        invalidate();
-                    } else {
-                        if (!state.compareAndSet(ConnectionState.REQUEST_SENT, ConnectionState.RELEASABLE)) {
-                            // this may be a bug
-                            LOG.log(Level.SEVERE, "sendLastHttpContent finished without " + ConnectionState.REQUEST_SENT + " state");
-                        }
-                        clientSidePeerHandler.lastHttpContentSent();
+            .writeAndFlush(msg)
+            .addListener((Future<? super Void> future) -> {
+                if (!future.isSuccess()) {
+                    LOG.log(Level.INFO, "sendLastHttpContent failed " + msg, future.cause());
+                    state.compareAndSet(ConnectionState.REQUEST_SENT, ConnectionState.RELEASABLE);
+                    clientSidePeerHandler.errorSendingRequest(EndpointConnectionImpl.this, future.cause());
+                    invalidate();
+                } else {
+                    if (!state.compareAndSet(ConnectionState.REQUEST_SENT, ConnectionState.RELEASABLE)) {
+                        // this may be a bug
+                        LOG.log(Level.SEVERE, "sendLastHttpContent finished without " + ConnectionState.REQUEST_SENT + " state");
                     }
-                });
+                    clientSidePeerHandler.lastHttpContentSent();
+                }
+            });
 
     }
 
@@ -326,8 +329,8 @@ public class EndpointConnectionImpl implements EndpointConnection {
 
     boolean isValid() {
         return valid
-                && (System.currentTimeMillis() - endpointstats.getLastActivity().longValue() <= idleTimeout)
-                && channelToEndpoint.isOpen();
+            && (System.currentTimeMillis() - endpointstats.getLastActivity().longValue() <= idleTimeout)
+            && channelToEndpoint.isOpen();
     }
 
     private void connectionDeactivated() {
@@ -354,13 +357,13 @@ public class EndpointConnectionImpl implements EndpointConnection {
             if (msg instanceof HttpContent) {
                 HttpContent f = (HttpContent) msg;
                 _clientSidePeerHandler.receivedFromRemote(f.copy(),
-                        EndpointConnectionImpl.this);
+                    EndpointConnectionImpl.this);
             } else if (msg instanceof DefaultHttpResponse) {
                 DefaultHttpResponse f = (DefaultHttpResponse) msg;
                 // DefaultHttpResponse has no "copy" method
                 _clientSidePeerHandler.receivedFromRemote(
-                        new DefaultHttpResponse(f.protocolVersion(), f.status(), f.headers()),
-                        EndpointConnectionImpl.this);
+                    new DefaultHttpResponse(f.protocolVersion(), f.status(), f.headers()),
+                    EndpointConnectionImpl.this);
             } else {
                 LOG.log(Level.SEVERE, "unknown message type " + msg.getClass() + ": " + msg);
             }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
@@ -182,8 +182,8 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
         return secure;
     }
     
-    public long getTotalRequestsCount() {
-        return (long) this.totalRequests.get();
+    public int getTotalRequestsCount() {
+        return (int) this.totalRequests.get();
     }
 
     public void errorSendingRequest(RequestHandler request, EndpointConnectionImpl endpointConnection, ChannelHandlerContext peerChannel, Throwable error) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
@@ -20,6 +20,7 @@
 package org.carapaceproxy.server;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.prometheus.client.exporter.MetricsServlet;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
@@ -124,8 +125,7 @@ public class HttpProxyServer implements AutoCloseable {
         this.listeners = new Listeners(this);
         this.cache = new ContentsCache(mainLogger, currentConfiguration);
         this.requestsLogger = new RequestsLogger(currentConfiguration);
-        this.connectionsManager = new ConnectionsManagerImpl(currentConfiguration,
-                mainLogger, backendHealthManager);
+        this.connectionsManager = new ConnectionsManagerImpl(currentConfiguration, backendHealthManager);
         this.dynamicCertificateManager = new DynamicCertificatesManager();
         if (mapper != null) {
             mapper.setDynamicCertificateManager(dynamicCertificateManager);
@@ -154,7 +154,7 @@ public class HttpProxyServer implements AutoCloseable {
         jerseyServlet.setInitOrder(0);
         jerseyServlet.setInitParameter(JAXRS_APPLICATION_CLASS, ApplicationConfig.class.getCanonicalName());
         context.addServlet(jerseyServlet, "/api/*");
-        context.addServlet(new ServletHolder(new PrometheusServlet(statsProvider)), "/metrics");
+        context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
         context.setAttribute("server", this);
         contexts.addHandler(context);
 

--- a/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
@@ -121,9 +121,9 @@ public class HttpProxyServer implements AutoCloseable {
 
         this.filters = new ArrayList<>();
         this.currentConfiguration = new RuntimeServerConfiguration();
-        this.backendHealthManager = new BackendHealthManager(currentConfiguration, mapper, mainLogger);
+        this.backendHealthManager = new BackendHealthManager(currentConfiguration, mapper);
         this.listeners = new Listeners(this);
-        this.cache = new ContentsCache(mainLogger, currentConfiguration);
+        this.cache = new ContentsCache(currentConfiguration);
         this.requestsLogger = new RequestsLogger(currentConfiguration);
         this.connectionsManager = new ConnectionsManagerImpl(currentConfiguration, backendHealthManager);
         this.dynamicCertificateManager = new DynamicCertificatesManager();
@@ -196,6 +196,11 @@ public class HttpProxyServer implements AutoCloseable {
 
     public void startMetrics() throws ConfigurationException {
         statsProvider.start(statsProviderConfig);
+        try {
+            io.prometheus.client.hotspot.DefaultExports.initialize();
+        } catch (IllegalArgumentException exc) {
+            //default metrics already initialized...ok
+        }
     }
 
     public String getMetricsUrl() {
@@ -398,10 +403,6 @@ public class HttpProxyServer implements AutoCloseable {
 
     public UserRealm getRealm() {
         return realm;
-    }
-
-    public StatsLogger getMainLogger() {
-        return mainLogger;
     }
 
     public File getBasePath() {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthManager.java
@@ -166,9 +166,9 @@ public class BackendHealthManager implements Runnable {
             status.setLastProbe(checkResult);
 
             if (status.isReportedAsUnreachable()) {
-                BACKEND_UPSTATUS_GAUGE.labels(bconf.getHost() + "_" + bconf.getHostPort()).set(0);
+                BACKEND_UPSTATUS_GAUGE.labels(bconf.getHost() + "_" + bconf.getPort()).set(0);
             } else {
-                BACKEND_UPSTATUS_GAUGE.labels(bconf.getHost() + "_" + bconf.getHostPort()).set(1);
+                BACKEND_UPSTATUS_GAUGE.labels(bconf.getHost() + "_" + bconf.getPort()).set(1);
             }
         }
         List<String> toRemove = new ArrayList<>();

--- a/carapace-server/src/main/java/org/carapaceproxy/server/cache/CacheStats.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/cache/CacheStats.java
@@ -82,8 +82,11 @@ public class CacheStats {
         return (long) MISSES_COUNTER.get();
     }
     
+    /**
+     * Resets to 0 all cache metrics. This should only be used for testing purposes
+     */
     @VisibleForTesting
-    public void resetAllMetrics() {
+    public void resetCacheMetrics() {
         TOTAL_MEMORY_USED_GAUGE.set(0);
         directMemoryUsed.set(0);
         heapMemoryUsed.set(0);

--- a/carapace-server/src/main/java/org/carapaceproxy/server/cache/CacheStats.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/cache/CacheStats.java
@@ -19,6 +19,7 @@
  */
 package org.carapaceproxy.server.cache;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import org.carapaceproxy.utils.PrometheusUtils;
@@ -58,7 +59,7 @@ public class CacheStats {
     public void released(long heap, long direct, long total) {
         directMemoryUsed.dec(direct);
         heapMemoryUsed.dec(heap);
-        PAYLOAD_MEMORY_USED_GAUGE.dec(total);
+        TOTAL_MEMORY_USED_GAUGE.dec(total);
     }
 
     public long getDirectMemoryUsed() {
@@ -70,7 +71,7 @@ public class CacheStats {
     }
 
     public long getTotalMemoryUsed() {
-        return (long) PAYLOAD_MEMORY_USED_GAUGE.get();
+        return (long) TOTAL_MEMORY_USED_GAUGE.get();
     }
 
     public long getHits() {
@@ -79,6 +80,16 @@ public class CacheStats {
 
     public long getMisses() {
         return (long) MISSES_COUNTER.get();
+    }
+    
+    @VisibleForTesting
+    public void resetAllMetrics() {
+        TOTAL_MEMORY_USED_GAUGE.set(0);
+        directMemoryUsed.set(0);
+        heapMemoryUsed.set(0);
+        
+        HITS_COUNTER.clear();
+        MISSES_COUNTER.clear();
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/utils/PrometheusUtils.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/utils/PrometheusUtils.java
@@ -1,0 +1,102 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package org.carapaceproxy.utils;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.SimpleCollector;
+import io.prometheus.client.Summary;
+
+/**
+ *
+ * @author dennis.mercuriali
+ */
+public class PrometheusUtils {
+
+    /**
+     * Creates a new Counter. The created Counter will not be registered to metrics registry
+     *
+     * @param namespace
+     * @param name
+     * @param help
+     * @param labels
+     * @return
+     */
+    public static Counter createCounter(String namespace, String name, String help, String... labels) {
+        Counter.Builder builder = Counter.build()
+                .namespace(namespace)
+                .name(name)
+                .help(help);
+        
+        if (labels != null && labels.length > 0) {
+            builder.labelNames(labels);
+        }
+
+        return builder.create();
+    }
+
+    /**
+     * Creates a new Gauge. The created Gauge will not be registered to metrics registry
+     *
+     * @param namespace
+     * @param name
+     * @param help
+     * @param labels
+     * @return
+     */
+    public static Gauge createGauge(String namespace, String name, String help, String... labels) {
+        Gauge.Builder builder =  Gauge.build()
+                .namespace(namespace)
+                .name(name)
+                .help(help);
+        
+        if (labels != null && labels.length > 0) {
+            builder.labelNames(labels);
+        }
+
+        return builder.create();
+    }
+
+    /**
+     * Creates a new Summary. The created Summary will not be registered to metrics registry<br>
+     * Summary is created with 0.5, 0.9 and 0.99 quantiles
+     *
+     * @param namespace
+     * @param name
+     * @param help
+     * @param labels
+     * @return
+     */
+    public static Summary createSummary(String namespace, String name, String help, String... labels) {
+        Summary.Builder builder = Summary.build()
+                .namespace(namespace)
+                .name(name)
+                .quantile(0.5, 0.05) // Add 50th percentile (= median) with 5% tolerated error
+                .quantile(0.9, 0.01) // Add 90th percentile with 1% tolerated error
+                .quantile(0.99, 0.001) // Add 99th percentile with 0.1% tolerated error
+                .help(help);
+
+        if (labels != null && labels.length > 0) {
+            builder.labelNames(labels);
+        }
+
+        return builder.create();
+    }
+}

--- a/carapace-server/src/test/java/org/carapaceproxy/api/UseAdminServer.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/UseAdminServer.java
@@ -81,7 +81,7 @@ public class UseAdminServer {
 
             server.start();
             server.startAdminInterface();
-            server.getCache().getStats().resetAllMetrics();
+            server.getCache().getStats().resetCacheMetrics();
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/api/UseAdminServer.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/UseAdminServer.java
@@ -81,6 +81,7 @@ public class UseAdminServer {
 
             server.start();
             server.startAdminInterface();
+            server.getCache().getStats().resetAllMetrics();
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendTest.java
@@ -146,7 +146,7 @@ public class UnreachableBackendTest {
             }
             TestUtils.waitForCondition(TestUtils.ALL_CONNECTIONS_CLOSED(stats), 100);
             
-            Double value = ((ConnectionsManagerImpl) server.getConnectionsManager()).getPendingRequestsStat().get();            
+            Double value = ((ConnectionsManagerImpl) server.getConnectionsManager()).getPENDING_REQUESTS_GAUGE().get();            
             assertEquals(0, value.intValue());
 
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendTest.java
@@ -146,7 +146,7 @@ public class UnreachableBackendTest {
             }
             TestUtils.waitForCondition(TestUtils.ALL_CONNECTIONS_CLOSED(stats), 100);
             
-            Long value = ((ConnectionsManagerImpl) server.getConnectionsManager()).getPendingRequestsStat().get();            
+            Double value = ((ConnectionsManagerImpl) server.getConnectionsManager()).getPendingRequestsStat().get();            
             assertEquals(0, value.intValue());
 
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/ManagersExecutionTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/ManagersExecutionTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import org.apache.bookkeeper.stats.StatsLogger;
 import org.carapaceproxy.EndpointMapper;
 import org.carapaceproxy.configstore.ConfigurationStore;
 import org.carapaceproxy.server.backends.BackendHealthManager;
@@ -46,9 +45,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
  *
  * @author paolo
  *
- * Test about reconfiguring the execution period from initial value of '0' to > 0.
- * Because of the zero period the manager never start and when reconfigured with period > 0 it still won't run (#33).
- * 
+ * Test about reconfiguring the execution period from initial value of '0' to > 0. Because of the zero period the
+ * manager never start and when reconfigured with period > 0 it still won't run (#33).
+ *
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({BackendHealthManager.class, DynamicCertificatesManager.class})
@@ -57,7 +56,7 @@ public class ManagersExecutionTest {
     @Test
     public void testBackendHealthManagerExecution() {
         RuntimeServerConfiguration config = new RuntimeServerConfiguration();
-        BackendHealthManager man = new BackendHealthManager(config, mock(EndpointMapper.class), mock(StatsLogger.class));
+        BackendHealthManager man = new BackendHealthManager(config, mock(EndpointMapper.class));
 
         ScheduledExecutorService timer = mock(ScheduledExecutorService.class);
         when(timer.scheduleAtFixedRate(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(mock(ScheduledFuture.class));

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheExpireTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheExpireTest.java
@@ -45,7 +45,7 @@ import org.junit.rules.TemporaryFolder;
  * more, depending on various factors.
  * Executing all tests in this class will hide the issue because the first test to be executed (and probably warm up
  * wiremock) is testHandleExpiresFromServer, that is not affected by a delay of 1000ms.
- * 
+ *
  * In order to fix the issue test should be refactored to start wiremock (and by the way HttpProxyServer) in a @Before rule
  */
 public class CacheExpireTest {
@@ -55,7 +55,7 @@ public class CacheExpireTest {
 
     @Rule
     public TemporaryFolder tmpDir = new TemporaryFolder();
-    
+
     @Test
     public void testHandleExpiresFromServer() throws Exception {
 
@@ -63,12 +63,12 @@ public class CacheExpireTest {
         String formatted = HttpUtils.formatDateHeader(expire);
 
         stubFor(get(urlEqualTo("/index-with-expire.html"))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withHeader("Content-Type", "text/html")
-                        .withHeader("Content-Length", "it <b>works</b> !!".length() + "")
-                        .withHeader("Expires", formatted)
-                        .withBody("it <b>works</b> !!"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/html")
+                .withHeader("Content-Length", "it <b>works</b> !!".length() + "")
+                .withHeader("Expires", formatted)
+                .withBody("it <b>works</b> !!"))
         );
 
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.port(), true);
@@ -78,6 +78,7 @@ public class CacheExpireTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
+            server.getCache().getStats().resetAllMetrics();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index-with-expire.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
@@ -115,8 +116,8 @@ public class CacheExpireTest {
         TestUtils.waitForCondition(() -> {
             EndpointStats epstats = stats.getEndpointStats(key);
             return epstats.getTotalConnections().intValue() == 1
-                    && epstats.getActiveConnections().intValue() == 0
-                    && epstats.getOpenConnections().intValue() == 0;
+                && epstats.getActiveConnections().intValue() == 0
+                && epstats.getOpenConnections().intValue() == 0;
         }, 100);
 
         TestUtils.waitForCondition(TestUtils.ALL_CONNECTIONS_CLOSED(stats), 100);
@@ -126,11 +127,11 @@ public class CacheExpireTest {
     public void testHandleExpiresMissingFromServer() throws Exception {
 
         stubFor(get(urlEqualTo("/index-no-expire.html"))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withHeader("Content-Type", "text/html")
-                        .withHeader("Content-Length", "it <b>works</b> !!".length() + "")
-                        .withBody("it <b>works</b> !!"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/html")
+                .withHeader("Content-Length", "it <b>works</b> !!".length() + "")
+                .withBody("it <b>works</b> !!"))
         );
 
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.port(), true);
@@ -140,6 +141,7 @@ public class CacheExpireTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
+            server.getCache().getStats().resetAllMetrics();
 
             String expires;
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
@@ -176,8 +178,8 @@ public class CacheExpireTest {
         TestUtils.waitForCondition(() -> {
             EndpointStats epstats = stats.getEndpointStats(key);
             return epstats.getTotalConnections().intValue() == 1
-                    && epstats.getActiveConnections().intValue() == 0
-                    && epstats.getOpenConnections().intValue() == 0;
+                && epstats.getActiveConnections().intValue() == 0
+                && epstats.getOpenConnections().intValue() == 0;
         }, 100);
 
         TestUtils.waitForCondition(TestUtils.ALL_CONNECTIONS_CLOSED(stats), 100);
@@ -206,6 +208,7 @@ public class CacheExpireTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
+            server.getCache().getStats().resetAllMetrics();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index-with-expire.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
@@ -241,8 +244,8 @@ public class CacheExpireTest {
         TestUtils.waitForCondition(() -> {
             EndpointStats epstats = stats.getEndpointStats(key);
             return epstats.getTotalConnections().intValue() == 1
-                    && epstats.getActiveConnections().intValue() == 0
-                    && epstats.getOpenConnections().intValue() == 0;
+                && epstats.getActiveConnections().intValue() == 0
+                && epstats.getOpenConnections().intValue() == 0;
         }, 100);
 
         TestUtils.waitForCondition(TestUtils.ALL_CONNECTIONS_CLOSED(stats), 100);
@@ -258,6 +261,7 @@ public class CacheExpireTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
+            server.getCache().getStats().resetAllMetrics();
 
             long startts = System.currentTimeMillis();
             java.util.Date expire = new java.util.Date(startts + 1500);
@@ -271,7 +275,7 @@ public class CacheExpireTest {
                     .withHeader("Expires", formatted)
                     .withBody("it <b>works</b> !!"))
             );
-            
+
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index-with-expire.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 String s = resp.toString();
@@ -314,8 +318,8 @@ public class CacheExpireTest {
         TestUtils.waitForCondition(() -> {
             EndpointStats epstats = stats.getEndpointStats(key);
             return epstats.getTotalConnections().intValue() == 1
-                    && epstats.getActiveConnections().intValue() == 0
-                    && epstats.getOpenConnections().intValue() == 0;
+                && epstats.getActiveConnections().intValue() == 0
+                && epstats.getOpenConnections().intValue() == 0;
         }, 100);
 
         TestUtils.waitForCondition(TestUtils.ALL_CONNECTIONS_CLOSED(stats), 200);
@@ -331,6 +335,7 @@ public class CacheExpireTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
+            server.getCache().getStats().resetAllMetrics();
             server.getCache().getInnerCache().setVerbose(true);
 
             long startts = System.currentTimeMillis();
@@ -345,7 +350,7 @@ public class CacheExpireTest {
                     .withHeader("Expires", formatted)
                     .withBody("it <b>works</b> !!"))
             );
-            
+
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index-with-expire.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 String s = resp.toString();
@@ -363,7 +368,7 @@ public class CacheExpireTest {
             assertEquals(1, server.getCache().getCacheSize());
             assertEquals(0, server.getCache().getStats().getHits());
             assertEquals(1, server.getCache().getStats().getMisses());
-            
+
             TestUtils.waitForCondition(() -> {
                 server.getCache().getInnerCache().evict();
                 return server.getCache().getCacheSize() == 0;
@@ -374,8 +379,8 @@ public class CacheExpireTest {
         TestUtils.waitForCondition(() -> {
             EndpointStats epstats = stats.getEndpointStats(key);
             return epstats.getTotalConnections().intValue() == 1
-                    && epstats.getActiveConnections().intValue() == 0
-                    && epstats.getOpenConnections().intValue() == 0;
+                && epstats.getActiveConnections().intValue() == 0
+                && epstats.getOpenConnections().intValue() == 0;
         }, 100);
 
         TestUtils.waitForCondition(TestUtils.ALL_CONNECTIONS_CLOSED(stats), 100);

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheExpireTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheExpireTest.java
@@ -78,7 +78,7 @@ public class CacheExpireTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
-            server.getCache().getStats().resetAllMetrics();
+            server.getCache().getStats().resetCacheMetrics();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index-with-expire.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
@@ -141,7 +141,7 @@ public class CacheExpireTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
-            server.getCache().getStats().resetAllMetrics();
+            server.getCache().getStats().resetCacheMetrics();
 
             String expires;
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
@@ -208,7 +208,7 @@ public class CacheExpireTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
-            server.getCache().getStats().resetAllMetrics();
+            server.getCache().getStats().resetCacheMetrics();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index-with-expire.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
@@ -261,7 +261,7 @@ public class CacheExpireTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
-            server.getCache().getStats().resetAllMetrics();
+            server.getCache().getStats().resetCacheMetrics();
 
             long startts = System.currentTimeMillis();
             java.util.Date expire = new java.util.Date(startts + 1500);
@@ -335,7 +335,7 @@ public class CacheExpireTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
-            server.getCache().getStats().resetAllMetrics();
+            server.getCache().getStats().resetCacheMetrics();
             server.getCache().getInnerCache().setVerbose(true);
 
             long startts = System.currentTimeMillis();

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheTest.java
@@ -71,7 +71,7 @@ public class CacheTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
-            server.getCache().getStats().resetAllMetrics();
+            server.getCache().getStats().resetCacheMetrics();
 
             long startTs = System.currentTimeMillis();
 
@@ -153,7 +153,7 @@ public class CacheTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
-            server.getCache().getStats().resetAllMetrics();
+            server.getCache().getStats().resetCacheMetrics();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
@@ -253,7 +253,7 @@ public class CacheTest {
                     null, null));
             server.start();
             int port = server.getLocalPort();
-            server.getCache().getStats().resetAllMetrics();
+            server.getCache().getStats().resetCacheMetrics();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port, true)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
@@ -318,7 +318,7 @@ public class CacheTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
-            server.getCache().getStats().resetAllMetrics();
+            server.getCache().getStats().resetCacheMetrics();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
@@ -389,7 +389,7 @@ public class CacheTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
-            server.getCache().getStats().resetAllMetrics();
+            server.getCache().getStats().resetCacheMetrics();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
@@ -460,7 +460,7 @@ public class CacheTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
-            server.getCache().getStats().resetAllMetrics();
+            server.getCache().getStats().resetCacheMetrics();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.get("/index.html?_nocache").toString();
@@ -508,7 +508,7 @@ public class CacheTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
-            server.getCache().getStats().resetAllMetrics();
+            server.getCache().getStats().resetCacheMetrics();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.get("/index.png?_nocache").toString();

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheTest.java
@@ -71,6 +71,7 @@ public class CacheTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
+            server.getCache().getStats().resetAllMetrics();
 
             long startTs = System.currentTimeMillis();
 
@@ -152,6 +153,7 @@ public class CacheTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
+            server.getCache().getStats().resetAllMetrics();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
@@ -251,6 +253,7 @@ public class CacheTest {
                     null, null));
             server.start();
             int port = server.getLocalPort();
+            server.getCache().getStats().resetAllMetrics();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port, true)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
@@ -315,6 +318,7 @@ public class CacheTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
+            server.getCache().getStats().resetAllMetrics();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
@@ -385,6 +389,7 @@ public class CacheTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
+            server.getCache().getStats().resetAllMetrics();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
@@ -455,6 +460,7 @@ public class CacheTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
+            server.getCache().getStats().resetAllMetrics();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.get("/index.html?_nocache").toString();
@@ -502,6 +508,7 @@ public class CacheTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
+            server.getCache().getStats().resetAllMetrics();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.get("/index.png?_nocache").toString();

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CaffeineCacheImplTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CaffeineCacheImplTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider;
 import org.carapaceproxy.server.cache.ContentsCache.ContentKey;
 import org.carapaceproxy.server.cache.ContentsCache.ContentPayload;
 import org.carapaceproxy.utils.TestUtils;
@@ -55,23 +54,23 @@ public class CaffeineCacheImplTest {
     private final Logger logger = new Logger("Cache", null) {
         @Override
         public void log(Level level, String msg, Object[] params) {
-            System.out.println((new MessageFormat(getName()+": "+level+" "+msg)).format(params));
+            System.out.println((new MessageFormat(getName() + ": " + level + " " + msg)).format(params));
         }
 
         @Override
         public void log(Level level, String msg, Object param1) {
-            Object[] params = { param1 };
-            System.out.println((new MessageFormat(getName()+": "+level+" "+msg)).format(params));
+            Object[] params = {param1};
+            System.out.println((new MessageFormat(getName() + ": " + level + " " + msg)).format(params));
         }
 
         @Override
         public void log(Level level, String msg) {
-            System.out.println(String.format(getName()+": "+level+" "+msg));
+            System.out.println(String.format(getName() + ": " + level + " " + msg));
         }
     };
 
     public void initializeCache(int maxSize) throws Exception {
-        stats = new CacheStats((new PrometheusMetricsProvider()).getStatsLogger("").scope("cache"));
+        stats = new CacheStats();
 
         cache = new CaffeineCacheImpl(stats, maxSize, logger);
         cache.setVerbose(true);
@@ -99,6 +98,7 @@ public class CaffeineCacheImplTest {
     }
 
     private static final class CacheEntry {
+
         final ContentKey key;
         final ContentPayload payload;
         RemovalCause removalCause;
@@ -168,7 +168,7 @@ public class CaffeineCacheImplTest {
         if (expireTs > 0) {
             payload.expiresTs = expireTs;
         } else {
-            payload.expiresTs = System.currentTimeMillis() + 60*60*1000;
+            payload.expiresTs = System.currentTimeMillis() + 60 * 60 * 1000;
         }
         return new CacheEntry(key, payload, false);
     }
@@ -304,12 +304,12 @@ public class CaffeineCacheImplTest {
         long totSize = 0;
         boolean ok = false;
         while (!ok) {
-            CacheEntry e = genCacheEntry("res_"+(c++), 100, 0);
-            System.out.println("Adding element "+e.key.uri+" of size="+e.getMemUsage());
+            CacheEntry e = genCacheEntry("res_" + (c++), 100, 0);
+            System.out.println("Adding element " + e.key.uri + " of size=" + e.getMemUsage());
             entries.add(e);
             cache.put(e.key, e.payload);
             assertThat(cache.get(e.key), is(e.payload));
-            System.out.println(" > cache.memSize="+cache.getMemSize());
+            System.out.println(" > cache.memSize=" + cache.getMemSize());
             totSize += e.getMemUsage();
             // In the last insertion cache.getMemSize() will exceed the maximum
             if (totSize <= maxSize) {
@@ -336,7 +336,6 @@ public class CaffeineCacheImplTest {
 //            }
 //        }
 //        entries.remove(0);
-
         CacheEntry evictedEntry = evictedResources.get(0);
         assertTrue(entries.remove(evictedEntry));
 
@@ -355,8 +354,8 @@ public class CaffeineCacheImplTest {
         List<CacheEntry> entries = new ArrayList<>();
         long expireTs = System.currentTimeMillis() + 1000;
         for (int i = 0; i < 10; i++) {
-            CacheEntry e = genCacheEntry("res_"+(i), 100, expireTs);
-            System.out.println("Adding element "+e.key.uri+" with expireTs="+new java.sql.Timestamp(expireTs));
+            CacheEntry e = genCacheEntry("res_" + (i), 100, expireTs);
+            System.out.println("Adding element " + e.key.uri + " with expireTs=" + new java.sql.Timestamp(expireTs));
             entries.add(e);
             cache.put(e.key, e.payload);
             assertThat(cache.get(e.key), is(e.payload));
@@ -386,7 +385,7 @@ public class CaffeineCacheImplTest {
         evictedResources.clear();
         entries.remove(0);
 
-        assertThat((int) cache.getSize(), is(10-1));
+        assertThat((int) cache.getSize(), is(10 - 1));
 
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CaffeineCacheImplTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CaffeineCacheImplTest.java
@@ -72,7 +72,7 @@ public class CaffeineCacheImplTest {
 
     @After
     public void afterEach() {
-        stats.resetAllMetrics();
+        stats.resetCacheMetrics();
     }
 
     public void initializeCache(int maxSize) throws Exception {

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CaffeineCacheImplTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CaffeineCacheImplTest.java
@@ -36,6 +36,7 @@ import org.carapaceproxy.utils.TestUtils;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import org.junit.After;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
@@ -69,6 +70,11 @@ public class CaffeineCacheImplTest {
         }
     };
 
+    @After
+    public void afterEach() {
+        stats.resetAllMetrics();
+    }
+
     public void initializeCache(int maxSize) throws Exception {
         stats = new CacheStats();
 
@@ -90,7 +96,6 @@ public class CaffeineCacheImplTest {
             Field modifiersField = Field.class.getDeclaredField("modifiers");
             modifiersField.setAccessible(true);
             modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-
             field.set(o, newValue);
         } catch (Exception ex) {
             throw new RuntimeException(ex);

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/HealthCheckTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/HealthCheckTest.java
@@ -26,8 +26,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.bookkeeper.stats.NullStatsLogger;
-import org.apache.bookkeeper.stats.StatsLogger;
 import org.carapaceproxy.EndpointMapper;
 import org.carapaceproxy.server.RuntimeServerConfiguration;
 import org.carapaceproxy.server.backends.BackendHealthCheck;
@@ -65,8 +63,7 @@ public class HealthCheckTest {
         EndpointMapper mapper = new TestEndpointMapper(null, 0, false, backends);
         RuntimeServerConfiguration conf = new RuntimeServerConfiguration();
 
-        StatsLogger statsLogger = new NullStatsLogger();
-        BackendHealthManager hman = new BackendHealthManager(conf, mapper, statsLogger);
+        BackendHealthManager hman = new BackendHealthManager(conf, mapper);
 
         {
             stubFor(get(urlEqualTo("/status.html"))
@@ -134,7 +131,7 @@ public class HealthCheckTest {
             assertThat(_status.isReportedAsUnreachable(), is(true));
             assertThat(_status.getReportedAsUnreachableTs() >= startTs, is(true));
             assertThat(_status.getReportedAsUnreachableTs() <= endTs, is(true));
-            reportedAsUnreachableTs =_status.getReportedAsUnreachableTs();
+            reportedAsUnreachableTs = _status.getReportedAsUnreachableTs();
 
             BackendHealthCheck lastProbe = _status.getLastProbe();
             assertThat(lastProbe.getPath(), is("/status.html"));

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/requestmatcher/RequestMatcherTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/requestmatcher/RequestMatcherTest.java
@@ -51,7 +51,7 @@ public class RequestMatcherTest {
 
         DefaultHttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_0, HttpMethod.GET, "/test.html");
 
-        RequestHandler handler = new RequestHandler(0, request, null, null, cch, null, null, null, null);
+        RequestHandler handler = new RequestHandler(0, request, null, cch, null, null, null, null);
 
         {
             RequestMatcher matcher = new RequestMatchParser("all").parse();
@@ -230,7 +230,7 @@ public class RequestMatcherTest {
         when(cch.getListenerHost()).thenReturn("localhost");
         when(cch.getListenerPort()).thenReturn(8080);
 
-        RequestHandler handler = new RequestHandler(0, request, null, null, cch, null, null, null, null);
+        RequestHandler handler = new RequestHandler(0, request, null, cch, null, null, null, null);
 
         // Test headers
         {

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,6 @@
     <properties>
         <curator.version>4.2.0</curator.version>
         <zookkeeper.version>3.5.4-beta</zookkeeper.version>
-        <bookkeeper.version>4.8.1</bookkeeper.version>
         <commons.lang3>3.8.1</commons.lang3>
         <netty.version>4.1.32.Final</netty.version>
         <netty.ssl.version>2.0.20.Final</netty.ssl.version>
@@ -65,6 +64,7 @@
         <libs.slf4j>1.7.25</libs.slf4j>
         <libs.stringtemplate>4.0.8</libs.stringtemplate>
         <libs.herddb>0.10.0-SNAPSHOT</libs.herddb>
+        <libs.prometheus>0.6.0</libs.prometheus>
         <javacc-maven-plugin.version>2.4</javacc-maven-plugin.version>
     </properties>
      <repositories>


### PR DESCRIPTION
Replaced bookkeeper metric provider with Prometheus java client. Bookkeeper StatsLogger is still used for HerdDB metrics.

Refactored metrics:
backends_pending_requests   GAUGE
backends_stuck_requests_total   COUNTER
backends_connection_time_ns   SUMMARY [host (host_port), result(success/failure)], quantiles 0.5 0.9 0.99
backends_open_connections   GAUGE [host (host_port)]
backends_active_connections   GAUGE [host (host_port)]
backends_sent_requests_total   COUNTER [host (host_port)]

listeners_requests_total   COUNTER [listener (host_port)]
listeners_running_requests   GAUGE
listeners_user_requests_total   COUNTER [userId]

clients_current_connected   GAUGE

health_backend_status   GAUGE [host (host_port)] - 0/1

cache_hits_total   COUNTER
cache_misses_total   COUNTER
cache_payload_memory_usage_bytes   GAUGE [area (direct/heap)]
cache_total_memory_usage_bytes   GAUGE
cache_non_cachable_requests_total   COUNTER

