### PR TITLE
UI: General Fixies #94

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/EndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/EndpointMapper.java
@@ -32,6 +32,7 @@ import org.carapaceproxy.server.config.BackendConfiguration;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.config.DirectorConfiguration;
 import org.carapaceproxy.server.config.RouteConfiguration;
+import org.carapaceproxy.server.mapper.CustomHeader;
 
 /**
  * Maps requests to a remote HTTP server
@@ -47,6 +48,8 @@ public abstract class EndpointMapper {
     public abstract List<ActionConfiguration> getActions();
 
     public abstract List<DirectorConfiguration> getDirectors();
+
+    public abstract List<CustomHeader> getHeaders();
 
     public abstract MapResult map(HttpRequest request, String userId, String sessionId, BackendHealthManager backendHealthManager, RequestHandler requestHandler);
 

--- a/carapace-server/src/main/java/org/carapaceproxy/api/ActionsResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/ActionsResource.java
@@ -123,7 +123,7 @@ public class ActionsResource {
         }
     }
 
-    private String emptyAsOther(String value, String other) {
+    static private String emptyAsOther(String value, String other) {
         return value.isEmpty() ? other : value;
     }
 

--- a/carapace-server/src/main/java/org/carapaceproxy/api/ApplicationConfig.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/ApplicationConfig.java
@@ -47,6 +47,7 @@ public class ApplicationConfig extends Application {
         resources.add(UserRealmResource.class);
         resources.add(MetricsResource.class);
         resources.add(ClusterResource.class);
+        resources.add(HeadersResource.class);
         return resources;
     }
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/api/BackendsResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/BackendsResource.java
@@ -19,8 +19,11 @@
  */
 package org.carapaceproxy.api;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
 import javax.servlet.ServletContext;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -32,6 +35,7 @@ import org.carapaceproxy.server.HttpProxyServer;
 import org.carapaceproxy.server.backends.BackendHealthCheck;
 import org.carapaceproxy.server.backends.BackendHealthManager;
 import org.carapaceproxy.server.backends.BackendHealthStatus;
