### PR TITLE
UI: Section Cluster Peers > port does not  set correctly if https is …

### DIFF
--- a/carapace-server/src/main/resources/conf/cluster.properties
+++ b/carapace-server/src/main/resources/conf/cluster.properties
@@ -24,9 +24,9 @@ db.server.base.dir=dbdata
 http.admin.enabled=true
 http.admin.port=8001
 http.admin.host=localhost
-https.admin.port=-1
-https.admin.sslcertfile=
-https.admin.sslcertfilepassword=
+https.admin.port=4001
+https.admin.sslcertfile=conf/localhost.p12
+https.admin.sslcertfilepassword=testproxy
 #admin.advertised.host=localhost #to customize the hostname shown for Admin/API/peers urls
 
 admin.accesslog.path=admin.access.log

--- a/carapace-server/src/main/resources/conf/server.properties
+++ b/carapace-server/src/main/resources/conf/server.properties
@@ -5,9 +5,9 @@ config.type=database
 http.admin.enabled=true
 http.admin.port=8001
 http.admin.host=localhost
-https.admin.port=-1
-https.admin.sslcertfile=
-https.admin.sslcertfilepassword=
+https.admin.port=4001
+https.admin.sslcertfile=conf/localhost.p12
+https.admin.sslcertfilepassword=testproxy
 #admin.advertised.host=localhost #to customize the hostname shown for Admin/API/peers urls
 
 admin.accesslog.path=admin.access.log

--- a/carapace-ui/src/main/webapp/src/components/Peers.vue
+++ b/carapace-ui/src/main/webapp/src/components/Peers.vue
@@ -22,9 +22,14 @@
                         </div>
                     </td>                    
                     <td>
-                        <div class="label">
+                        <div v-if="item.info['peer_admin_server_port'] > 0" class="label">
                             <a :href="'http://' + item.info['peer_admin_server_host'] + ':' + item.info['peer_admin_server_port'] + '/ui/#/'" >
-                                {{item.info['peer_admin_server_host']}}:{{item.info['peer_admin_server_port']}}
+                                http://{{item.info['peer_admin_server_host']}}:{{item.info['peer_admin_server_port']}}
+                            </a>
+                        </div>
+                        <div v-if="item.info['peer_admin_server_https_port'] > 0" class="label">
+                            <a :href="'https://' + item.info['peer_admin_server_host'] + ':' + item.info['peer_admin_server_https_port'] + '/ui/#/'" >
+                                https://{{item.info['peer_admin_server_host']}}:{{item.info['peer_admin_server_https_port']}}
                             </a>
                         </div>
                     </td>


### PR DESCRIPTION
Now Cluster Peers section shows both http and https links to the Admin UI

Also, server.properties and cluster.properties files has been updated with https default port and certificate file