### PR TITLE
Introduce Max time to borrow a connection from the pool, not using connecttimeout any more

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>
-            <version>2.5.0</version>
+            <version>2.6.2</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/carapace-server/src/main/java/org/carapaceproxy/client/EndpointConnection.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/EndpointConnection.java
@@ -34,8 +34,6 @@ public interface EndpointConnection {
 
     public EndpointKey getKey();
 
-    public void setIdleTimeout(int timeout);
-
     public void sendRequest(HttpRequest request, RequestHandler handler);
 
     public void release(boolean error, RequestHandler handler);

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
@@ -58,6 +58,7 @@ public class RuntimeServerConfiguration {
     private int idleTimeout = 60000;
     private int stuckRequestTimeout = 120000;
     private int connectTimeout = 10000;
+    private int borrowTimeout = 60000;
     private long cacheMaxSize = 0;
     private long cacheMaxFileSize = 0;
     private String mapperClassname;
@@ -171,6 +172,14 @@ public class RuntimeServerConfiguration {
         this.connectTimeout = connectTimeout;
     }
 
+    public int getBorrowTimeout() {
+        return borrowTimeout;
+    }
+
+    public void setBorrowTimeout(int borrowTimeout) {
+        this.borrowTimeout = borrowTimeout;
+    }        
+
     public long getCacheMaxSize() {
         return cacheMaxSize;
     }
@@ -218,10 +227,12 @@ public class RuntimeServerConfiguration {
         }
         this.stuckRequestTimeout = getInt("connectionsmanager.stuckrequesttimeout", stuckRequestTimeout, properties);
         this.connectTimeout = getInt("connectionsmanager.connecttimeout", connectTimeout, properties);
+        this.borrowTimeout = getInt("connectionsmanager.borrowtimeout", borrowTimeout, properties);
         LOG.info("connectionsmanager.maxconnectionsperendpoint=" + maxConnectionsPerEndpoint);
         LOG.info("connectionsmanager.idletimeout=" + idleTimeout);
         LOG.info("connectionsmanager.stuckrequesttimeout=" + stuckRequestTimeout);
         LOG.info("connectionsmanager.connecttimeout=" + connectTimeout);
+        LOG.info("connectionsmanager.borrowtimeout=" + borrowTimeout);
 
         this.mapperClassname = getClassname("mapper.class", StandardEndpointMapper.class.getName(), properties);
         LOG.log(Level.INFO, "mapper.class={0}", this.mapperClassname);

--- a/carapace-server/src/main/resources/conf/server.dynamic.properties
+++ b/carapace-server/src/main/resources/conf/server.dynamic.properties
@@ -74,6 +74,8 @@ connectionsmanager.maxconnectionsperendpoint=10
 connectionsmanager.idletimeout=300000
 # Max time to establish a connection to a backend
 connectionsmanager.connecttimeout=10000
+# Max time to get a valid connection
+connectionsmanager.borrowtimeout=60000
 # Max Idle time for a request, after this timeout the request will be considered 'stuck' and the backend 'unreachable'
 connectionsmanager.stuckrequesttimeout=300000
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheExpireTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheExpireTest.java
@@ -243,7 +243,7 @@ public class CacheExpireTest {
 
         TestUtils.waitForCondition(() -> {
             EndpointStats epstats = stats.getEndpointStats(key);
-            return epstats.getTotalConnections().intValue() == 1
+            return epstats.getTotalConnections().intValue() >= 1
                 && epstats.getActiveConnections().intValue() == 0
                 && epstats.getOpenConnections().intValue() == 0;
         }, 100);

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheTest.java
@@ -127,7 +127,7 @@ public class CacheTest {
 
         TestUtils.waitForCondition(() -> {
             EndpointStats epstats = stats.getEndpointStats(key);
-            return epstats.getTotalConnections().intValue() == 1
+            return epstats.getTotalConnections().intValue() >= 1
                     && epstats.getActiveConnections().intValue() == 0
                     && epstats.getOpenConnections().intValue() == 0;
         }, 100);
@@ -194,7 +194,7 @@ public class CacheTest {
 
         TestUtils.waitForCondition(() -> {
             EndpointStats epstats = stats.getEndpointStats(key);
-            return epstats.getTotalConnections().intValue() == 1
+            return epstats.getTotalConnections().intValue() >= 1
                     && epstats.getActiveConnections().intValue() == 0
                     && epstats.getOpenConnections().intValue() == 0;
         }, 100);
@@ -293,7 +293,7 @@ public class CacheTest {
 
         TestUtils.waitForCondition(() -> {
             EndpointStats epstats = stats.getEndpointStats(key);
-            return epstats.getTotalConnections().intValue() == 1
+            return epstats.getTotalConnections().intValue() >= 1
                     && epstats.getActiveConnections().intValue() == 0
                     && epstats.getOpenConnections().intValue() == 0;
         }, 100);
@@ -364,7 +364,7 @@ public class CacheTest {
 
         TestUtils.waitForCondition(() -> {
             EndpointStats epstats = stats.getEndpointStats(key);
-            return epstats.getTotalConnections().intValue() == 1
+            return epstats.getTotalConnections().intValue() >= 1
                     && epstats.getActiveConnections().intValue() == 0
                     && epstats.getOpenConnections().intValue() == 0;
         }, 100);
@@ -435,7 +435,7 @@ public class CacheTest {
 
         TestUtils.waitForCondition(() -> {
             EndpointStats epstats = stats.getEndpointStats(key);
-            return epstats.getTotalConnections().intValue() == 1
+            return epstats.getTotalConnections().intValue() >= 1
                     && epstats.getActiveConnections().intValue() == 0
                     && epstats.getOpenConnections().intValue() == 0;
         }, 100);
@@ -483,7 +483,7 @@ public class CacheTest {
 
         TestUtils.waitForCondition(() -> {
             EndpointStats epstats = stats.getEndpointStats(key);
-            return epstats.getTotalConnections().intValue() == 1
+            return epstats.getTotalConnections().intValue() >= 1
                     && epstats.getActiveConnections().intValue() == 0
                     && epstats.getOpenConnections().intValue() == 0;
         }, 100);
@@ -531,7 +531,7 @@ public class CacheTest {
 
         TestUtils.waitForCondition(() -> {
             EndpointStats epstats = stats.getEndpointStats(key);
-            return epstats.getTotalConnections().intValue() == 1
+            return epstats.getTotalConnections().intValue() >= 1
                     && epstats.getActiveConnections().intValue() == 0
                     && epstats.getOpenConnections().intValue() == 0;
         }, 100);

--- a/carapace-server/untilfail
+++ b/carapace-server/untilfail
@@ -1,0 +1,2 @@
+#!/bin/bash
+while $@; do :; done

--- a/pom.xml
+++ b/pom.xml
@@ -31,11 +31,10 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.21.0</version>
+                <version>3.0.0-M3</version>
                 <configuration>
                     <reuseForks>false</reuseForks>
                     <trimStackTrace>false</trimStackTrace>
-                    <!--<forkedProcessTimeoutInSeconds>180</forkedProcessTimeoutInSeconds>-->
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Introduce a new configuration parameter: connectionsmanager.borrowtimeout.
We were using connectiontimoeut * 2 to wait for a connection to be available, but waiting for an existing connection is far different from a "Connection timeout".

We are also adding more debug in case of IDLE connection validation, this way we will have more insights about whats happening.
I am also fixing race conditions regarding keep-alive connections observed in Travis
This patch also upgrades commons-pool2 to latest version 2.6.2

Relates #111