### PR TITLE
Certificates: DB management for Static Certificates #76

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -256,6 +256,12 @@
             <scope>test</scope>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>com.sun.jersey.contribs</groupId>
+            <artifactId>jersey-multipart</artifactId>
+            <version>1.19.1</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -255,13 +255,7 @@
             <version>1.1.1</version>
             <scope>test</scope>
             <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jersey.contribs</groupId>
-            <artifactId>jersey-multipart</artifactId>
-            <version>1.19.1</version>
-            <type>jar</type>
-        </dependency>
+        </dependency>       
     </dependencies>
     <build>
         <plugins>

--- a/carapace-server/src/main/java/org/carapaceproxy/api/ConfigResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/ConfigResource.java
@@ -90,7 +90,7 @@ public class ConfigResource {
         }
     }
 
-    private PropertiesConfigurationStore buildStore(String newConfiguration) throws ConfigurationNotValidException {
+    public static PropertiesConfigurationStore buildStore(String newConfiguration) throws ConfigurationNotValidException {
         if (newConfiguration == null || newConfiguration.trim().isEmpty()) {
             throw new ConfigurationNotValidException("Invalid empty configuration");
         }

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
@@ -39,6 +39,7 @@ public class CertificateData {
     private String pendingOrderLocation;
     private String pendingChallengeData;
     private boolean available;
+    private boolean manual;
 
     public CertificateData(String domain, String privateKey, String chain, String state,
             String orderLocation, String challengeData, boolean available) {
@@ -117,6 +118,14 @@ public class CertificateData {
 
     public void setPendingChallengeData(JSON challengeData) {
         this.pendingChallengeData = challengeData.toString();
+    }
+
+    public boolean isManual() {
+        return manual;
+    }
+
+    public void setManual(boolean manual) {
+        this.manual = manual;
     }
 
     @Override

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationStore.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationStore.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
 
 /**
  * Stores configuration
@@ -79,14 +80,13 @@ public interface ConfigurationStore extends AutoCloseable {
 
     /**
      *
-     * @param keyRegexp
-     * @param valueRegexp
-     * @return whether exist at least one property with both key and value matching to passed regexps.
+     * @param predicate
+     * @return  whether exist at least one property matching to passed predicate.
      */
-    default boolean anyPropertyMatches(String keyRegexp, String valueRegexp) {
+    default boolean anyPropertyMatches(BiPredicate<String, String> predicate) {
         BooleanHolder any = new BooleanHolder(false);
         this.forEach((k, v) -> {            
-            if (k.matches(keyRegexp) && v.matches(valueRegexp)) {
+            if (predicate.test(k, v)) {
                 any.value = true;                
             }
         });

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationStore.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationStore.java
@@ -34,12 +34,17 @@ import java.util.function.BiConsumer;
  */
 public interface ConfigurationStore extends AutoCloseable {
 
-    String getProperty(String key, String defaultValue);    
+    String getProperty(String key, String defaultValue);
 
     void forEach(BiConsumer<String, String> consumer);
 
-    void forEach(String prefix, BiConsumer<String, String> consumer);    
+    void forEach(String prefix, BiConsumer<String, String> consumer);
 
+    /**
+     *
+     * @param prefix prefix for properties to fetch. Whether null, all properties will be fetched.
+     * @return properties with key starting with prefix.
+     */
     default Properties asProperties(String prefix) {
         Properties copy = new Properties();
         this.forEach((k, v) -> {
@@ -72,11 +77,16 @@ public interface ConfigurationStore extends AutoCloseable {
         return 1 + usedIndexes.stream().max(Comparator.naturalOrder()).orElse(-1);
     }
 
-    default boolean anyPropertyMatches(String regexp) {
+    /**
+     *
+     * @param keyRegexp
+     * @param valueRegexp
+     * @return whether exist at least one property with both key and value matching to passed regexps.
+     */
+    default boolean anyPropertyMatches(String keyRegexp, String valueRegexp) {
         BooleanHolder any = new BooleanHolder(false);
-        this.forEach((k, v) -> {
-            boolean matches = (k + "=" + v).matches(regexp);
-            if (matches) {
+        this.forEach((k, v) -> {            
+            if (k.matches(keyRegexp) && v.matches(valueRegexp)) {
                 any.value = true;                
             }
         });

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationStoreUtils.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationStoreUtils.java
@@ -19,13 +19,9 @@
  */
 package org.carapaceproxy.configstore;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.Key;
 import java.security.KeyFactory;
-import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
@@ -33,12 +29,10 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
+import static org.carapaceproxy.utils.CertificatesUtils.createKeystore;
+import static org.carapaceproxy.utils.CertificatesUtils.readFromKeystore;
 
 public final class ConfigurationStoreUtils {
-
-    public static final String KEYSTORE_FORMAT = "PKCS12";
-    public static final String KEYSTORE_CERT_ALIAS = "cert-chain";
-    static final char[] KEYSTORE_PW = new char[0];
 
     private ConfigurationStoreUtils() {
     }
@@ -94,26 +88,12 @@ public final class ConfigurationStoreUtils {
     }
 
     public static String base64EncodeCertificateChain(Certificate[] chain, PrivateKey key) throws GeneralSecurityException {
-        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
-            KeyStore keyStore = KeyStore.getInstance(KEYSTORE_FORMAT);
-            keyStore.load(null, KEYSTORE_PW);
-            keyStore.setKeyEntry(KEYSTORE_CERT_ALIAS, key, KEYSTORE_PW, chain);
-            keyStore.store(os, KEYSTORE_PW);
-            return Base64.getEncoder().encodeToString(os.toByteArray());
-        } catch (IOException ex) {
-            throw new GeneralSecurityException(ex);
-        }
+        return Base64.getEncoder().encodeToString(createKeystore(chain, key));
     }
 
     public static Certificate[] base64DecodeCertificateChain(String chain) throws GeneralSecurityException {
         byte[] data = Base64.getDecoder().decode(chain);
-        try (ByteArrayInputStream is = new ByteArrayInputStream(data)) {
-            KeyStore keyStore = KeyStore.getInstance(KEYSTORE_FORMAT);
-            keyStore.load(is, KEYSTORE_PW);
-            return keyStore.getCertificateChain(KEYSTORE_CERT_ALIAS);
-        } catch (IOException ex) {
-            throw new GeneralSecurityException(ex);
-        }
+        return readFromKeystore(data);
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/HerdDBConfigurationStore.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/HerdDBConfigurationStore.java
@@ -31,11 +31,14 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -47,6 +50,7 @@ import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64Decode
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64DecodePublicKey;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64EncodeKey;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
+import sun.net.www.content.text.plain;
 
 /**
  * Reads/Write the configuration to a JDBC database. This configuration store is able to track versions of configuration

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/HerdDBConfigurationStore.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/HerdDBConfigurationStore.java
@@ -31,14 +31,11 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -50,7 +47,6 @@ import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64Decode
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64DecodePublicKey;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64EncodeKey;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
-import sun.net.www.content.text.plain;
 
 /**
  * Reads/Write the configuration to a JDBC database. This configuration store is able to track versions of configuration

--- a/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
@@ -404,7 +404,7 @@ public class HttpProxyServer implements AutoCloseable {
             throw new IllegalStateException("server already started");
         }
 
-        readClusterConfiguration(bootConfigurationStore); // need to be always first thing to do (loads cluster setup)        
+        readClusterConfiguration(bootConfigurationStore); // need to be always first thing to do (loads cluster setup)
         String dynamicConfigurationType = bootConfigurationStore.getProperty("config.type", cluster ? "database" : "file");
         switch (dynamicConfigurationType) {
             case "file":
@@ -545,12 +545,12 @@ public class HttpProxyServer implements AutoCloseable {
 
     public RuntimeServerConfiguration buildValidConfiguration(ConfigurationStore simpleStore) throws ConfigurationNotValidException {
         RuntimeServerConfiguration newConfiguration = new RuntimeServerConfiguration();
-        
+
         // Try to perform a service configuration from the passed store.
         newConfiguration.configure(simpleStore);
         buildMapper(newConfiguration.getMapperClassname(), simpleStore);
         buildRealm(userRealmClassname, simpleStore);
-        
+
         return newConfiguration;
     }
 
@@ -560,7 +560,8 @@ public class HttpProxyServer implements AutoCloseable {
 
         // Configuration updating with new certificate (whether not yet existent)
         Properties props = dynamicConfigurationStore.asProperties(null);
-        if (!dynamicConfigurationStore.anyPropertyMatches("certificate\\.[0-9]+\\.hostname", cert.getDomain())) {
+        if (!dynamicConfigurationStore.anyPropertyMatches((k, v) ->
+                 k.matches("certificate\\.[0-9]+\\.hostname") && v.equals(cert.getDomain()))) {
             String prefix = "certificate." + dynamicConfigurationStore.nextIndexFor("certificate") + ".";
             props.setProperty(prefix + "hostname", cert.getDomain());
             props.setProperty(prefix + "mode", cert.isManual() ? "manual" : "acme");

--- a/carapace-server/src/main/java/org/carapaceproxy/server/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/Listeners.java
@@ -127,16 +127,16 @@ public class Listeners {
                 String domain = certificate.getHostname();
                 byte[] keystoreContent = parent.getDynamicCertificateManager().getCertificateForDomain(domain);
                 if (keystoreContent == null) {
-                    throw new ConfigurationNotValidException("Dynamic certificate for domain " + domain + " is not yet available.");
+                    throw new ConfigurationNotValidException("Certificate for domain " + domain + " NOT AVAILABLE.");
                 }
                 LOG.log(Level.SEVERE, "start SSL with dynamic certificate id " + certificate.getId() + ", on listener " + listener.getHost() + ":" + port + " OCPS " + listener.isOcps());
-                keyFactory = initKeyManagerFactory("PKCS12", keystoreContent, "");
+                keyFactory = initKeyManagerFactory("PKCS12", keystoreContent, certificate.getPassword());
             } else {
-                String certificateFile = certificate.getSslCertificateFile();
+                String certificateFile = certificate.getFile();
                 File sslCertFile = certificateFile.startsWith("/") ? new File(certificateFile) : new File(basePath, certificateFile);
                 sslCertFile = sslCertFile.getAbsoluteFile();
                 LOG.log(Level.SEVERE, "start SSL with certificate id " + certificate.getId() + ", on listener " + listener.getHost() + ":" + port + " file=" + sslCertFile + " OCPS " + listener.isOcps());
-                keyFactory = initKeyManagerFactory("PKCS12", sslCertFile, certificate.getSslCertificatePassword());
+                keyFactory = initKeyManagerFactory("PKCS12", sslCertFile, certificate.getPassword());
             }
 
             TrustManagerFactory trustManagerFactory = null;

--- a/carapace-server/src/main/java/org/carapaceproxy/server/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/Listeners.java
@@ -123,15 +123,19 @@ public class Listeners {
 
         try {
             KeyManagerFactory keyFactory;
-            if (certificate.isDynamic()) {
-                String domain = certificate.getHostname();
-                byte[] keystoreContent = parent.getDynamicCertificateManager().getCertificateForDomain(domain);
-                if (keystoreContent == null) {
-                    throw new ConfigurationNotValidException("Certificate for domain " + domain + " NOT AVAILABLE.");
-                }
+            String domain = certificate.getHostname();
+            // Try to find certificate data on db
+            byte[] keystoreContent = parent.getDynamicCertificateManager().getCertificateForDomain(domain);
+            if (keystoreContent != null) {
                 LOG.log(Level.SEVERE, "start SSL with dynamic certificate id " + certificate.getId() + ", on listener " + listener.getHost() + ":" + port + " OCPS " + listener.isOcps());
                 keyFactory = initKeyManagerFactory("PKCS12", keystoreContent, certificate.getPassword());
             } else {
+                if (certificate.isDynamic()) { // fallback to default certificate
+                    certificate = currentConfiguration.getCertificates().get(listener.getDefaultCertificate());
+                    if (certificate == null) {
+                        throw new ConfigurationNotValidException("Unable to boot SSL context for listener " + listener.getHost() + ": no default certificate setup.");
+                    }
+                }
                 String certificateFile = certificate.getFile();
                 File sslCertFile = certificateFile.startsWith("/") ? new File(certificateFile) : new File(basePath, certificateFile);
                 sslCertFile = sslCertFile.getAbsoluteFile();
@@ -274,7 +278,7 @@ public class Listeners {
         }
         return -1;
     }
-    
+
     public ClientConnectionHandler getListenerHandler(HostPort key) {
         return listenersHandlers.get(key);
     }
@@ -374,8 +378,10 @@ public class Listeners {
             this.currentConfiguration = newConfiguration;
             return;
         }
-        // stop dropped listeners, start new one
+        // Clear cached ssl contexts
+        sslContexts.clear();
 
+        // stop dropped listeners, start new one
         List<HostPort> listenersToStop = new ArrayList<>();
         List<HostPort> listenersToStart = new ArrayList<>();
         List<HostPort> listenersToRestart = new ArrayList<>();

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
@@ -37,6 +37,7 @@ import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.carapaceproxy.server.config.RequestFilterConfiguration;
 import org.carapaceproxy.server.config.SSLCertificateConfiguration;
+import org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode;
 import static org.carapaceproxy.server.filters.RequestFilterFactory.buildRequestFilter;
 import org.carapaceproxy.server.mapper.StandardEndpointMapper;
 import org.carapaceproxy.user.SimpleUserRealm;
@@ -177,7 +178,7 @@ public class RuntimeServerConfiguration {
 
     public void setBorrowTimeout(int borrowTimeout) {
         this.borrowTimeout = borrowTimeout;
-    }        
+    }
 
     public long getCacheMaxSize() {
         return cacheMaxSize;
@@ -285,18 +286,24 @@ public class RuntimeServerConfiguration {
 
     private void tryConfigureCertificate(int i, ConfigurationStore properties) throws ConfigurationNotValidException {
         String prefix = "certificate." + i + ".";
-
-        String certificateHostname = properties.getProperty(prefix + "hostname", "");
-
-        if (!certificateHostname.isEmpty()) {
-            String certificateFile = properties.getProperty(prefix + "sslcertfile", "");
-            String certificatePassword = properties.getProperty(prefix + "sslcertfilepassword", "");
-            boolean isDynamic = properties.getProperty(prefix + "dynamic", "false").equalsIgnoreCase("true");
-            LOG.log(Level.INFO, "Configuring SSL certificate {0}hostname={1}, file: {2}", new Object[]{prefix, certificateHostname, certificateFile});
-
-            SSLCertificateConfiguration config = new SSLCertificateConfiguration(certificateHostname, certificateFile, certificatePassword, isDynamic);
-            this.addCertificate(config);
-
+        String hostname = properties.getProperty(prefix + "hostname", "");
+        if (!hostname.isEmpty()) {
+            String file = properties.getProperty(prefix + "file", "");
+            String pw = properties.getProperty(prefix + "password", "");
+            String mode = properties.getProperty(prefix + "mode", "static");
+            try {
+                CertificateMode _mode = CertificateMode.valueOf(mode.toUpperCase());                
+                LOG.log(Level.INFO,
+                        "Configuring SSL certificate {0}: hostname={1}, file={2}, password={3}, mode={4}",
+                        new Object[]{prefix, hostname, file, pw, mode}
+                );
+                SSLCertificateConfiguration config = new SSLCertificateConfiguration(hostname, file, pw, _mode);
+                this.addCertificate(config);
+            } catch (IllegalArgumentException e) {
+                throw new ConfigurationNotValidException(
+                        "Invalid value of '" + mode +  "' for " + prefix + "mode. Supperted ones: static, acme, manual"
+                );
+            }
         }
     }
 

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
@@ -40,7 +40,6 @@ import org.carapaceproxy.server.config.SSLCertificateConfiguration;
 import org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode;
 import static org.carapaceproxy.server.filters.RequestFilterFactory.buildRequestFilter;
 import org.carapaceproxy.server.mapper.StandardEndpointMapper;
-import org.carapaceproxy.user.SimpleUserRealm;
 
 /**
  * Configuration

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certiticates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certiticates/DynamicCertificatesManager.java
@@ -151,7 +151,7 @@ public class DynamicCertificatesManager implements Runnable {
                 if (config.isDynamic()) {
                     String domain = config.getHostname();
                     CertificateData cert = loadOrCreateDynamicCertificateForDomain(domain);
-                    if (MANUAL.equals(config.getMode())) {
+                    if (MANUAL == config.getMode()) {
                         cert.setManual(true);   // in-memory only
                     }
                     _certificates.put(domain, cert);

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certiticates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certiticates/DynamicCertificatesManager.java
@@ -152,7 +152,7 @@ public class DynamicCertificatesManager implements Runnable {
                     String domain = config.getHostname();
                     CertificateData cert = loadOrCreateDynamicCertificateForDomain(domain);
                     if (MANUAL == config.getMode()) {
-                        cert.setManual(true);   // in-memory only
+                        cert.setManual(true);
                     }
                     _certificates.put(domain, cert);
                 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certiticates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certiticates/DynamicCertificatesManager.java
@@ -30,9 +30,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -43,6 +41,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.carapaceproxy.cluster.GroupMembershipHandler;
 import org.carapaceproxy.configstore.CertificateData;
 import org.carapaceproxy.configstore.ConfigurationStore;
@@ -58,6 +57,7 @@ import static org.carapaceproxy.server.certiticates.DynamicCertificateState.VERI
 import static org.carapaceproxy.server.certiticates.DynamicCertificateState.VERIFYING;
 import static org.carapaceproxy.server.certiticates.DynamicCertificateState.WAITING;
 import org.carapaceproxy.server.config.SSLCertificateConfiguration;
+import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.MANUAL;
 import org.glassfish.jersey.internal.guava.ThreadFactoryBuilder;
 import org.shredzone.acme4j.Order;
 import org.shredzone.acme4j.Status;
@@ -150,7 +150,11 @@ public class DynamicCertificatesManager implements Runnable {
                 SSLCertificateConfiguration config = e.getValue();
                 if (config.isDynamic()) {
                     String domain = config.getHostname();
-                    _certificates.put(domain, loadOrCreateDynamicCertificateForDomain(domain));
+                    CertificateData cert = loadOrCreateDynamicCertificateForDomain(domain);
+                    if (MANUAL.equals(config.getMode())) {
+                        cert.setManual(true);   // in-memory only
+                    }
+                    _certificates.put(domain, cert);
                 }
             }
             this.certificates = _certificates; // only certificates/domains specified in the config have to be managed.
@@ -209,9 +213,12 @@ public class DynamicCertificatesManager implements Runnable {
     }
 
     private void certificatesLifecycle() {
-        List<String> domains = new ArrayList(certificates.keySet()); // to get a predictable execution sequence in tests
-        Collections.sort(domains);
-        for (String domain : domains) {
+        List<String> domains = certificates.entrySet().stream()
+                .filter(e -> !e.getValue().isManual())
+                .map(e -> e.getKey())
+                .sorted()
+                .collect(Collectors.toList());
+        for (String domain : domains) {          
             boolean updateDB = true;
             boolean notifyCertAvailChanged = false;
             try {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/SSLCertificateConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/SSLCertificateConfiguration.java
@@ -19,21 +19,27 @@
  */
 package org.carapaceproxy.server.config;
 
+import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.STATIC;
+
 /**
  * Configuration for a TLS Certificate
  *
  * @author enrico.olivelli
  */
-public class SSLCertificateConfiguration {
+public class SSLCertificateConfiguration {   
+
+    public static enum CertificateMode {
+        STATIC, ACME, MANUAL
+    }
 
     private final String id;
     private final String hostname;
-    private final String sslCertificateFile;
-    private final String sslCertificatePassword;
-    private final boolean wildcard;
-    private final boolean dynamic; // true for ACME certificates (p.e. issued by Let's Encrypt).    
-    
-    public SSLCertificateConfiguration(String hostname, String sslCertificateFile, String sslCertificatePassword, boolean dynamic) {
+    private final String file;
+    private final String password;
+    private final boolean wildcard;    
+    private final CertificateMode mode;
+        
+    public SSLCertificateConfiguration(String hostname, String file, String password, CertificateMode mode) {
         this.id = hostname;
         if (hostname.equals("*")) {
             this.hostname = "";
@@ -45,14 +51,10 @@ public class SSLCertificateConfiguration {
             this.hostname = hostname;
             this.wildcard = false;
         }
-        this.sslCertificateFile = sslCertificateFile;
-        this.sslCertificatePassword = sslCertificatePassword;
-        this.dynamic = dynamic;
-    }
-
-    public SSLCertificateConfiguration(String hostname, String sslCertificateFile, String sslCertificatePassword) {
-        this(hostname, sslCertificateFile, sslCertificatePassword, false);
-    }
+        this.file = file;
+        this.password = password;
+        this.mode = mode;
+    }    
 
     public String getId() {
         return id;
@@ -66,16 +68,20 @@ public class SSLCertificateConfiguration {
         return wildcard;
     }
 
-    public String getSslCertificateFile() {
-        return sslCertificateFile;
+    public String getFile() {
+        return file;
     }
 
-    public String getSslCertificatePassword() {
-        return sslCertificatePassword;
+    public String getPassword() {
+        return password;
     }
 
     public boolean isDynamic() {
-        return this.dynamic;
+        return !STATIC.equals(mode);
+    }
+
+    public CertificateMode getMode() {
+        return mode;
     }
 
     @Override

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/SSLCertificateConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/SSLCertificateConfiguration.java
@@ -36,9 +36,9 @@ public class SSLCertificateConfiguration {
     private final String hostname;
     private final String file;
     private final String password;
-    private final boolean wildcard;    
+    private final boolean wildcard;
     private final CertificateMode mode;
-        
+
     public SSLCertificateConfiguration(String hostname, String file, String password, CertificateMode mode) {
         this.id = hostname;
         if (hostname.equals("*")) {

--- a/carapace-server/src/main/java/org/carapaceproxy/utils/CertificatesUtils.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/utils/CertificatesUtils.java
@@ -1,0 +1,89 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package org.carapaceproxy.utils;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+
+/**
+ * Utilitis for Certificates storing as Keystores
+ *
+ * @author paolo
+ */
+public final class CertificatesUtils {
+
+    private static final String KEYSTORE_FORMAT = "PKCS12";
+    private static final String KEYSTORE_CERT_ALIAS = "cert-chain";
+    private static final char[] KEYSTORE_PW = new char[0];
+
+    /**
+     *
+     * @param chain to store into a keystore
+     * @param key private key for the chain
+     * @return keystore data
+     * @throws GeneralSecurityException
+     */
+    public static byte[] createKeystore(Certificate[] chain, PrivateKey key) throws GeneralSecurityException {
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            KeyStore keyStore = KeyStore.getInstance(KEYSTORE_FORMAT);
+            keyStore.load(null, KEYSTORE_PW);
+            keyStore.setKeyEntry(KEYSTORE_CERT_ALIAS, key, KEYSTORE_PW, chain);
+            keyStore.store(os, KEYSTORE_PW);
+            return os.toByteArray();
+        } catch (IOException ex) {
+            throw new GeneralSecurityException(ex);
+        }
+    }
+
+    /**
+     *
+     * @param data keystore data.
+     * @return certificate chain contained into the keystore.
+     * @throws GeneralSecurityException
+     */
+    public static Certificate[] readFromKeystore(byte[] data) throws GeneralSecurityException {
+        try (ByteArrayInputStream is = new ByteArrayInputStream(data)) {
+            KeyStore keyStore = KeyStore.getInstance(KEYSTORE_FORMAT);
+            keyStore.load(is, KEYSTORE_PW);
+            return keyStore.getCertificateChain(KEYSTORE_CERT_ALIAS);
+        } catch (IOException ex) {
+            throw new GeneralSecurityException(ex);
+        }
+    }
+
+    /**
+     *
+     * @param data keystore data.
+     * @return whether a valid keystore can be retrived from data.
+     */
+    public static boolean validateKeystore(byte[] data) {
+        try {
+            Certificate[] chain = readFromKeystore(data);
+            return  chain != null && chain.length > 0;
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+}

--- a/carapace-server/src/main/resources/conf/server.dynamic.properties
+++ b/carapace-server/src/main/resources/conf/server.dynamic.properties
@@ -7,13 +7,12 @@ listener.1.enabled=true
 
 # this is the fallback certificate
 certificate.1.hostname=*
-certificate.1.sslcertfile=conf/localhost.p12
-certificate.1.sslcertfilepassword=testproxy
-certificate.1.dynamic=false
+certificate.1.file=conf/localhost.p12
+certificate.1.password=testproxy
 
 # example of a Dynamic certificate
 #certificate.100.hostname=mypublicdnsname.mycompany.com
-#certificate.100.dynamic=true
+#certificate.100.mode=acme
 
 listener.2.host=0.0.0.0
 listener.2.port=4089

--- a/carapace-server/src/test/java/org/carapaceproxy/SimpleHTTPProxyTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/SimpleHTTPProxyTest.java
@@ -34,6 +34,7 @@ import org.carapaceproxy.client.EndpointKey;
 import org.carapaceproxy.server.HttpProxyServer;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.carapaceproxy.server.config.SSLCertificateConfiguration;
+import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.STATIC;
 import org.carapaceproxy.utils.HttpUtils;
 import org.carapaceproxy.utils.TestEndpointMapper;
 import org.carapaceproxy.utils.TestUtils;
@@ -129,8 +130,7 @@ public class SimpleHTTPProxyTest {
         ConnectionsManagerStats stats;
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot());) {
 
-            server.addCertificate(new SSLCertificateConfiguration("localhost",
-                    certificate, "changeit"));
+            server.addCertificate(new SSLCertificateConfiguration("localhost", certificate, "changeit", STATIC));
             server.addListener(new NetworkListenerConfiguration("localhost", 0,
                     true, false, null, "localhost",
                     cacertificate, "changeit"));

--- a/carapace-server/src/test/java/org/carapaceproxy/api/UseAdminServer.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/UseAdminServer.java
@@ -21,7 +21,6 @@ package org.carapaceproxy.api;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Properties;
 import org.carapaceproxy.configstore.PropertiesConfigurationStore;
 import org.carapaceproxy.server.HttpProxyServer;
@@ -44,11 +43,12 @@ public class UseAdminServer {
 
     public static final String DEFAULT_USERNAME = "admin";
     public static final String DEFAULT_PASSWORD = "admin";
-    
+    public static final int DEFAULT_ADMIN_PORT = 8761;
+
     protected static final Properties HTTP_ADMIN_SERVER_CONFIG = new Properties();
     static {
         HTTP_ADMIN_SERVER_CONFIG.setProperty("http.admin.enabled", "true");
-        HTTP_ADMIN_SERVER_CONFIG.setProperty("http.admin.port", "8761");
+        HTTP_ADMIN_SERVER_CONFIG.setProperty("http.admin.port", DEFAULT_ADMIN_PORT + "");
         HTTP_ADMIN_SERVER_CONFIG.setProperty("http.admin.host", "localhost");
     }
 
@@ -80,7 +80,7 @@ public class UseAdminServer {
         }
 
         fixAccessLogFileConfiguration(properties);
-        
+
         if (server != null) {
             server.configureAtBoot(new PropertiesConfigurationStore(properties));
 
@@ -101,7 +101,7 @@ public class UseAdminServer {
             server.applyDynamicConfigurationFromAPI(config);
         }
     }
-    
+
     private void fixAccessLogFileConfiguration(Properties properties) throws IOException {
         if (!properties.containsKey("admin.accesslog.path")) {
             properties.put("admin.accesslog.path", tmpDir.newFile().getAbsolutePath());

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreTest.java
@@ -80,8 +80,12 @@ public class ConfigurationStoreTest {
             assertEquals(5, store.asProperties(null).size());
             assertEquals(2, store.nextIndexFor("certificate"));
             assertEquals(0, store.nextIndexFor("unknown"));
-            assertEquals(true, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname", d1));
-            assertEquals(false, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname", "unknown"));
+            assertEquals(true, store.anyPropertyMatches(
+                    (k, v) -> k.matches("certificate\\.[0-9]+\\.hostname") && v.equals(d1)
+            ));
+            assertEquals(false, store.anyPropertyMatches(
+                    (k, v) -> k.matches("certificate\\.[0-9]+\\.hostname") && v.equals("unknown")
+            ));
         }
 
         testKeyPairOperations();
@@ -188,8 +192,12 @@ public class ConfigurationStoreTest {
         assertEquals(5, store.asProperties(null).size());
         assertEquals(2, store.nextIndexFor("certificate"));
         assertEquals(0, store.nextIndexFor("unknown"));
-        assertEquals(true, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname", d1));
-        assertEquals(false, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname", "unknown"));
+        assertEquals(true, store.anyPropertyMatches(
+                (k, v) -> k.matches("certificate\\.[0-9]+\\.hostname") && v.equals(d1)
+        ));
+        assertEquals(false, store.anyPropertyMatches(
+                (k, v) -> k.matches("certificate\\.[0-9]+\\.hostname") && v.equals("unknown")
+        ));
 
         // New configuration to apply
         props = new Properties();
@@ -228,9 +236,16 @@ public class ConfigurationStoreTest {
         assertEquals(4, store.asProperties(null).size());
         assertEquals(4, store.nextIndexFor("certificate"));
         assertEquals(0, store.nextIndexFor("unknown"));
-        assertEquals(true, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname", d1));
-        assertEquals(true, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname", d3));
-        assertEquals(false, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname", "unknown"));
+
+        assertEquals(true, store.anyPropertyMatches(
+                (k, v) -> k.matches("certificate\\.[0-9]+\\.hostname") && v.equals(d1)
+        ));
+        assertEquals(true, store.anyPropertyMatches(
+                (k, v) -> k.matches("certificate\\.[0-9]+\\.hostname") && v.equals(d3)
+        ));
+        assertEquals(false, store.anyPropertyMatches(
+                (k, v) -> k.matches("certificate\\.[0-9]+\\.hostname") && v.equals("unknown")
+        ));
     }
 
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreTest.java
@@ -19,13 +19,9 @@
  */
 package org.carapaceproxy.configstore;
 
-import herddb.utils.BooleanHolder;
 import java.net.URL;
 import java.security.KeyPair;
-import java.util.Comparator;
-import java.util.HashSet;
 import java.util.Properties;
-import java.util.Set;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.bookkeeper.stats.NullStatsLogger;
@@ -84,8 +80,8 @@ public class ConfigurationStoreTest {
             assertEquals(5, store.asProperties(null).size());
             assertEquals(2, store.nextIndexFor("certificate"));
             assertEquals(0, store.nextIndexFor("unknown"));
-            assertEquals(true, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname=" + d1));
-            assertEquals(false, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname=unknown"));
+            assertEquals(true, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname", d1));
+            assertEquals(false, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname", "unknown"));
         }
 
         testKeyPairOperations();
@@ -192,8 +188,8 @@ public class ConfigurationStoreTest {
         assertEquals(5, store.asProperties(null).size());
         assertEquals(2, store.nextIndexFor("certificate"));
         assertEquals(0, store.nextIndexFor("unknown"));
-        assertEquals(true, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname=" + d1));
-        assertEquals(false, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname=unknown"));
+        assertEquals(true, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname", d1));
+        assertEquals(false, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname", "unknown"));
 
         // New configuration to apply
         props = new Properties();
@@ -232,9 +228,9 @@ public class ConfigurationStoreTest {
         assertEquals(4, store.asProperties(null).size());
         assertEquals(4, store.nextIndexFor("certificate"));
         assertEquals(0, store.nextIndexFor("unknown"));
-        assertEquals(true, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname=" + d1));
-        assertEquals(true, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname=" + d3));
-        assertEquals(false, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname=unknown"));
+        assertEquals(true, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname", d1));
+        assertEquals(true, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname", d3));
+        assertEquals(false, store.anyPropertyMatches("certificate\\.[0-9]\\.hostname", "unknown"));
     }
 
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/listeners/SSLSNITest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/listeners/SSLSNITest.java
@@ -34,6 +34,7 @@ import org.carapaceproxy.client.ConnectionsManagerStats;
 import org.carapaceproxy.client.EndpointKey;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.carapaceproxy.server.config.SSLCertificateConfiguration;
+import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.STATIC;
 import org.carapaceproxy.utils.RawHttpClient;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -70,8 +71,7 @@ public class SSLSNITest {
         ConnectionsManagerStats stats;
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot());) {
 
-            server.addCertificate(new SSLCertificateConfiguration(nonLocalhost,
-                    certificate, "testproxy"));
+            server.addCertificate(new SSLCertificateConfiguration(nonLocalhost, certificate, "testproxy", STATIC));
 
             server.addListener(new NetworkListenerConfiguration(nonLocalhost, 0,
                     true, false, null, nonLocalhost /* default */,
@@ -108,13 +108,9 @@ public class SSLSNITest {
         ConnectionsManagerStats stats;
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot());) {
 
-            server.addCertificate(new SSLCertificateConfiguration("other",
-                    "cert", "pwd"));
-
-            server.addCertificate(new SSLCertificateConfiguration("*.example.com",
-                    "cert", "pwd"));
-            server.addCertificate(new SSLCertificateConfiguration("www.example.com",
-                    "cert", "pwd"));
+            server.addCertificate(new SSLCertificateConfiguration("other", "cert", "pwd", STATIC));
+            server.addCertificate(new SSLCertificateConfiguration("*.example.com", "cert", "pwd", STATIC));
+            server.addCertificate(new SSLCertificateConfiguration("www.example.com", "cert", "pwd", STATIC));
 
             // client requests bad SNI, bad default in listener
             assertNull(server.getListeners().chooseCertificate("no", "no-default"));
@@ -134,7 +130,7 @@ public class SSLSNITest {
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot());) {
 
             // full wildcard
-            server.addCertificate(new SSLCertificateConfiguration("*", "cert", "pwd"));
+            server.addCertificate(new SSLCertificateConfiguration("*", "cert", "pwd", STATIC));
 
             assertEquals("*", server.getListeners().chooseCertificate(null, "www.example.com").getId());
             assertEquals("*", server.getListeners().chooseCertificate("www.example.com", null).getId());

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheTest.java
@@ -32,6 +32,7 @@ import org.carapaceproxy.client.EndpointKey;
 import org.carapaceproxy.server.HttpProxyServer;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.carapaceproxy.server.config.SSLCertificateConfiguration;
+import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.STATIC;
 import org.carapaceproxy.utils.RawHttpClient;
 import org.carapaceproxy.utils.TestEndpointMapper;
 import org.carapaceproxy.utils.TestUtils;
@@ -220,8 +221,7 @@ public class CacheTest {
 
         ConnectionsManagerStats stats;
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot());) {
-            server.addCertificate(new SSLCertificateConfiguration("localhost",
-                    "localhost.p12", "testproxy"));
+            server.addCertificate(new SSLCertificateConfiguration("localhost", "localhost.p12", "testproxy", STATIC));
             server.addListener(new NetworkListenerConfiguration("localhost", 0,
                     true, false, null, "localhost",
                     null, null));
@@ -246,8 +246,7 @@ public class CacheTest {
 
         ConnectionsManagerStats stats;
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot());) {
-            server.addCertificate(new SSLCertificateConfiguration("localhost",
-                    "localhost.p12", "testproxy"));
+            server.addCertificate(new SSLCertificateConfiguration("localhost", "localhost.p12", "testproxy", STATIC));
             server.addListener(new NetworkListenerConfiguration("localhost", 0,
                     true, false, null, "localhost",
                     null, null));

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certiticates/CertificatesTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certiticates/CertificatesTest.java
@@ -1,0 +1,191 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package org.carapaceproxy.server.certiticates;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.security.KeyPair;
+import java.security.cert.Certificate;
+import java.util.Properties;
+import org.carapaceproxy.api.UseAdminServer;
+import static org.carapaceproxy.server.certiticates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
+import static org.carapaceproxy.utils.CertificatesTestUtils.generateSampleChain;
+import static org.carapaceproxy.utils.CertificatesTestUtils.uploadCertificate;
+import static org.carapaceproxy.utils.CertificatesUtils.createKeystore;
+import org.carapaceproxy.utils.HttpUtils;
+import org.carapaceproxy.utils.RawHttpClient;
+import org.carapaceproxy.utils.RawHttpClient.HttpResponse;
+import org.carapaceproxy.utils.TestUtils;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Rule;
+import org.junit.Test;
+import org.shredzone.acme4j.util.KeyPairUtils;
+
+/**
+ * Test about basic certificate management and client requests.
+ *
+ * @author paolo.venturi
+ */
+public class CertificatesTest extends UseAdminServer {
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(0);
+
+    private Properties config;
+
+    /**
+     * Test case:
+     * - Start server with a default certificate
+     * - Make request expected default certificate
+     *
+     * - Add a manual certificate to config (without upload)
+     * - Make request expected default certificate
+     *
+     * - Upload the certificate
+     * - Make request expected uploaded certificate
+     *
+     * - Update the certificate
+     * - Make request expected updated certificate
+     */
+    @Test
+    public void test() throws Exception {
+
+        configureAndStartServer();
+        int port = server.getLocalPort();
+
+        // Request #0: expected default certificate
+        Certificate[] chain0;
+        try (RawHttpClient client = new RawHttpClient("localhost", port, true, "localhost")) {
+            RawHttpClient.HttpResponse resp = client.get("https://localhost:" + port + "/index.html", credentials);
+            assertEquals("it <b>works</b> !!", resp.getBodyString());
+            chain0 = client.getServerCertificate();
+            assertNotNull(chain0);
+        }
+
+        // Update settings adding manual certificate (but without upload it)
+        config.put("certificate.2.hostname", "localhost");
+        config.put("certificate.2.mode", "manual");
+        changeDynamicConfiguration(config);
+
+        // Request #1: still expected default certificate
+        Certificate[] chain1;
+        try (RawHttpClient client = new RawHttpClient("localhost", port, true, "localhost")) {
+            RawHttpClient.HttpResponse resp = client.get("https://localhost:" + port + "/index.html", credentials);
+            assertEquals("it <b>works</b> !!", resp.getBodyString());
+            chain1 = client.getServerCertificate();
+            assertNotNull(chain1);
+            assertTrue(chain0[0].equals(chain1[0]));
+        }
+
+        // Upload manual certificate
+        Certificate[] uploadedChain;
+        try (RawHttpClient client = new RawHttpClient("localhost", DEFAULT_ADMIN_PORT)) {
+            KeyPair endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
+            uploadedChain = generateSampleChain(endUserKeyPair, false);
+            byte[] chainData = createKeystore(uploadedChain, endUserKeyPair.getPrivate());
+            HttpResponse resp = uploadCertificate("localhost", chainData, client, credentials);
+            assertTrue(resp.getBodyString().contains("SUCCESS: Certificate saved."));
+        }
+
+        // Request #2: expected uploaded certificate
+        Certificate[] chain2;
+        try (RawHttpClient client = new RawHttpClient("localhost", port, true, "localhost")) {
+            RawHttpClient.HttpResponse resp = client.get("https://localhost:" + port + "/index.html", credentials);
+            assertEquals("it <b>works</b> !!", resp.getBodyString());
+            chain2 = client.getServerCertificate();
+            assertNotNull(chain2);
+            assertTrue(uploadedChain[0].equals(chain2[0]));
+        }
+
+        // Update manual certificate
+        Certificate[] uploadedChain2;
+        try (RawHttpClient client = new RawHttpClient("localhost", DEFAULT_ADMIN_PORT)) {
+            KeyPair endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
+            uploadedChain2 = generateSampleChain(endUserKeyPair, false);
+            assertFalse(uploadedChain[0].equals(uploadedChain2[0]));
+            byte[] chainData = createKeystore(uploadedChain2, endUserKeyPair.getPrivate());
+            HttpResponse resp = uploadCertificate("localhost", chainData, client, credentials);
+            assertTrue(resp.getBodyString().contains("SUCCESS: Certificate saved."));
+        }
+
+        // Request #3: expected last uploaded certificate
+        Certificate[] chain3;
+        try (RawHttpClient client = new RawHttpClient("localhost", port, true, "localhost")) {
+            RawHttpClient.HttpResponse resp = client.get("https://localhost:" + port + "/index.html", credentials);
+            assertEquals("it <b>works</b> !!", resp.getBodyString());
+            chain3 = client.getServerCertificate();
+            assertNotNull(chain3);
+            assertTrue(uploadedChain2[0].equals(chain3[0]));
+        }
+    }
+
+    private void configureAndStartServer() throws Exception {
+        HttpUtils.overideJvmWideHttpsVerifier();
+
+        stubFor(get(urlEqualTo("/index.html"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/html")
+                        .withBody("it <b>works</b> !!")));
+
+        config = new Properties(HTTP_ADMIN_SERVER_CONFIG);
+        startServer(config);
+
+        // Default certificate
+        String defaultCertificate = TestUtils.deployResource("localhost.p12", tmpDir.getRoot());
+        config.put("certificate.1.hostname", "*");
+        config.put("certificate.1.file", defaultCertificate);
+        config.put("certificate.1.password", "testproxy");
+
+        // SSL Listener
+        config.put("listener.1.host", "localhost");
+        config.put("listener.1.port", "8443");
+        config.put("listener.1.ssl", "true");
+        config.put("listener.1.ocps", "false");
+        config.put("listener.1.enabled", "true");
+        config.put("listener.1.defaultcertificate", "*");
+
+        // Backend
+        config.put("backend.1.id", "localhost");
+        config.put("backend.1.enabled", "true");
+        config.put("backend.1.host", "localhost");
+        config.put("backend.1.port", wireMockRule.port() + "");
+
+        // Default director
+        config.put("director.1.id", "*");
+        config.put("director.1.backends", "*");
+        config.put("director.1.enabled", "true");
+
+        // Default route
+        config.put("route.100.id", "default");
+        config.put("route.100.enabled", "true");
+        config.put("route.100.match", "all");
+        config.put("route.100.action", "proxy-all");
+
+        changeDynamicConfiguration(config);
+    }
+
+}

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certiticates/DynamicCertificatesManagerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certiticates/DynamicCertificatesManagerTest.java
@@ -71,10 +71,10 @@ public class DynamicCertificatesManagerTest {
 
     @Test
     @Parameters({
-//        "challenge_null",
-//        "challenge_status_invalid",
-//        "order_response_error",
-//        "available_to_expired",
+        "challenge_null",
+        "challenge_status_invalid",
+        "order_response_error",
+        "available_to_expired",
         "all_ok"
     })
     public void testCertificateStateManagement(String runCase) throws Exception {

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certiticates/DynamicCertificatesManagerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certiticates/DynamicCertificatesManagerTest.java
@@ -31,7 +31,6 @@ import org.carapaceproxy.cluster.impl.NullGroupMembershipHandler;
 import org.carapaceproxy.configstore.CertificateData;
 import org.carapaceproxy.configstore.ConfigurationStore;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64EncodeCertificateChain;
-import static org.carapaceproxy.configstore.ConfigurationStoreUtilsTest.generateSampleChain;
 import org.carapaceproxy.configstore.PropertiesConfigurationStore;
 import org.carapaceproxy.server.RuntimeServerConfiguration;
 import static org.carapaceproxy.server.certiticates.DynamicCertificateState.AVAILABLE;
@@ -42,6 +41,7 @@ import static org.carapaceproxy.server.certiticates.DynamicCertificateState.VERI
 import static org.carapaceproxy.server.certiticates.DynamicCertificateState.VERIFYING;
 import static org.carapaceproxy.server.certiticates.DynamicCertificateState.WAITING;
 import static org.carapaceproxy.server.certiticates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
+import static org.carapaceproxy.utils.CertificatesTestUtils.generateSampleChain;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -104,7 +104,7 @@ public class DynamicCertificatesManagerTest {
         man.attachGroupMembershipHandler(new NullGroupMembershipHandler());
         Field client = man.getClass().getDeclaredField("client");
         client.setAccessible(true);
-        client.set(man, ac);        
+        client.set(man, ac);
 
         // Store mocking
         ConfigurationStore s = mock(ConfigurationStore.class);
@@ -123,10 +123,10 @@ public class DynamicCertificatesManagerTest {
         // manual certificate
         String d2 = "notacme";
         CertificateData cd2 = new CertificateData(d2, "", "", AVAILABLE.name(), "", "", true);
-        when(s.loadCertificateForDomain(eq(d2))).thenReturn(cd2);        
+        when(s.loadCertificateForDomain(eq(d2))).thenReturn(cd2);
 
-        man.setConfigurationStore(s);        
-        
+        man.setConfigurationStore(s);
+
         // Manager setup
         Properties props = new Properties();
         props.setProperty("certificate.0.hostname", d0);
@@ -146,9 +146,9 @@ public class DynamicCertificatesManagerTest {
         assertNotNull(man.getCertificateForDomain(d2));
         man.setStateOfCertificate(d2, WAITING); // has not to be renewed by the manager
         assertEquals(WAITING, man.getStateOfCertificate(d2));
-        
+
         int saveCounter = 1; // at every run the certificate has to be saved to the db (whether not AVAILABLE).
-        
+
         // WAITING
         assertEquals(WAITING, man.getStateOfCertificate(d1));
         man.run();
@@ -180,7 +180,7 @@ public class DynamicCertificatesManagerTest {
                 assertEquals(runCase.equals("available_to_expired") ? EXPIRED : AVAILABLE, state);
                 saveCounter += AVAILABLE.equals(state) ? 0 : 1; // only with state AVAILABLE the certificate hasn't to be saved.
                 verify(s, times(saveCounter)).saveCertificate(any());
-                
+
                 man.run();
                 state = man.getStateOfCertificate(d1);
                 assertEquals(runCase.equals("available_to_expired") ? WAITING : AVAILABLE, state);
@@ -189,5 +189,5 @@ public class DynamicCertificatesManagerTest {
             }
         }
     }
-    
+
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/CertificatesTestUtils.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/CertificatesTestUtils.java
@@ -1,0 +1,140 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package org.carapaceproxy.utils;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.Security;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.Random;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import static org.carapaceproxy.server.certiticates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
+import static org.carapaceproxy.utils.CertificatesUtils.createKeystore;
+import org.carapaceproxy.utils.RawHttpClient.BasicAuthCredentials;
+import org.carapaceproxy.utils.RawHttpClient.HttpResponse;
+import org.shredzone.acme4j.util.KeyPairUtils;
+import static org.shredzone.acme4j.util.KeyPairUtils.createKeyPair;
+
+/**
+ *
+ * @author paolo
+ */
+public class CertificatesTestUtils {
+
+    public static Certificate[] generateSampleChain(KeyPair endUserKeypair, boolean expired) throws Exception {
+        Security.addProvider(new BouncyCastleProvider());
+
+        // Create self signed Root CA certificate
+        KeyPair rootCAKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
+        X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                new X500Name("CN=rootCA"), // issuer authority
+                BigInteger.valueOf(new Random().nextInt()), //serial number of certificate
+                new Date(), // start of validity
+                new Date(), //end of certificate validity
+                new X500Name("CN=rootCA"), // subject name of certificate
+                rootCAKeyPair.getPublic()
+        ); // public key of certificate
+
+        // Key usage restrictions
+        builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign));
+        builder.addExtension(Extension.basicConstraints, false, new BasicConstraints(true));
+
+        // Root certificate
+        X509Certificate rootCA = new JcaX509CertificateConverter().getCertificate(builder
+                .build(new JcaContentSignerBuilder("SHA256withRSA").setProvider("BC").
+                        build(rootCAKeyPair.getPrivate()))); // private key of signing authority , here it is self signed
+
+        // Create Intermediate CA cert signed by Root CA
+        KeyPair intermedCAKeyPair = createKeyPair(DEFAULT_KEYPAIRS_SIZE);
+        builder = new JcaX509v3CertificateBuilder(
+                rootCA, // here rootCA is issuer authority
+                BigInteger.valueOf(new Random().nextInt()),
+                new Date(),
+                new Date(),
+                new X500Name("CN=IntermedCA"), intermedCAKeyPair.getPublic());
+
+        // Key usage restrictions
+        builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign));
+        builder.addExtension(Extension.basicConstraints, false, new BasicConstraints(true));
+
+        // Intermediate certificate
+        X509Certificate intermediateCA = new JcaX509CertificateConverter().getCertificate(builder
+                .build(new JcaContentSignerBuilder("SHA256withRSA").setProvider("BC").
+                        build(rootCAKeyPair.getPrivate())));// private key of signing authority , here it is signed by rootCA
+
+        //create end user cert signed by Intermediate CA
+        int offset = 1000 * 60 * 60 * 24; // yesterday/tomorrow
+        Date expiringDate = new Date(System.currentTimeMillis() + (expired ? - offset : + offset));
+        builder = new JcaX509v3CertificateBuilder(
+                intermediateCA, //here intermedCA is issuer authority
+                BigInteger.valueOf(new Random().nextInt()),
+                new Date(System.currentTimeMillis() - offset),
+                expiringDate,
+                new X500Name("CN=endUserCert"), endUserKeypair.getPublic());
+
+        // Key usage restrictions
+        builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature));
+        builder.addExtension(Extension.basicConstraints, false, new BasicConstraints(false));
+
+        // End-user certificate
+        X509Certificate endUserCert = new JcaX509CertificateConverter().getCertificate(builder
+                .build(new JcaContentSignerBuilder("SHA256withRSA").setProvider("BC").
+                        build(intermedCAKeyPair.getPrivate())));// private key of signing authority , here it is signed by intermedCA
+
+        return new X509Certificate [] {
+            endUserCert,
+            intermediateCA,
+            rootCA,
+        };
+    }
+
+    public static byte[] generateSampleChainData() throws Exception {
+        KeyPair endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
+        Certificate[] originalChain = generateSampleChain(endUserKeyPair, false);
+        return createKeystore(originalChain, endUserKeyPair.getPrivate());
+    }
+
+    public static HttpResponse uploadCertificate(String domain, byte[] data, RawHttpClient client, BasicAuthCredentials credentials) throws Exception {
+
+        ByteArrayOutputStream oo = new ByteArrayOutputStream();
+        oo.write(("POST /api/certificates/" + domain + "/upload HTTP/1.1\r\n"
+                + "Host: localhost\r\n"
+                + "Content-Type: application/octet-stream\r\n"
+                + "Content-Length: " + data.length + "\r\n"
+                + "Authorization: Basic " + credentials.toBase64() + "\r\n"
+                + "\r\n").getBytes("ASCII"));
+        oo.write(data);
+
+        return client.executeRequest(new ByteArrayInputStream(oo.toByteArray()));
+    }
+}

--- a/carapace-ui/src/main/webapp/src/components/Certificate.vue
+++ b/carapace-ui/src/main/webapp/src/components/Certificate.vue
@@ -10,6 +10,7 @@
                         <ul class="list-group">
                             <li class="list-group-item"><strong>ID:</strong> {{certificate.id}}</li>
                             <li class="list-group-item"><strong>Hostname:</strong> {{certificate.hostname}}</li>
+                            <li class="list-group-item"><strong>Mode:</strong> {{certificate.mode}}</li>
                             <li class="list-group-item"><strong>Dynamic:</strong> {{certificate.dynamic | symbolFormat}}</li>
                             <li class="list-group-item"><strong>Status:</strong> {{certificate.status}}</li>                            
                             <li class="list-group-item">

--- a/carapace-ui/src/main/webapp/src/components/CertificatesStatus.vue
+++ b/carapace-ui/src/main/webapp/src/components/CertificatesStatus.vue
@@ -12,6 +12,7 @@
                 <tr>
                     <th scope="col">ID</th>
                     <th scope="col">Hostname</th>
+                    <th scope="col">Mode</th>
                     <th scope="col">Dynamic</th>
                     <th scope="col">Status</th>
                     <th scope="col">SSLCertificateFile</th>
@@ -27,6 +28,7 @@
 
                     <td>{{(item.id)}}</td>
                     <td>{{(item.hostname)}}</td>
+                    <td>{{(item.mode)}}</td>
                     <td>{{(item.dynamic) | symbolFormat}}</td>
                     <td>{{(item.status)}}</td>
                     <td>{{(item.sslCertificateFile)}}</td>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <libs.javaxactivation.api>1.2.0</libs.javaxactivation.api>
         <libs.slf4j>1.7.25</libs.slf4j>
         <libs.stringtemplate>4.0.8</libs.stringtemplate>
-        <libs.herddb>0.10.0</libs.herddb>
+        <libs.herddb>0.10.1</libs.herddb>
         <libs.prometheus>0.6.0</libs.prometheus>
         <javacc-maven-plugin.version>2.4</javacc-maven-plugin.version>
     </properties>


### PR DESCRIPTION
New kind of certificate: MANUAL:
* loadble only from api (.p12 file with no pw)
* stored to db but managed by admin (renewal)

ConfigurationStore:
* ability to retrive next available index for a property-name
* check whether a regexp matches with an existing property (key+value)
* get all properties

SSlCertificateConfiguration:
* property sslcertfile renamed to file
* property sslcertfilepassword renamed to password
* property iddynamic removed
* new property mode = acme|static|manual added

Dependecies:
* updated herddb to 0.10.1

Refactoring:
* extract keystore store-load-check methods to CertificateUtils class