### PR TITLE
DynamiCertificateManager: certificate locked at WAITING state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 jobs:
   include:
   - stage: test
-    jdk: oraclejdk11
+    jdk: openjdk11
     script: mvn verify -Pproduction -Dmaven.test.redirectTestOutputToFile=true -Dsurefire.rerunFailingTestsCount=2 
 
 branches:

--- a/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
@@ -161,6 +161,9 @@ public class CertificatesResource {
     }
 
     static String stateToStatusString(DynamicCertificateState state) {
+        if (state == null ) {
+            return "unknown";
+        }
         switch (state) {
             case WAITING:
                 return "waiting"; // certificate waiting for issuing/renews

--- a/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthManager.java
@@ -152,7 +152,7 @@ public class BackendHealthManager implements Runnable {
                             new Object[]{status.getHostPort(), checkResult.getEndTs() - checkResult.getStartTs()});
                     reportBackendReachable(status.getHostPort());
                 } else {
-                    LOG.log(Level.INFO, "backend {0} seems reachable. Response time {1}ms",
+                    LOG.log(Level.FINE, "backend {0} seems reachable. Response time {1}ms",
                             new Object[]{status.getHostPort(), checkResult.getEndTs() - checkResult.getStartTs()});
                 }
             } else {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certiticates/ACMEClient.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certiticates/ACMEClient.java
@@ -105,13 +105,14 @@ public class ACMEClient {
     public Http01Challenge getHTTPChallengeForOrder(Order order) throws AcmeException {
         Authorization auth = order.getAuthorizations().get(0);
         String domain = auth.getIdentifier().getDomain();
-        LOG.info("Authorization for domain {}", domain);
-
+        LOG.debug("Authorization for domain {} status:{}", domain, auth.getStatus());
+        
         // The authorization is already valid. No need to process a challenge.
         if (auth.getStatus() == Status.VALID) {
             return null;
         }
-
+        
+        LOG.debug("Retrieving challenge...");
         Http01Challenge challenge = httpChallenge(auth);
 
         if (challenge == null) {
@@ -119,6 +120,7 @@ public class ACMEClient {
         }
 
         // If the challenge is already verified, there's no need to execute it again.
+        LOG.debug("Challenge for domain {} status:{}", domain, challenge.getStatus());
         if (challenge.getStatus() == Status.VALID) {
             return null;
         }
@@ -144,10 +146,10 @@ public class ACMEClient {
         Http01Challenge challenge = auth.findChallenge(Http01Challenge.TYPE);
         if (challenge == null) {
             throw new AcmeException("Found no " + Http01Challenge.TYPE + " challenge, don't know what to do...");
-        }
+        }        
 
         // Output the challenge, wait for acknowledge...
-        LOG.info("It must be reachable at: http://{}/.well-known/acme-challenge/{}",
+        LOG.debug("It must be reachable at: http://{}/.well-known/acme-challenge/{}",
                 auth.getIdentifier().getDomain(), challenge.getToken());
 
         return challenge;

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certiticates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certiticates/DynamicCertificatesManager.java
@@ -221,13 +221,12 @@ public class DynamicCertificatesManager implements Runnable {
                         LOG.info("Certificate ISSUING process for domain: " + domain + " STARTED.");
                         Order order = client.createOrderForDomain(domain);
                         cert.setPendingOrderLocation(order.getLocation());
-                        LOG.fine("Pending order location for domain " + domain + ": " + order.getLocation());
+                        LOG.info("Pending order location for domain " + domain + ": " + order.getLocation());
                         Http01Challenge challenge = client.getHTTPChallengeForOrder(order);
                         if (challenge == null) {
-                            LOG.info("VERIFIED");
                             cert.setState(VERIFIED);
                         } else {
-                            LOG.fine("Pending challenge data for domain " + domain + ": " + challenge.getJSON());
+                            LOG.info("Pending challenge data for domain " + domain + ": " + challenge.getJSON());
                             triggerChallenge(challenge);                            
                             cert.setPendingChallengeData(challenge.getJSON());
                             cert.setState(VERIFYING);


### PR DESCRIPTION
* Added more debug
* Moved to FINE/DEBUG some too verbose INFO logs
* Fixed bug for which WAITING certificates were not saved on db whether AVAILABLE ones were processed before them
* Fixed a NPE in CertificatesResource when trying to stringify the certificate status (status is null as long as the certificate isn't stored to the db, which happens only when the manager successfully process it)
* Now certificates are processed according to the hostname in ascending alphabetically order