+import org.carapaceproxy.server.config.BackendConfiguration;
 
 /**
  * Access to backends status
@@ -47,8 +51,9 @@ public class BackendsResource {
 
     public static final class BackendBean {
 
-        private String host;
-        private int port;
+        private final String id;
+        private final String host;
+        private final int port;
         private long openConnections;
         private long totalRequests;
         private long lastActivityTs;
@@ -62,9 +67,14 @@ public class BackendsResource {
         private String httpResponse;
         private String httpBody;
 
-        public BackendBean(String host, int port) {
+        public BackendBean(String id, String host, int port) {
+            this.id = id;
             this.host = host;
             this.port = port;
+        }
+
+        public String getId() {
+            return id;
         }
 
         public long getOpenConnections() {
@@ -130,10 +140,16 @@ public class BackendsResource {
         Map<String, BackendHealthStatus> backendsSnapshot = backendHealthManager.getBackendsSnapshot();
 
         Map<String, BackendBean> res = new HashMap<>();
+        Collection<BackendConfiguration> backendsConf = server.getMapper().getBackends().values();
         for (Map.Entry<String, BackendHealthStatus> bb : backendsSnapshot.entrySet()) {
             EndpointKey key = EndpointKey.make(bb.getKey());
             EndpointStats epstats = stats.getEndpointStats(key);
-            BackendBean bean = new BackendBean(key.getHost(), key.getPort());
+            String id = backendsConf.stream()
+                    .filter(b -> key.getHostPort().equals(b.getId()))
+                    .findFirst()
+                    .map(b -> b.getId())
+                    .orElse("");
+            BackendBean bean = new BackendBean(id, key.getHost(), key.getPort());
             if (epstats != null) {
                 bean.openConnections = epstats.getOpenConnections().longValue();
                 bean.totalRequests = epstats.getTotalRequests().longValue();

--- a/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
@@ -105,7 +105,7 @@ public class CertificatesResource {
 
             if (certificate.isDynamic()) {
                 DynamicCertificateState state = dynamicCertificateManager.getStateOfCertificate(certBean.getId());
-                certBean.setStatus(stateToStatusString(state));
+                certBean.setStatus(state.toString());
             }
             res.put(certificateEntry.getKey(), certBean);
         }
@@ -126,7 +126,7 @@ public class CertificatesResource {
         CertificateBean cert = findCertificateById(certId);
         byte[] data = new byte[0];
         if (cert != null && cert.isDynamic()) {
-            HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");            
+            HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
             DynamicCertificatesManager dynamicCertificateManager = server.getDynamicCertificateManager();
             data = dynamicCertificateManager.getCertificateForDomain(cert.hostname);
         }
@@ -152,7 +152,7 @@ public class CertificatesResource {
 
             if (certificate.isDynamic()) {
                 DynamicCertificateState state = server.getDynamicCertificateManager().getStateOfCertificate(certBean.getId());
-                certBean.setStatus(stateToStatusString(state));
+                certBean.setStatus(state.toString());
             }
             return certBean;
         }
@@ -160,24 +160,4 @@ public class CertificatesResource {
         return null;
     }
 
-    static String stateToStatusString(DynamicCertificateState state) {
-        switch (state) {
-            case WAITING:
-                return "waiting"; // certificate waiting for issuing/renews
-            case VERIFYING:
-                return "verifying"; // challenge verification by LE pending
-            case VERIFIED:
-                return "verified"; // challenge succeded
-            case ORDERING:
-                return "ordering"; // certificate order pending
-            case REQUEST_FAILED:
-                return "request failed"; // challenge/order failed
-            case AVAILABLE:
-                return "available";// certificate available(saved) and not expired
-            case EXPIRED:     // certificate expired
-                return "expired";
-            default:
-                return "unknown";
-        }
-    }
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
@@ -105,7 +105,7 @@ public class CertificatesResource {
 
             if (certificate.isDynamic()) {
                 DynamicCertificateState state = dynamicCertificateManager.getStateOfCertificate(certBean.getId());
-                certBean.setStatus(state.toString());
+                certBean.setStatus(stateToStatusString(state));
             }
             res.put(certificateEntry.getKey(), certBean);
         }
@@ -133,7 +133,7 @@ public class CertificatesResource {
 
         return Response
                 .ok(data, MediaType.APPLICATION_OCTET_STREAM)
-                .header("content-disposition","attachment; filename = " + cert.hostname + ".p12")
+                .header("content-disposition", "attachment; filename = " + cert.hostname + ".p12")
                 .build();
     }
 
@@ -152,7 +152,7 @@ public class CertificatesResource {
 
             if (certificate.isDynamic()) {
                 DynamicCertificateState state = server.getDynamicCertificateManager().getStateOfCertificate(certBean.getId());
-                certBean.setStatus(state.toString());
+                certBean.setStatus(stateToStatusString(state));
             }
             return certBean;
         }
@@ -160,4 +160,24 @@ public class CertificatesResource {
         return null;
     }
 
+    static String stateToStatusString(DynamicCertificateState state) {
+        switch (state) {
+            case WAITING:
+                return "waiting"; // certificate waiting for issuing/renews
+            case VERIFYING:
+                return "verifying"; // challenge verification by LE pending
+            case VERIFIED:
+                return "verified"; // challenge succeded
+            case ORDERING:
+                return "ordering"; // certificate order pending
+            case REQUEST_FAILED:
+                return "request failed"; // challenge/order failed
+            case AVAILABLE:
+                return "available";// certificate available(saved) and not expired
+            case EXPIRED:     // certificate expired
+                return "expired";
+            default:
+                return "unknown";
+        }
+    }
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/api/HeadersResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/HeadersResource.java
@@ -21,17 +21,12 @@ package org.carapaceproxy.api;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.servlet.ServletContext;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import org.carapaceproxy.server.HttpProxyServer;
-import static org.carapaceproxy.server.config.ActionConfiguration.TYPE_ACME_CHALLENGE;
-import static org.carapaceproxy.server.config.ActionConfiguration.TYPE_CACHE;
-import static org.carapaceproxy.server.config.ActionConfiguration.TYPE_PROXY;
-import static org.carapaceproxy.server.config.ActionConfiguration.TYPE_REDIRECT;
-import static org.carapaceproxy.server.config.ActionConfiguration.TYPE_STATIC;
+import org.carapaceproxy.server.mapper.CustomHeader;
 
 /**
  * Access to configured actions
@@ -81,12 +76,23 @@ public class HeadersResource {
         final List<HeaderBean> headers = new ArrayList();
         HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
         server.getMapper().getHeaders().forEach(header -> {
-            headers.add(new HeaderBean(header.getId(), header.getName(), header.getValue(), header.getMode().toString()));
+            headers.add(new HeaderBean(header.getId(), header.getName(), header.getValue(), modeToString(header.getMode())));
         });
 
         return headers;
     }
 
-
+    static String modeToString(CustomHeader.HeaderMode mode) {
+        switch (mode) {
+            case ADD:
+                return "add";
+            case SET:
+                return "set";
+            case REMOVE:
+                return "remove";
+            default:
+                return "unknown";
+        }
+    }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/api/HeadersResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/HeadersResource.java
@@ -1,0 +1,92 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package org.carapaceproxy.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.servlet.ServletContext;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import org.carapaceproxy.server.HttpProxyServer;
+import static org.carapaceproxy.server.config.ActionConfiguration.TYPE_ACME_CHALLENGE;
+import static org.carapaceproxy.server.config.ActionConfiguration.TYPE_CACHE;
+import static org.carapaceproxy.server.config.ActionConfiguration.TYPE_PROXY;
+import static org.carapaceproxy.server.config.ActionConfiguration.TYPE_REDIRECT;
+import static org.carapaceproxy.server.config.ActionConfiguration.TYPE_STATIC;
+
+/**
+ * Access to configured actions
+ *
+ * @author paolo.venturi
+ */
+@Path("/headers")
+@Produces("application/json")
+public class HeadersResource {
+
+    @javax.ws.rs.core.Context
+    ServletContext context;
+
+    public static final class HeaderBean {
+
+        private final String id;
+        private final String name;
+        private final String value;
+        private final String mode;
+
+        public HeaderBean(String id, String name, String value, String mode) {
+            this.id = id;
+            this.name = name;
+            this.value = value;
+            this.mode = mode;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public String getMode() {
+            return mode;
+        }
+    }
+
+    @GET
+    public List<HeaderBean> getAll() {
+        final List<HeaderBean> headers = new ArrayList();
+        HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
+        server.getMapper().getHeaders().forEach(header -> {
+            headers.add(new HeaderBean(header.getId(), header.getName(), header.getValue(), header.getMode().toString()));
+        });
+
+        return headers;
+    }
+
+
+
+}

--- a/carapace-server/src/main/java/org/carapaceproxy/api/RoutesResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/RoutesResource.java
@@ -26,6 +26,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import org.carapaceproxy.server.HttpProxyServer;
+import static org.carapaceproxy.server.mapper.StandardEndpointMapper.ACME_CHALLENGE_ROUTE_ACTION_ID;
 
 /**
  * Access to configured routes
@@ -73,7 +74,9 @@ public class RoutesResource {
     public List<RouteBean> getAll() {
         final List<RouteBean> routes = new ArrayList();
         HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
-        server.getMapper().getRoutes().forEach(route -> {
+        server.getMapper().getRoutes().stream()
+                .filter(r -> !r.getId().equals(ACME_CHALLENGE_ROUTE_ACTION_ID))
+                .forEach(route -> {            
             routes.add(new RouteBean(route.getId(), route.getAction(), route.isEnabled(), route.getMatcher().getDescription()));
         });
 

--- a/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
@@ -296,11 +296,11 @@ public class HttpProxyServer implements AutoCloseable {
     }
 
     public void configureAtBoot(ConfigurationStore bootConfigurationStore) throws ConfigurationNotValidException, InterruptedException {
-
         if (started) {
             throw new IllegalStateException("server already started");
         }
-
+        
+        readClusterConfiguration(bootConfigurationStore); // need to be always first thing to do (loads cluster setup)
         String dynamicConfigurationType = bootConfigurationStore.getProperty("config.type", cluster ? "database" : "file");
         switch (dynamicConfigurationType) {
             case "file":
@@ -322,7 +322,7 @@ public class HttpProxyServer implements AutoCloseable {
         // "static" configuration cannot change without a reboot
         applyStaticConfiguration(bootConfigurationStore);
         // need to be done after static configuration loading in order to know peer info
-        initGroupMembership(bootConfigurationStore);
+        initGroupMembership();
 
         try {
             // apply configuration
@@ -526,7 +526,7 @@ public class HttpProxyServer implements AutoCloseable {
         return this.groupMembershipHandler;
     }
 
-    private void initGroupMembership(ConfigurationStore staticConfiguration) throws ConfigurationNotValidException {
+    private void readClusterConfiguration(ConfigurationStore staticConfiguration) throws ConfigurationNotValidException {
         String mode = staticConfiguration.getProperty("mode", "standalone");
         switch (mode) {
             case "cluster":
@@ -535,24 +535,30 @@ public class HttpProxyServer implements AutoCloseable {
                 zkAddress = staticConfiguration.getProperty("zkAddress", "localhost:2181");
                 zkTimeout = Integer.parseInt(staticConfiguration.getProperty("zkTimeout", "40000"));
                 LOG.log(Level.INFO, "mode=cluster, zkAddress=''{0}'',zkTimeout={1}, peer.id=''{2}''", new Object[]{zkAddress, zkTimeout, peerId});
-                Map<String, String> peerInfo = new HashMap();
-                String adminHost = adminServerHost;
-                try {
-                    adminHost = InetAddress.getLocalHost().getHostName();
-                } catch (UnknownHostException ex) {
-                    LOG.log(Level.INFO, "Unable to resolve Admin Server Hostname for peer " + peerId + ". Using " + adminServerHost);
-                }
-                peerInfo.put(PROPERTY_PEER_ADMIN_SERVER_HOST, adminHost);
-                peerInfo.put(PROPERTY_PEER_ADMIN_SERVER_PORT, adminServerPort + "");
-                this.groupMembershipHandler = new ZooKeeperGroupMembershipHandler(zkAddress, zkTimeout, peerId, peerInfo);
                 break;
             case "standalone":
                 cluster = false;
-                this.groupMembershipHandler = new NullGroupMembershipHandler();
+                LOG.log(Level.INFO, "mode=standalone");
                 break;
             default:
                 throw new ConfigurationNotValidException("Invalid mode '" + mode + "', only 'cluster' or 'standalone'");
+        }
+    }
 
+    private void initGroupMembership() throws ConfigurationNotValidException {
+        if (cluster) {
+            Map<String, String> peerInfo = new HashMap();
+            String adminHost = adminServerHost;
+            try {
+                adminHost = InetAddress.getLocalHost().getHostName();
+            } catch (UnknownHostException ex) {
+                LOG.log(Level.INFO, "Unable to resolve Admin Server Hostname for peer " + peerId + ". Using " + adminServerHost);
+            }
+            peerInfo.put(PROPERTY_PEER_ADMIN_SERVER_HOST, adminHost);
+            peerInfo.put(PROPERTY_PEER_ADMIN_SERVER_PORT, adminServerPort + "");
+            this.groupMembershipHandler = new ZooKeeperGroupMembershipHandler(zkAddress, zkTimeout, peerId, peerInfo);
+        } else {
+            this.groupMembershipHandler = new NullGroupMembershipHandler();
         }
     }
 

--- a/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
@@ -560,6 +560,7 @@ public class HttpProxyServer implements AutoCloseable {
         try {
             return InetAddress.getLocalHost().getHostName();
         } catch (UnknownHostException ex) {
+            LOG.log(Level.INFO, "Unable to resolve Admin Server Hostname. Using localhost.");
             return "localhost";
         }
     }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
@@ -62,9 +62,7 @@ import org.carapaceproxy.server.backends.BackendHealthManager;
 import org.carapaceproxy.server.cache.ContentsCache;
 import org.carapaceproxy.server.filters.UrlEncodedQueryString;
 import static org.carapaceproxy.server.StaticContentsManager.DEFAULT_INTERNAL_SERVER_ERROR;
-import static org.carapaceproxy.server.mapper.CustomHeader.HeaderMode.HEADER_MODE_ADD;
-import static org.carapaceproxy.server.mapper.CustomHeader.HeaderMode.HEADER_MODE_REMOVE;
-import static org.carapaceproxy.server.mapper.CustomHeader.HeaderMode.HEADER_MODE_SET;
+import org.carapaceproxy.server.mapper.CustomHeader.HeaderMode;
 import org.carapaceproxy.server.mapper.requestmatcher.MatchingContext;
 import org.carapaceproxy.utils.PrometheusUtils;
 
@@ -660,12 +658,12 @@ public class RequestHandler implements MatchingContext {
         if (msg instanceof HttpResponse && action != null && action.customHeaders != null) {
             HttpHeaders headers = ((HttpResponse) msg).headers();
             action.customHeaders.forEach(customHeader -> {
-                if (HEADER_MODE_SET.equals(customHeader.getMode())
-                        || HEADER_MODE_REMOVE.equals(customHeader.getMode())) {
+                if (HeaderMode.SET.equals(customHeader.getMode())
+                        || HeaderMode.REMOVE.equals(customHeader.getMode())) {
                     headers.remove(customHeader.getName());
                 }
-                if (HEADER_MODE_SET.equals(customHeader.getMode())
-                        || HEADER_MODE_ADD.equals(customHeader.getMode())) {
+                if (HeaderMode.SET.equals(customHeader.getMode())
+                        || HeaderMode.ADD.equals(customHeader.getMode())) {
                     headers.add(customHeader.getName(), customHeader.getValue());
                 }
             });
@@ -822,7 +820,7 @@ public class RequestHandler implements MatchingContext {
     /**
      * RequestHandler as MatchingContext
      */
-    // All properties name have been converted to lowercase during parsing.    
+    // All properties name have been converted to lowercase during parsing.
     public static final String PROPERTY_URI = "request.uri";
     public static final String PROPERTY_METHOD = "request.method";
     public static final String PROPERTY_CONTENT_TYPE = "request.content-type";
@@ -833,7 +831,7 @@ public class RequestHandler implements MatchingContext {
     @Override
     public String getProperty(String name) {
         if (name.startsWith(PROPERTY_HEADERS)) {
-            // In case of multiple headers with same name, the first one is returned.            
+            // In case of multiple headers with same name, the first one is returned.
             return request.headers().get(name.substring(HEADERS_SUBSTRING_INDEX, name.length()), "");
         } else {
             switch (name) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthManager.java
@@ -140,8 +140,8 @@ public class BackendHealthManager implements Runnable {
         }
         Collection<BackendConfiguration> backendConfigurations = mapper.getBackends().values();
         for (BackendConfiguration bconf : backendConfigurations) {
-            String backendId = bconf.getHostPort();
-            BackendHealthStatus status = backends.computeIfAbsent(backendId, (id) -> new BackendHealthStatus(id));
+            String hostPort = bconf.getHostPort();
+            BackendHealthStatus status = backends.computeIfAbsent(hostPort, (_hostPort) -> new BackendHealthStatus(_hostPort));
 
             BackendHealthCheck checkResult = BackendHealthCheck.check(
                     bconf.getHost(), bconf.getPort(), bconf.getProbePath(), connectTimeout);

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certiticates/DynamicCertificateState.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certiticates/DynamicCertificateState.java
@@ -30,6 +30,10 @@ public enum DynamicCertificateState {
     ORDERING, // certificate order pending
     REQUEST_FAILED, // challenge/order failed
     AVAILABLE, // certificate available(saved) and not expired
-    EXPIRED // certificate expired
+    EXPIRED; // certificate expired
 
+    @Override
+    public String toString() {
+        return super.toString().toLowerCase().replaceAll("_", " ");
+    }
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/CustomHeader.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/CustomHeader.java
@@ -22,26 +22,36 @@ package org.carapaceproxy.server.mapper;
 /**
  *
  * Custom Header to add/set/remove in HttpResponses
- * 
+ *
  * @author paolo.venturi
  */
 public final class CustomHeader {
 
-    // ADD: to append the header
-    // SET: to set the header as the only one
-    // REMOVE: to remove the header
     public static enum HeaderMode {
-        HEADER_MODE_ADD, HEADER_MODE_SET, HEADER_MODE_REMOVE
+        ADD, // to append the header
+        SET, // to set the header as the only one
+        REMOVE; // to remove the header
+
+        @Override
+        public String toString() {
+            return super.toString().toLowerCase();
+        }
     }
 
+    private final String id;
     private final String name;
     private final String value;
     private final HeaderMode mode;
 
-    public CustomHeader(String name, String value, HeaderMode mode) {
+    public CustomHeader(String id, String name, String value, HeaderMode mode) {
+        this.id = id;
         this.name = name;
         this.value = value;
         this.mode = mode;
+    }
+
+    public String getId() {
+        return id;
     }
 
     public String getName() {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -60,6 +60,7 @@ import org.carapaceproxy.server.mapper.requestmatcher.parser.RequestMatchParser;
  */
 public class StandardEndpointMapper extends EndpointMapper {
 
+    public static final String ACME_CHALLENGE_ROUTE_ACTION_ID = "acme-challenge";
     private final Map<String, BackendConfiguration> backends = new HashMap<>();
     private final Map<String, DirectorConfiguration> directors = new HashMap<>();
     private final List<String> allbackendids = new ArrayList<>();
@@ -94,8 +95,8 @@ public class StandardEndpointMapper extends EndpointMapper {
         addAction(new ActionConfiguration("internal-error", ActionConfiguration.TYPE_STATIC, null, DEFAULT_INTERNAL_SERVER_ERROR, 500));
 
         // Route+Action configuration for Let's Encrypt ACME challenging
-        addAction(new ActionConfiguration("acme-challenge", ActionConfiguration.TYPE_ACME_CHALLENGE, null, null, HttpResponseStatus.OK.code()));
-        addRoute(new RouteConfiguration("acme-challenge", "acme-challenge", true, new RegexpRequestMatcher(PROPERTY_URI, ".*" + ACME_CHALLENGE_URI_PATTERN + ".*")));
+        addAction(new ActionConfiguration(ACME_CHALLENGE_ROUTE_ACTION_ID, ActionConfiguration.TYPE_ACME_CHALLENGE, null, null, HttpResponseStatus.OK.code()));
+        addRoute(new RouteConfiguration(ACME_CHALLENGE_ROUTE_ACTION_ID, ACME_CHALLENGE_ROUTE_ACTION_ID, true, new RegexpRequestMatcher(PROPERTY_URI, ".*" + ACME_CHALLENGE_URI_PATTERN + ".*")));
 
         this.defaultNotFoundAction = properties.getProperty("default.action.notfound", "not-found");
         LOG.info("configured default.action.notfound=" + defaultNotFoundAction);

--- a/carapace-server/src/main/resources/conf/cluster.properties
+++ b/carapace-server/src/main/resources/conf/cluster.properties
@@ -23,4 +23,4 @@ db.server.base.dir=dbdata
 # API
 http.admin.enabled=true
 http.admin.port=8001
-#http.admin.host=0.0.0.0 # # default system hostname (/etc/hostname) used
+#http.admin.host=0.0.0.0 # default the address of the localhost, achieved by retrieving the name of the host from the system.     

--- a/carapace-server/src/main/resources/conf/cluster.properties
+++ b/carapace-server/src/main/resources/conf/cluster.properties
@@ -1,4 +1,4 @@
-# example cluster configuration 
+# example cluster configuration
 config.type=database
 mode=cluster
 
@@ -23,4 +23,4 @@ db.server.base.dir=dbdata
 # API
 http.admin.enabled=true
 http.admin.port=8001
-http.admin.host=0.0.0.0
+#http.admin.host=0.0.0.0 # # default system hostname (/etc/hostname) used

--- a/carapace-server/src/main/resources/conf/server.properties
+++ b/carapace-server/src/main/resources/conf/server.properties
@@ -4,4 +4,4 @@ config.type=database
 # API
 http.admin.enabled=true
 http.admin.port=8001
-#http.admin.host=0.0.0.0 # default system hostname (/etc/hostname) used
+#http.admin.host=0.0.0.0 # default the address of the localhost, achieved by retrieving the name of the host from the system.

--- a/carapace-server/src/main/resources/conf/server.properties
+++ b/carapace-server/src/main/resources/conf/server.properties
@@ -4,4 +4,4 @@ config.type=database
 # API
 http.admin.enabled=true
 http.admin.port=8001
-http.admin.host=0.0.0.0
+#http.admin.host=0.0.0.0 # default system hostname (/etc/hostname) used

--- a/carapace-server/src/test/java/org/carapaceproxy/api/StartAPIServerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/StartAPIServerTest.java
@@ -22,7 +22,6 @@ package org.carapaceproxy.api;
 import java.util.Base64;
 import java.util.Properties;
 import javax.servlet.http.HttpServletResponse;
-import static org.carapaceproxy.api.CertificatesResource.stateToStatusString;
 import org.carapaceproxy.configstore.CertificateData;
 import org.carapaceproxy.configstore.ConfigurationStore;
 import org.carapaceproxy.server.certiticates.DynamicCertificateState;
@@ -329,16 +328,16 @@ public class StartAPIServerTest extends UseAdminServer {
                 json = response.getBodyString();
                 assertThat(json, containsString(dynDomain));
                 assertThat(json, containsString("\"dynamic\":true"));
-                assertThat(json, containsString("\"status\":\"" + stateToStatusString(state) + "\""));
+                assertThat(json, containsString("\"status\":\"" + state + "\""));
 
                 response = client.get("/api/certificates/" + dynDomain, credentials);
                 json = response.getBodyString();
                 assertThat(json, containsString(dynDomain));
                 assertThat(json, containsString("\"dynamic\":true"));
-                assertThat(json, containsString("\"status\":\"" + stateToStatusString(state) + "\""));
+                assertThat(json, containsString("\"status\":\"" + state + "\""));
             }
 
-            // Downloading            
+            // Downloading
             CertificateData cert = store.loadCertificateForDomain(dynDomain);
             cert.setChain(Base64.getEncoder().encodeToString("CHAIN".getBytes()));
             store.saveCertificate(cert);

--- a/carapace-server/src/test/java/org/carapaceproxy/api/StartAPIServerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/StartAPIServerTest.java
@@ -22,6 +22,7 @@ package org.carapaceproxy.api;
 import java.util.Base64;
 import java.util.Properties;
 import javax.servlet.http.HttpServletResponse;
+import static org.carapaceproxy.api.CertificatesResource.stateToStatusString;
 import org.carapaceproxy.configstore.CertificateData;
 import org.carapaceproxy.configstore.ConfigurationStore;
 import org.carapaceproxy.server.certiticates.DynamicCertificateState;
@@ -156,7 +157,6 @@ public class StartAPIServerTest extends UseAdminServer {
             assertTrue(s.contains("\"not-found\",\"type\":\"static\""));
             assertTrue(s.contains("\"cache-if-possible\",\"type\":\"cache\""));
             assertTrue(s.contains("\"internal-error\",\"type\":\"static\""));
-            assertTrue(s.contains("\"acme-challenge\",\"type\":\"acme-challenge\""));
             assertTrue(s.contains("\"proxy-all\",\"type\":\"proxy\""));
         }
     }
@@ -328,13 +328,13 @@ public class StartAPIServerTest extends UseAdminServer {
                 json = response.getBodyString();
                 assertThat(json, containsString(dynDomain));
                 assertThat(json, containsString("\"dynamic\":true"));
-                assertThat(json, containsString("\"status\":\"" + state + "\""));
+                assertThat(json, containsString("\"status\":\"" + stateToStatusString(state) + "\""));
 
                 response = client.get("/api/certificates/" + dynDomain, credentials);
                 json = response.getBodyString();
                 assertThat(json, containsString(dynDomain));
                 assertThat(json, containsString("\"dynamic\":true"));
-                assertThat(json, containsString("\"status\":\"" + state + "\""));
+                assertThat(json, containsString("\"status\":\"" + stateToStatusString(state) + "\""));
             }
 
             // Downloading

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/TestEndpointMapper.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/TestEndpointMapper.java
@@ -32,6 +32,7 @@ import org.carapaceproxy.server.config.ActionConfiguration;
 import org.carapaceproxy.server.config.BackendConfiguration;
 import org.carapaceproxy.server.config.DirectorConfiguration;
 import org.carapaceproxy.server.config.RouteConfiguration;
+import org.carapaceproxy.server.mapper.CustomHeader;
 
 public class TestEndpointMapper extends EndpointMapper {
 
@@ -42,6 +43,7 @@ public class TestEndpointMapper extends EndpointMapper {
     private final List<RouteConfiguration> routes = new ArrayList();
     private final List<ActionConfiguration> actions = new ArrayList();
     private final List<DirectorConfiguration> directors = new ArrayList();
+    private final List<CustomHeader> headers = new ArrayList();
 
     public TestEndpointMapper(String host, int port) {
         this(host, port, false);
@@ -91,4 +93,10 @@ public class TestEndpointMapper extends EndpointMapper {
     public List<DirectorConfiguration> getDirectors() {
         return directors;
     }
+
+    public List<CustomHeader> getHeaders() {
+        return headers;
+    }
+
+
 }

--- a/carapace-ui/nb-configuration.xml
+++ b/carapace-ui/nb-configuration.xml
@@ -15,5 +15,8 @@ Any value defined here will override the pom.xml file value but is only applicab
 -->
         <org-netbeans-modules-maven-j2ee.netbeans_2e_hint_2e_j2eeVersion>1.7-web</org-netbeans-modules-maven-j2ee.netbeans_2e_hint_2e_j2eeVersion>
         <org-netbeans-modules-maven-j2ee.netbeans_2e_hint_2e_deploy_2e_server>Tomcat</org-netbeans-modules-maven-j2ee.netbeans_2e_hint_2e_deploy_2e_server>
+        <org-netbeans-modules-css-prep.sass_2e_configured>true</org-netbeans-modules-css-prep.sass_2e_configured>
+        <org-netbeans-modules-css-prep.sass_2e_enabled>true</org-netbeans-modules-css-prep.sass_2e_enabled>
+        <org-netbeans-modules-css-prep.sass_2e_mappings>/scss:/css</org-netbeans-modules-css-prep.sass_2e_mappings>
     </properties>
 </project-shared-configuration>

--- a/carapace-ui/nb-configuration.xml
+++ b/carapace-ui/nb-configuration.xml
@@ -14,9 +14,6 @@ That way multiple projects can share the same settings (useful for formatting ru
 Any value defined here will override the pom.xml file value but is only applicable to the current project.
 -->
         <org-netbeans-modules-maven-j2ee.netbeans_2e_hint_2e_j2eeVersion>1.7-web</org-netbeans-modules-maven-j2ee.netbeans_2e_hint_2e_j2eeVersion>
-        <org-netbeans-modules-maven-j2ee.netbeans_2e_hint_2e_deploy_2e_server>Tomcat</org-netbeans-modules-maven-j2ee.netbeans_2e_hint_2e_deploy_2e_server>
-        <org-netbeans-modules-css-prep.sass_2e_configured>true</org-netbeans-modules-css-prep.sass_2e_configured>
-        <org-netbeans-modules-css-prep.sass_2e_enabled>true</org-netbeans-modules-css-prep.sass_2e_enabled>
-        <org-netbeans-modules-css-prep.sass_2e_mappings>/scss:/css</org-netbeans-modules-css-prep.sass_2e_mappings>
+        <org-netbeans-modules-maven-j2ee.netbeans_2e_hint_2e_deploy_2e_server>Tomcat</org-netbeans-modules-maven-j2ee.netbeans_2e_hint_2e_deploy_2e_server>       
     </properties>
 </project-shared-configuration>

--- a/carapace-ui/src/main/webapp/src/App.vue
+++ b/carapace-ui/src/main/webapp/src/App.vue
@@ -22,16 +22,17 @@
                     <li>
                     <router-link to="/routes">Routes</router-link>
                     </li>
-
-                    <hr>
-
                     <li>
                     <router-link to="/listeners">Listeners</router-link>
+                    </li>
+                    
+                    <hr>
+                    <li>
+                    <router-link to="/headers">Headers</router-link>
                     </li>
                     <li>
                     <router-link to="/requestfilters">Request filters</router-link>
                     </li>
-
                     <hr>
 
                     <li>
@@ -78,7 +79,7 @@
         created: function () {
             var url = "/api/cluster/localpeer"
             var d = this
-            doGet(url, response => {            
+            doGet(url, response => {
                 d.peerId = response.id
                 document.title += ' (' + d.peerId + ')'
             })

--- a/carapace-ui/src/main/webapp/src/app.scss
+++ b/carapace-ui/src/main/webapp/src/app.scss
@@ -96,6 +96,12 @@ body {
     background: none;
 }
 
+/* Other Styles */
+.box-warning {
+    background-color: #FFD212B3;
+    padding: 0.3em;   
+}
+
 @media(min-width:768px) {
     #wrapper {
         padding-left: 0;

--- a/carapace-ui/src/main/webapp/src/components/Actions.vue
+++ b/carapace-ui/src/main/webapp/src/components/Actions.vue
@@ -4,10 +4,10 @@
         <table class="table table-striped">
             <thead>
                 <tr>
-                    <th scope="col">Action ID</th>
+                    <th scope="col">ID</th>
                     <th scope="col">Type</th>
-                    <th scope="col">File</th>
-                    <th scope="col">Director</th>
+                    <th scope="col">Description</th>
+                    <th scope="col">Headers</th>
                     <th scope="col">Error code</th>
                 </tr>
             </thead>
@@ -20,10 +20,10 @@
                         <div class="label">{{action.type}}</div>
                     </td>
                     <td>
-                        <div class="label">{{action.file}}</div>
+                        <div class="label">{{action.description}}</div>
                     </td>
                     <td>
-                        <div class="label">{{action.director}}</div>
+                        <div class="label">{{action.headers}}</div>
                     </td>
                     <td>
                         <div class="label">{{action.errorcode}}</div>

--- a/carapace-ui/src/main/webapp/src/components/Backends.vue
+++ b/carapace-ui/src/main/webapp/src/components/Backends.vue
@@ -1,39 +1,10 @@
-<style scoped>
-    table th,
-    table tr td .label {
-        font-size: 13px;
-    }
-    table tr td .label-error{
-        background-color: #f44336;
-        border-radius: 2px;
-
-        text-transform: uppercase;
-        text-align: center;
-        font-weight: bold;
-        color: white;
-
-        padding: 10px;
-    }
-    table tr td .label-success{
-        background-color: #4CAF50;
-        border-radius: 2px;
-
-        text-transform: uppercase;
-        font-weight: bold;
-        text-align: center;
-        color: white;
-
-        padding: 10px;
-    }
-</style>
-
 <template>
     <div>
         <h2>Backends</h2>
         <table class="table table-striped">
             <thead>
                 <tr>
-                    <th scope="col">Backend ID</th>
+                    <th scope="col">ID</th>
                     <th scope="col">Host:Port</th>
                     <th scope="col">Open connections</th>
                     <th scope="col">Total Requests</th>
@@ -161,3 +132,32 @@
         }
     }
 </script>
+
+<style scoped>
+    table th,
+    table tr td .label {
+        font-size: 13px;
+    }
+    table tr td .label-error{
+        background-color: #f44336;
+        border-radius: 2px;
+
+        text-transform: uppercase;
+        text-align: center;
+        font-weight: bold;
+        color: white;
+
+        padding: 10px;
+    }
+    table tr td .label-success{
+        background-color: #4CAF50;
+        border-radius: 2px;
+
+        text-transform: uppercase;
+        font-weight: bold;
+        text-align: center;
+        color: white;
+
+        padding: 10px;
+    }
+</style>

--- a/carapace-ui/src/main/webapp/src/components/Backends.vue
+++ b/carapace-ui/src/main/webapp/src/components/Backends.vue
@@ -33,7 +33,8 @@
         <table class="table table-striped">
             <thead>
                 <tr>
-                    <th scope="col">Backend</th>
+                    <th scope="col">Backend ID</th>
+                    <th scope="col">Host:Port</th>
                     <th scope="col">Open connections</th>
                     <th scope="col">Total Requests</th>
                     <th scope="col">Last Activity (Timestamp)</th>
@@ -48,6 +49,11 @@
             </thead>
             <tbody>
                 <tr v-for="item of backends" :key="item.id">
+                    <td>
+                        <div class="label">
+                            {{item.id}}
+                        </div>
+                    </td>
                     <td>
                         <div class="label">
                             {{item.host}}:{{item.port}}

--- a/carapace-ui/src/main/webapp/src/components/Certificate.vue
+++ b/carapace-ui/src/main/webapp/src/components/Certificate.vue
@@ -8,7 +8,7 @@
                 <div class="panel panel-info">
                     <div class="panel-body">
                         <ul class="list-group">
-                            <li class="list-group-item"><strong>Certificate id:</strong> {{certificate.id}}</li>
+                            <li class="list-group-item"><strong>ID:</strong> {{certificate.id}}</li>
                             <li class="list-group-item"><strong>Hostname:</strong> {{certificate.hostname}}</li>
                             <li class="list-group-item"><strong>Dynamic:</strong> {{certificate.dynamic | symbolFormat}}</li>
                             <li class="list-group-item"><strong>Status:</strong> {{certificate.status}}</li>                            

--- a/carapace-ui/src/main/webapp/src/components/Directors.vue
+++ b/carapace-ui/src/main/webapp/src/components/Directors.vue
@@ -4,7 +4,7 @@
         <table class="table table-striped">
             <thead>
                 <tr>
-                    <th scope="col">Director ID</th>
+                    <th scope="col">ID</th>
                     <th scope="col">Backends IDs</th>
                 </tr>
             </thead>

--- a/carapace-ui/src/main/webapp/src/components/Headers.vue
+++ b/carapace-ui/src/main/webapp/src/components/Headers.vue
@@ -1,0 +1,56 @@
+<template>
+    <div>
+        <h2>Headers</h2>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th scope="col">ID</th>
+                    <th scope="col">Name</th>
+                    <th scope="col">Value</th>
+                    <th scope="col">Mode</th>                    
+                </tr>
+            </thead>
+            <tbody>
+                <tr v-for="header of headers" :key="header.id">
+                    <td>
+                        <div class="label">{{header.id}}</div>
+                    </td>
+                    <td>
+                        <div class="label">{{header.name}}</div>
+                    </td>
+                    <td>
+                        <div class="label">{{header.value}}</div>
+                    </td>
+                    <td>
+                        <div class="label">{{header.mode}}</div>
+                    </td>                   
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</template>
+
+<script>
+    import { doGet } from './../mockserver'
+    export default {
+        name: 'headers',
+        data: function () {
+            return {
+                headers: []
+            }
+        },
+        created: function () {
+            var url = "/api/headers"
+            var self = this
+            doGet(url, data => {
+                self.headers = []
+                Object.keys(data).forEach(idx => {
+                    self.headers.push(data[idx])
+                })
+            })
+        }
+    }
+</script>
+
+<style scoped>
+</style>

--- a/carapace-ui/src/main/webapp/src/components/Peers.vue
+++ b/carapace-ui/src/main/webapp/src/components/Peers.vue
@@ -4,7 +4,7 @@
         <table class="table table-striped">
             <thead>
                 <tr>
-                    <th scope="col">Id</th>
+                    <th scope="col">ID</th>
                     <th scope="col">Description</th>
                     <th scope="col">Admin Server UI</th>
                 </tr>

--- a/carapace-ui/src/main/webapp/src/components/Routes.vue
+++ b/carapace-ui/src/main/webapp/src/components/Routes.vue
@@ -1,13 +1,14 @@
 <template>
     <div>
         <h2>Routes</h2>
+        <p>Defined routes ordered by application priority.</p>        
         <table class="table table-striped">
             <thead>
-                <tr>
+                <tr>                    
                     <th scope="col">Route ID</th>
+                    <th scope="col">Request matcher</th>
                     <th scope="col">Action</th>
                     <th scope="col">Enabled</th>
-                    <th scope="col">Request matcher</th>
                 </tr>
             </thead>
             <tbody>
@@ -16,17 +17,18 @@
                         <div class="label">{{route.id}}</div>
                     </td>
                     <td>
+                        <div class="label">{{route.matcher}}</div>
+                    </td>
+                    <td>
                         <div class="label">{{route.action}}</div>
                     </td>
                     <td>
                         <div class="label">{{route.enabled | symbolFormat}}</div>
                     </td>
-                    <td>
-                        <div class="label">{{route.matcher}}</div>
-                    </td>
                 </tr>
             </tbody>
         </table>
+        <div class="box-warning">NOT-FOUND action will be performed with no route matching.</div>
     </div>
 </template>
 

--- a/carapace-ui/src/main/webapp/src/components/Routes.vue
+++ b/carapace-ui/src/main/webapp/src/components/Routes.vue
@@ -1,18 +1,21 @@
 <template>
     <div>
-        <h2>Routes</h2>
-        <p>Defined routes ordered by application priority.</p>        
+        <h2>Routes</h2>       
         <table class="table table-striped">
             <thead>
                 <tr>                    
-                    <th scope="col">Route ID</th>
+                    <th scope="col">Priority</th>
+                    <th scope="col">ID</th>
                     <th scope="col">Request matcher</th>
                     <th scope="col">Action</th>
                     <th scope="col">Enabled</th>
                 </tr>
             </thead>
             <tbody>
-                <tr v-for="route of routes" :key="route.id">
+                <tr v-for="(route, index) of routes" :key="route.id">
+                    <td>
+                        <div class="label">{{index + 1}}</div>
+                    </td>
                     <td>
                         <div class="label">{{route.id}}</div>
                     </td>
@@ -28,7 +31,7 @@
                 </tr>
             </tbody>
         </table>
-        <div class="box-warning">NOT-FOUND action will be performed with no route matching.</div>
+        <div class="box-warning">With no route matching the NOT-FOUND action will be performed.</div>
     </div>
 </template>
 

--- a/carapace-ui/src/main/webapp/src/router.js
+++ b/carapace-ui/src/main/webapp/src/router.js
@@ -15,6 +15,7 @@ import DatatableList from './components/DatatableList'
 import Configuration from './components/Configuration'
 import Metrics from './components/Metrics'
 import Peers from './components/Peers'
+import Headers from './components/Headers'
 
 Vue.component('backends-status', Backends)
 Vue.component('routes', Routes)
@@ -29,6 +30,7 @@ Vue.component('datatable-list', DatatableList)
 Vue.component('configuration', Configuration)
 Vue.component('metrics', Metrics)
 Vue.component('peers', Peers)
+Vue.component('headers', Headers)
 
 Vue.use(Router)
 
@@ -98,6 +100,11 @@ export default new Router({
         path: '/peers',
         name: 'Peers',
         component: Peers
-    }
+    },
+    {
+      path: '/headers',
+      name: 'Headers',
+      component: Headers
+  }
   ]
 })

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ cd carapace-server-${CARAPACE_V}
 timeout 22 sh -c 'until nc -z $0 $1; do sleep 1; done' localhost 8001
 
 # apply dynamic configuration
-curl -X POST --data-binary @conf/server.dynamic.properties http://localhost:8001/api/config/apply --user admin:admin -H "Content-Type: text/plain"
+curl -X POST --data-binary @conf/server.dynamic.properties http://$(hostname):8001/api/config/apply --user admin:admin -H "Content-Type: text/plain"
 
 tail -f server.service.log
 


### PR DESCRIPTION
Routes Section:
* Added new column *Priority*
* Reordered columns as: *Prioriry | Route ID |  Request matcher | Action | Enabled*
* Added a warning indication that *action NOT-FOUND will be performed for no-matching routes*
* Removed acme route

Backends Section:
* Added column *ID*

Actions Section:
* Added column *Description* indicating the DIRECTOR, FILE, REDIRECT PATH etc
* Deleted error code -1 for cache/proxy actions
* Hidden acme-challenge action
* Added column *Headers* for headers-id used

Prometheus Section:
* Changed link to metrics to hostname:port
* **IMPORTANT:** default hostname for Admin/API/Metrics (whether not defined in *server.properties*) is changed from "localhost" to the one defined in */etc/hostname* file. Whether even */etc/hostname* is not defined then "localhost" will still be the default.

Headers Section (NEW!):
* Add new API path */api/headers* for retrieving all headers defined as *{id, name, value, mode}*
* Add new Section *Headers* in Admin UI for showing all custom headers defined