### PR TITLE
Better EndpointConnection lifecycle handling:

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/client/EndpointConnection.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/EndpointConnection.java
@@ -26,7 +26,7 @@ import org.carapaceproxy.server.RequestHandler;
 
 /**
  * A Connection to a specific endpoint. Connections are pooled and so they have
- * to be returned to the pool
+ * to be returned to the pool. A connection can be bound to at most one RequestHandler at a time.
  *
  * @author enrico.olivelli
  */
@@ -34,12 +34,30 @@ public interface EndpointConnection {
 
     public EndpointKey getKey();
 
+    /**
+     * Start a requrest.
+     */
     public void sendRequest(HttpRequest request, RequestHandler handler);
 
-    public void release(boolean error, RequestHandler handler);
+    /**
+     * Send other chunks (chunked payload from the client).
+     * @param httpContent
+     * @param handler
+     */
+    public void sendChunk(HttpContent httpContent, RequestHandler handler);
 
+    /**
+     * Client finished its request.
+     * @param msg
+     * @param handler
+     */
     public void sendLastHttpContent(LastHttpContent msg, RequestHandler handler);
 
-    public void sendChunk(HttpContent httpContent, RequestHandler handler);
+    /**
+     * Connection is no more useful for the RequestHandler.
+     * @param forceClose
+     * @param handler
+     */
+    public void release(boolean forceClose, RequestHandler handler);
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/client/EndpointConnection.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/EndpointConnection.java
@@ -35,7 +35,7 @@ public interface EndpointConnection {
     public EndpointKey getKey();
 
     /**
-     * Start a requrest.
+     * Start a request and bind the connection to the RequestHandler.
      */
     public void sendRequest(HttpRequest request, RequestHandler handler);
 

--- a/carapace-server/src/main/java/org/carapaceproxy/client/impl/ConnectionsManagerImpl.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/impl/ConnectionsManagerImpl.java
@@ -241,7 +241,8 @@ public class ConnectionsManagerImpl implements ConnectionsManager, AutoCloseable
         try {
             EndpointConnection result = connections.borrowObject(key, borrowTimeout);
             return result;
-        } catch (NoSuchElementException ex) {
+        } catch (NoSuchElementException | IllegalStateException ex) {
+            // IllegalStateException occurs during service shutdown (pool is closed)
             if (LOG.isLoggable(Level.FINER)) {
                 long delta = System.currentTimeMillis() - _start;
                 LOG.log(Level.FINER,

--- a/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
@@ -210,11 +210,11 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
 
     @Override
     public String toString() {
-        return "ClientConnectionHandler{" + id + ",ka=" + keepAlive + '}';
+        return "ClientConnectionHandler{chid=" + id + ",ka=" + keepAlive + '}';
     }
 
     void addPendingRequest(RequestHandler request) {
         pendingRequests.add(request);
     }
-
+    
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
@@ -263,7 +263,6 @@ public class RequestHandler implements MatchingContext {
     }
 
     void continueClientRequest(HttpContent httpContent) {
-        LOG.log(Level.INFO, "continueClientRequest {0}", this);
         if (cacheSender != null) {
             LOG.log(Level.SEVERE, "{0} swallow chunk {1}, I am serving a cache content {2}", new Object[]{this, httpContent, cacheReceiver});
             return;

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
@@ -206,7 +206,6 @@ public class RequestHandler implements MatchingContext {
             requestsPerUser = USER_REQUESTS_COUNTER.labels("anonymous");
         }
         requestsPerUser.inc();
-        LOG.log(Level.INFO, "start {0}", this);
         if (LOG.isLoggable(Level.FINER)) {
             LOG.log(Level.FINER, "{0} Mapped {1} to {2}, userid {3}", new Object[]{this, uri, action, userId});
         }
@@ -298,7 +297,6 @@ public class RequestHandler implements MatchingContext {
     }
 
     void clientRequestFinished(LastHttpContent trailer) {
-        LOG.log(Level.INFO, "clientRequestFinished {0}", this);
         if (cacheSender != null) {
             serveFromCache();
             return;

--- a/carapace-server/src/test/java/org/carapaceproxy/ConnectionPoolTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/ConnectionPoolTest.java
@@ -52,7 +52,6 @@ import org.carapaceproxy.client.EndpointNotAvailableException;
 import org.carapaceproxy.client.impl.ConnectionsManagerImpl;
 import org.carapaceproxy.client.impl.EndpointConnectionImpl;
 import org.carapaceproxy.configstore.PropertiesConfigurationStore;
-import org.carapaceproxy.server.RuntimeServerConfiguration;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -193,7 +192,7 @@ public class ConnectionPoolTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
 
             // tewaking configuration
-            server.getCurrentConfiguration().setMaxConnectionsPerEndpoint(1);            
+            server.getCurrentConfiguration().setMaxConnectionsPerEndpoint(1);
             server.getCurrentConfiguration().setBorrowTimeout(1000);
             server.getConnectionsManager().applyNewConfiguration(server.getCurrentConfiguration());
             server.start();


### PR DESCRIPTION
- ensure that changes to the state of EndpointConnectionImpl happen inside the Endpoint event loop
- track status of writes to the client in RequestHandler (useful for heapdumps)
- release connection to the endpoint as soon as we receive the LastHttpContent from the backend, this saves resource in case of slow or stuck clients (non writable socket to the client)