### PR TITLE
Add systemd script

### DIFF
--- a/carapace-server/src/main/resources/bin/carapace.service
+++ b/carapace-server/src/main/resources/bin/carapace.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Carapace Service
+Documentation=https://github.com/diennea/carapaceproxy/wiki
+Requires=network.target
+After=network.target
+
+[Service]
+Type=forking
+User={RUNASUSER}
+Group={RUNASUSER_GROUP}
+ExecStart={CARAPACE_INSTALLATION_PATH}/bin/service server start
+ExecStop={CARAPACE_INSTALLATION_PATH}/bin/service server stop
+ExecReload={CARAPACE_INSTALLATION_PATH}/bin/service server restart
+WorkingDirectory={CARAPACE_INSTALLATION_PATH}
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
If you need to configure the service to run at startup, you can use this systemd script.

- edit carapace.service and insert correct "User", "Group" and "installation path"
- copy carapace.service in /etc/systemd/system
- systemctl enable carapace.service 
- systemctl start carapace.service (To start carapace)
- systemctl stop carapace.service (To stop carapace)
- systemctl restart carapace.service (To restart carapace)