### PR TITLE
API improvements to certificate upload function

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -329,9 +329,5 @@
                 </executions>
             </plugin>
         </plugins>
-    </build>
-    <properties>
-        <maven.compiler.source>12</maven.compiler.source>
-        <maven.compiler.target>12</maven.compiler.target>
-    </properties>
+    </build>    
 </project>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -330,5 +330,8 @@
             </plugin>
         </plugins>
     </build>
-
+    <properties>
+        <maven.compiler.source>12</maven.compiler.source>
+        <maven.compiler.target>12</maven.compiler.target>
+    </properties>
 </project>

--- a/carapace-server/src/main/java/org/carapaceproxy/EndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/EndpointMapper.java
@@ -26,7 +26,7 @@ import org.carapaceproxy.client.EndpointKey;
 import org.carapaceproxy.configstore.ConfigurationStore;
 import org.carapaceproxy.server.RequestHandler;
 import org.carapaceproxy.server.backends.BackendHealthManager;
-import org.carapaceproxy.server.certiticates.DynamicCertificatesManager;
+import org.carapaceproxy.server.certificates.DynamicCertificatesManager;
 import org.carapaceproxy.server.config.ActionConfiguration;
 import org.carapaceproxy.server.config.BackendConfiguration;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;

--- a/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
@@ -1,21 +1,21 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 package org.carapaceproxy.api;
 
@@ -36,16 +36,21 @@ import javax.ws.rs.core.Response;
 import org.carapaceproxy.configstore.CertificateData;
 import org.carapaceproxy.server.HttpProxyServer;
 import org.carapaceproxy.server.RuntimeServerConfiguration;
-import org.carapaceproxy.server.certiticates.DynamicCertificateState;
-import static org.carapaceproxy.server.certiticates.DynamicCertificateState.AVAILABLE;
-import static org.carapaceproxy.server.certiticates.DynamicCertificateState.WAITING;
-import org.carapaceproxy.server.certiticates.DynamicCertificatesManager;
+import org.carapaceproxy.server.certificates.DynamicCertificateState;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.AVAILABLE;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.WAITING;
+import org.carapaceproxy.server.certificates.DynamicCertificatesManager;
 import org.carapaceproxy.server.config.SSLCertificateConfiguration;
 import org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode;
-import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.ACME;
 import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.MANUAL;
 import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.STATIC;
+import java.util.Set;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.QueryParam;
 import org.carapaceproxy.utils.CertificatesUtils;
+import static org.carapaceproxy.utils.APIUtils.certificateStateToString;
+import static org.carapaceproxy.utils.APIUtils.certificateModeToString;
+import static org.carapaceproxy.utils.APIUtils.stringToCertificateMode;
 
 /**
  * Access to certificates
@@ -55,6 +60,8 @@ import org.carapaceproxy.utils.CertificatesUtils;
 @Path("/certificates")
 @Produces("application/json")
 public class CertificatesResource {
+
+    public static final Set<DynamicCertificateState> AVAILABLE_CERTIFICATES_STATES_FOR_UPLOAD = Set.of(AVAILABLE, WAITING);
 
     @javax.ws.rs.core.Context
     ServletContext context;
@@ -117,14 +124,14 @@ public class CertificatesResource {
             CertificateBean certBean = new CertificateBean(
                     certificate.getId(),
                     certificate.getHostname(),
-                    stateToStatusString(certificate.getMode()),
+                    certificateModeToString(certificate.getMode()),
                     certificate.isDynamic(),
                     certificate.getFile()
             );
 
             if (certificate.isDynamic()) {
                 DynamicCertificateState state = dynamicCertificateManager.getStateOfCertificate(certBean.getId());
-                certBean.setStatus(stateToStatusString(state));
+                certBean.setStatus(certificateStateToString(state));
             }
             res.put(certificateEntry.getKey(), certBean);
         }
@@ -165,14 +172,14 @@ public class CertificatesResource {
             CertificateBean certBean = new CertificateBean(
                     certificate.getId(),
                     certificate.getHostname(),
-                    stateToStatusString(certificate.getMode()),
+                    certificateModeToString(certificate.getMode()),
                     certificate.isDynamic(),
                     certificate.getFile()
             );
 
             if (certificate.isDynamic()) {
                 DynamicCertificateState state = server.getDynamicCertificateManager().getStateOfCertificate(certBean.getId());
-                certBean.setStatus(stateToStatusString(state));
+                certBean.setStatus(certificateStateToString(state));
             }
             return certBean;
         }
@@ -180,67 +187,39 @@ public class CertificatesResource {
         return null;
     }
 
-    static String stateToStatusString(DynamicCertificateState state) {
-        if (state == null) {
-            return "unknown";
-        }
-        switch (state) {
-            case WAITING:
-                return "waiting"; // certificate waiting for issuing/renews
-            case VERIFYING:
-                return "verifying"; // challenge verification by LE pending
-            case VERIFIED:
-                return "verified"; // challenge succeded
-            case ORDERING:
-                return "ordering"; // certificate order pending
-            case REQUEST_FAILED:
-                return "request failed"; // challenge/order failed
-            case AVAILABLE:
-                return "available";// certificate available(saved) and not expired
-            case EXPIRED:     // certificate expired
-                return "expired";
-            default:
-                return "unknown";
-        }
-    }
-
-    static String stateToStatusString(CertificateMode mode) {
-        if (mode == null) {
-            return "unknown";
-        }
-        switch (mode) {
-            case STATIC:
-                return "static";
-            case ACME:
-                return "acme";
-            case MANUAL:
-                return "manual";
-            default:
-                return "unknown";
-        }
-    }
-
     @POST
     @Path("{domain}/upload")
     @Consumes(MediaType.APPLICATION_OCTET_STREAM)
-    public Response uploadCertificate(@PathParam("domain") String domain, InputStream uploadedInputStream) throws Exception {
+    public Response uploadCertificate(
+            @PathParam("domain") String domain,
+            @QueryParam("type") @DefaultValue("manual") String type,
+            InputStream uploadedInputStream) throws Exception {
 
+        // Certificate type (manual | acme)
+        CertificateMode certType = stringToCertificateMode(type);
+        if (certType == null || STATIC.equals(certType)) {
+            return Response.status(422).entity("ERROR: illegal type of certificate. Available: manual, acme").build();
+        }
+        // Certificate content (optional)
         byte[] data = uploadedInputStream.readAllBytes();
-
-        // Validation
-        if (!CertificatesUtils.validateKeystore(data)) {
+        if (data != null && data.length > 0 && !CertificatesUtils.validateKeystore(data)) {
             return Response.status(422).entity("ERROR: unable to read uploded certificate.").build();
         }
 
-        CertificateData cert = new CertificateData(
-                domain, "", Base64.getEncoder().encodeToString(data), AVAILABLE.name(), "", "", true
-        );
-        cert.setManual(true);
-
+        String encodedData = "";
+        DynamicCertificateState state = WAITING;
+        boolean available = false;
+        if (data != null && data.length > 0) {
+            encodedData = Base64.getEncoder().encodeToString(data);
+            available = true;
+            state = AVAILABLE;
+        }
+        CertificateData cert = new CertificateData(domain, "", encodedData, state, "", "", available);
+        cert.setManual(MANUAL.equals(certType));
         HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
         server.createDynamicCertificateForDomain(cert);
 
-        return Response.status(200).entity("SUCCESS: Certificate saved as manual.").build();
+        return Response.status(200).entity("SUCCESS: Certificate saved.").build();
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
@@ -195,14 +195,14 @@ public class CertificatesResource {
             @QueryParam("type") @DefaultValue("manual") String type,
             InputStream uploadedInputStream) throws Exception {
 
-        try (uploadedInputStream) {
+        try (InputStream input = uploadedInputStream) {
             // Certificate type (manual | acme)
             CertificateMode certType = stringToCertificateMode(type);
             if (certType == null || STATIC.equals(certType)) {
                 return Response.status(422).entity("ERROR: illegal type of certificate. Available: manual, acme").build();
             }
             // Certificate content (optional for acme type)
-            byte[] data = uploadedInputStream.readAllBytes();
+            byte[] data = input.readAllBytes();
             if (MANUAL.equals(certType) && (data == null || data.length == 0)) {
                 return Response.status(422).entity("ERROR: certificate data required for type 'manual'").build();
             }

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
@@ -1,21 +1,21 @@
 /*
- * Licensed to Diennea S.r.l. under one
- * or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. Diennea S.r.l. licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- *
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
  */
 package org.carapaceproxy.configstore;
 

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
@@ -1,27 +1,27 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 package org.carapaceproxy.configstore;
 
 import java.net.URL;
 import java.util.Objects;
-import org.carapaceproxy.server.certiticates.DynamicCertificateState;
+import org.carapaceproxy.server.certificates.DynamicCertificateState;
 import org.shredzone.acme4j.toolbox.JSON;
 
 /**
@@ -35,14 +35,14 @@ public class CertificateData {
     private String domain;
     private String privateKey; // base64 encoded string.
     private String chain; // base64 encoded string of the KeyStore.
-    private String state;
+    private DynamicCertificateState state;
     private String pendingOrderLocation;
     private String pendingChallengeData;
     private boolean available;
     private boolean manual;
 
-    public CertificateData(String domain, String privateKey, String chain, String state,
-            String orderLocation, String challengeData, boolean available) {
+    public CertificateData(String domain, String privateKey, String chain, DynamicCertificateState state,
+                           String orderLocation, String challengeData, boolean available) {
         this.domain = domain;
         this.privateKey = privateKey;
         this.chain = chain;
@@ -64,7 +64,7 @@ public class CertificateData {
         return chain;
     }
 
-    public String getState() {
+    public DynamicCertificateState getState() {
         return state;
     }
 
@@ -90,14 +90,10 @@ public class CertificateData {
 
     public void setChain(String chain) {
         this.chain = chain;
-    }   
-
-    public void setState(String state) {
-        this.state = state;
     }
 
     public void setState(DynamicCertificateState state) {
-        this.state = state.name();
+        this.state = state;
     }
 
     public void setAvailable(boolean available) {

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/HerdDBConfigurationStore.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/HerdDBConfigurationStore.java
@@ -1,21 +1,21 @@
 /*
- * Licensed to Diennea S.r.l. under one
- * or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. Diennea S.r.l. licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- *
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
  */
 package org.carapaceproxy.configstore;
 

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/HerdDBConfigurationStore.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/HerdDBConfigurationStore.java
@@ -1,21 +1,21 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 package org.carapaceproxy.configstore;
 
@@ -46,11 +46,11 @@ import org.apache.bookkeeper.stats.StatsLogger;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64DecodePrivateKey;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64DecodePublicKey;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64EncodeKey;
+import org.carapaceproxy.server.certificates.DynamicCertificateState;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 
 /**
- * Reads/Write the configuration to a JDBC database. This configuration store is able to track versions of configuration
- * properties
+ * Reads/Write the configuration to a JDBC database. This configuration store is able to track versions of configuration properties
  *
  * @author enrico.olivelli
  */
@@ -58,7 +58,7 @@ import org.carapaceproxy.server.config.ConfigurationNotValidException;
 public class HerdDBConfigurationStore implements ConfigurationStore {
 
     private static final int TIMEOUT_WAIT_FOR_TABLE_SPACE = Integer.getInteger("herd.waitfortablespace.timeout", 1000 * 60 * 5); // default 5 min
-    
+
     public static final String ACME_USER_KEY = "_acmeuserkey";
 
     // Main table
@@ -107,7 +107,7 @@ public class HerdDBConfigurationStore implements ConfigurationStore {
     private final HerdDBEmbeddedDataSource datasource;
 
     public HerdDBConfigurationStore(ConfigurationStore staticConfiguration,
-            boolean cluster, String zkAddress, File baseDir, StatsLogger statsLogger) throws ConfigurationNotValidException {
+                                    boolean cluster, String zkAddress, File baseDir, StatsLogger statsLogger) throws ConfigurationNotValidException {
         this.datasource = buildDatasource(staticConfiguration, cluster, zkAddress, baseDir, statsLogger);
         loadCurrentConfiguration();
     }
@@ -134,7 +134,7 @@ public class HerdDBConfigurationStore implements ConfigurationStore {
     }
 
     private HerdDBEmbeddedDataSource buildDatasource(ConfigurationStore staticConfiguration,
-            boolean cluster, String zkAddress, File baseDir, StatsLogger statsLogger) {
+                                                     boolean cluster, String zkAddress, File baseDir, StatsLogger statsLogger) {
         Properties props = new Properties();
 
         if (cluster) {
@@ -149,7 +149,7 @@ public class HerdDBConfigurationStore implements ConfigurationStore {
             props.setProperty(ServerConfiguration.PROPERTY_BOOKKEEPER_WRITEQUORUMSIZE, replication);
 
             props.setProperty(ClientConfiguration.PROPERTY_MODE, ClientConfiguration.PROPERTY_MODE_CLUSTER);
-            props.setProperty(ClientConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, zkAddress);            
+            props.setProperty(ClientConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, zkAddress);
         }
 
         props.setProperty(ServerConfiguration.PROPERTY_BASEDIR, baseDir.getAbsolutePath());
@@ -334,7 +334,8 @@ public class HerdDBConfigurationStore implements ConfigurationStore {
     }
 
     private boolean saveKeyPair(KeyPair pair, String pk, boolean update) {
-        try (Connection con = datasource.getConnection(); PreparedStatement psInsert = con.prepareStatement(INSERT_INTO_KEYPAIR_TABLE); PreparedStatement psUpdate = con.prepareStatement(UPDATE_KEYPAIR_TABLE)) {
+        try (Connection con = datasource.getConnection(); PreparedStatement psInsert = con.prepareStatement(INSERT_INTO_KEYPAIR_TABLE); PreparedStatement psUpdate = con.prepareStatement(
+                UPDATE_KEYPAIR_TABLE)) {
             String privateKey = base64EncodeKey(pair.getPrivate());
             String publicKey = base64EncodeKey(pair.getPublic());
             boolean updateDone = false;
@@ -351,7 +352,7 @@ public class HerdDBConfigurationStore implements ConfigurationStore {
                 return psInsert.executeUpdate() > 0;
             }
             return updateDone;
-        } catch (SQLException e ) {
+        } catch (SQLException e) {
             return false;
         }
     }
@@ -372,7 +373,15 @@ public class HerdDBConfigurationStore implements ConfigurationStore {
                         String pendingOrder = rs.getString(5);
                         String pendigChallenge = rs.getString(6);
                         boolean available = rs.getInt(7) == 1;
-                        return new CertificateData(domain, privateKey, chain, state, pendingOrder, pendigChallenge, available);
+                        return new CertificateData(
+                                domain,
+                                privateKey,
+                                chain,
+                                DynamicCertificateState.fromStorableFormat(state),
+                                pendingOrder,
+                                pendigChallenge,
+                                available
+                        );
                     }
                 }
                 return null;
@@ -391,7 +400,7 @@ public class HerdDBConfigurationStore implements ConfigurationStore {
             String domain = cert.getDomain();
             String privateKey = cert.getPrivateKey();
             String chain = cert.getChain();
-            String state = cert.getState();
+            String state = cert.getState().toStorableFormat();
             String pendingOrder = cert.getPendingOrderLocation();
             String pendigChallenge = cert.getPendingChallengeData();
             int available = cert.isAvailable() ? 1 : 0;

--- a/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
@@ -60,7 +60,7 @@ import org.carapaceproxy.configstore.HerdDBConfigurationStore;
 import org.carapaceproxy.configstore.PropertiesConfigurationStore;
 import org.carapaceproxy.server.backends.BackendHealthManager;
 import org.carapaceproxy.server.cache.ContentsCache;
-import org.carapaceproxy.server.certiticates.DynamicCertificatesManager;
+import org.carapaceproxy.server.certificates.DynamicCertificatesManager;
 import org.carapaceproxy.server.config.ConfigurationChangeInProgressException;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
@@ -32,7 +32,7 @@ import org.carapaceproxy.configstore.ConfigurationStore;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.getClassname;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.getInt;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.getLong;
-import static org.carapaceproxy.server.certiticates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
+import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.carapaceproxy.server.config.RequestFilterConfiguration;

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/ACMEClient.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/ACMEClient.java
@@ -17,7 +17,7 @@
  under the License.
 
  */
-package org.carapaceproxy.server.certiticates;
+package org.carapaceproxy.server.certificates;
 
 import java.io.IOException;
 import java.net.URI;

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificateState.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificateState.java
@@ -17,19 +17,31 @@
  under the License.
 
  */
-package org.carapaceproxy.server.certiticates;
+package org.carapaceproxy.server.certificates;
 
 /**
  *
  * @author paolo.venturi
  */
-public final class DynamicCertificatesManagerException extends RuntimeException {
+public enum DynamicCertificateState {
+    WAITING, // certificate waiting for issuing/renews
+    VERIFYING, // challenge verification by LE pending
+    VERIFIED, // challenge succeded
+    ORDERING, // certificate order pending
+    REQUEST_FAILED, // challenge/order failed
+    AVAILABLE, // certificate available(saved) and not expired
+    EXPIRED; // certificate expired
 
-    public DynamicCertificatesManagerException(String message, Throwable cause) {
-        super(message, cause);
+    public String toStorableFormat() {
+        return this.name();
     }
 
-    public DynamicCertificatesManagerException(String message) {
-        super(message);
+    public static DynamicCertificateState fromStorableFormat(String state) {
+        return DynamicCertificateState.valueOf(state);
+    }
+
+    @Override
+    public String toString() {
+        return super.toString().toLowerCase().replaceAll("_", " ");
     }
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerException.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerException.java
@@ -17,23 +17,19 @@
  under the License.
 
  */
-package org.carapaceproxy.server.certiticates;
+package org.carapaceproxy.server.certificates;
 
 /**
  *
  * @author paolo.venturi
  */
-public enum DynamicCertificateState {
-    WAITING, // certificate waiting for issuing/renews
-    VERIFYING, // challenge verification by LE pending
-    VERIFIED, // challenge succeded
-    ORDERING, // certificate order pending
-    REQUEST_FAILED, // challenge/order failed
-    AVAILABLE, // certificate available(saved) and not expired
-    EXPIRED; // certificate expired
+public final class DynamicCertificatesManagerException extends RuntimeException {
 
-    @Override
-    public String toString() {
-        return super.toString().toLowerCase().replaceAll("_", " ");
+    public DynamicCertificatesManagerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DynamicCertificatesManagerException(String message) {
+        super(message);
     }
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -1,21 +1,21 @@
 /*
- * Licensed to Diennea S.r.l. under one
- * or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. Diennea S.r.l. licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- *
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
  */
 package org.carapaceproxy.server.mapper;
 

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -1,21 +1,21 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 package org.carapaceproxy.server.mapper;
 
@@ -40,13 +40,13 @@ import static org.carapaceproxy.server.StaticContentsManager.DEFAULT_INTERNAL_SE
 import static org.carapaceproxy.server.StaticContentsManager.DEFAULT_NOT_FOUND;
 import static org.carapaceproxy.server.StaticContentsManager.IN_MEMORY_RESOURCE;
 import org.carapaceproxy.server.backends.BackendHealthManager;
+import org.carapaceproxy.server.certificates.DynamicCertificatesManager;
 import org.carapaceproxy.server.config.ActionConfiguration;
 import org.carapaceproxy.server.config.BackendConfiguration;
 import org.carapaceproxy.server.config.BackendSelector;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.config.DirectorConfiguration;
 import static org.carapaceproxy.server.config.DirectorConfiguration.ALL_BACKENDS;
-import org.carapaceproxy.server.certiticates.DynamicCertificatesManager;
 import org.carapaceproxy.server.mapper.requestmatcher.RequestMatcher;
 import org.carapaceproxy.server.config.RouteConfiguration;
 import org.carapaceproxy.server.mapper.requestmatcher.RegexpRequestMatcher;
@@ -331,8 +331,6 @@ public class StandardEndpointMapper extends EndpointMapper {
         routes.add(route);
     }
 
-
-
     @Override
     public Map<String, BackendConfiguration> getBackends() {
         return backends;
@@ -457,12 +455,12 @@ public class StandardEndpointMapper extends EndpointMapper {
                 // none of selected backends available
                 if (!selectedBackends.isEmpty()) {
                     return MapResult.INTERNAL_ERROR(route.getId());
+                }
             }
         }
-        }
         // no one route matched
-            return MapResult.NOT_FOUND(MapResult.NO_ROUTE);
-        }
+        return MapResult.NOT_FOUND(MapResult.NO_ROUTE);
+    }
 
     public String getDefaultNotFoundAction() {
         return defaultNotFoundAction;

--- a/carapace-server/src/main/java/org/carapaceproxy/utils/APIUtils.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/utils/APIUtils.java
@@ -1,21 +1,21 @@
 /*
- * Licensed to Diennea S.r.l. under one
- * or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. Diennea S.r.l. licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- *
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
  */
 package org.carapaceproxy.utils;
 
@@ -37,7 +37,10 @@ import org.carapaceproxy.server.config.SSLCertificateConfiguration;
  *
  * @author paolo.venturi
  */
-public class APIUtils {
+public abstract class APIUtils {
+
+    private APIUtils() {
+    }
 
     /*
      * Utilities for CertificatesResource

--- a/carapace-server/src/main/java/org/carapaceproxy/utils/APIUtils.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/utils/APIUtils.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.carapaceproxy.utils;
+
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.AVAILABLE;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.EXPIRED;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.ORDERING;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.REQUEST_FAILED;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.VERIFIED;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.VERIFYING;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.WAITING;
+import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.ACME;
+import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.MANUAL;
+import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.STATIC;
+import org.carapaceproxy.server.certificates.DynamicCertificateState;
+import org.carapaceproxy.server.config.SSLCertificateConfiguration;
+
+/**
+ * Utilities for the API
+ *
+ * @author paolo.venturi
+ */
+public class APIUtils {
+
+    /*
+     * Utilities for CertificatesResource
+     */
+    public static String certificateStateToString(DynamicCertificateState state) {
+        if (state == null) {
+            return "unknown";
+        }
+        switch (state) {
+            case WAITING:
+                return "waiting"; // certificate waiting for issuing/renews
+            case VERIFYING:
+                return "verifying"; // challenge verification by LE pending
+            case VERIFIED:
+                return "verified"; // challenge succeded
+            case ORDERING:
+                return "ordering"; // certificate order pending
+            case REQUEST_FAILED:
+                return "request failed"; // challenge/order failed
+            case AVAILABLE:
+                return "available";// certificate available(saved) and not expired
+            case EXPIRED:     // certificate expired
+                return "expired";
+            default:
+                return "unknown";
+        }
+    }
+
+    public static DynamicCertificateState stringToCertificateState(String state) {
+        if (state == null) {
+            return null;
+        }
+        switch (state.toLowerCase()) {
+            case "waiting":
+                return WAITING;
+            case "verifying":
+                return VERIFYING;
+            case "verified":
+                return VERIFIED;
+            case "ordering":
+                return ORDERING;
+            case "request failed":
+                return REQUEST_FAILED;
+            case "available":
+                return AVAILABLE;
+            case "expired":
+                return EXPIRED;
+            default:
+                return null;
+        }
+    }
+
+    public static String certificateModeToString(SSLCertificateConfiguration.CertificateMode mode) {
+        if (mode == null) {
+            return "unknown";
+        }
+        switch (mode) {
+            case STATIC:
+                return "static";
+            case ACME:
+                return "acme";
+            case MANUAL:
+                return "manual";
+            default:
+                return "unknown";
+        }
+    }
+
+    public static SSLCertificateConfiguration.CertificateMode stringToCertificateMode(String mode) {
+        if (mode == null) {
+            return null;
+        }
+        switch (mode.toLowerCase()) {
+            case "static":
+                return STATIC;
+            case "acme":
+                return ACME;
+            case "manual":
+                return MANUAL;
+            default:
+                return null;
+        }
+    }
+}

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreTest.java
@@ -25,8 +25,8 @@ import java.util.Properties;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.bookkeeper.stats.NullStatsLogger;
-import org.carapaceproxy.server.certiticates.DynamicCertificateState;
-import static org.carapaceproxy.server.certiticates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
+import org.carapaceproxy.server.certificates.DynamicCertificateState;
+import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import static org.carapaceproxy.utils.TestUtils.assertEqualsKey;
 import org.junit.After;
@@ -127,12 +127,12 @@ public class ConfigurationStoreTest {
 
         // Certificates saving
         CertificateData cert1 = new CertificateData(
-                d1, "encodedPK1", "encodedChain1", DynamicCertificateState.AVAILABLE.name(), order, challenge, true
+                d1, "encodedPK1", "encodedChain1", DynamicCertificateState.AVAILABLE, order, challenge, true
         );
         store.saveCertificate(cert1);
 
         CertificateData cert2 = new CertificateData(
-                d2, "encodedPK2", "encodedChain2", DynamicCertificateState.WAITING.name(), null, null, false
+                d2, "encodedPK2", "encodedChain2", DynamicCertificateState.WAITING, null, null, false
         );
         store.saveCertificate(cert2);
 
@@ -142,7 +142,7 @@ public class ConfigurationStoreTest {
 
         // Cert Updating
         cert1.setAvailable(false);
-        cert1.setState(DynamicCertificateState.WAITING.name());
+        cert1.setState(DynamicCertificateState.WAITING);
         cert1.setPendingOrderLocation(new URL("http://locallhost/updatedorder").toString());
         cert1.setPendingChallengeData(JSON.parse("{\"challenge\": \"updateddata\"}").toString());
         store.saveCertificate(cert1);

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreUtilsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreUtilsTest.java
@@ -29,7 +29,7 @@ import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64Decode
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64DecodePublicKey;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64EncodeCertificateChain;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64EncodeKey;
-import static org.carapaceproxy.server.certiticates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
+import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
 import static org.carapaceproxy.utils.CertificatesTestUtils.generateSampleChain;
 import static org.carapaceproxy.utils.TestUtils.assertEqualsKey;
 import static org.junit.Assert.assertEquals;

--- a/carapace-server/src/test/java/org/carapaceproxy/server/ManagersExecutionTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/ManagersExecutionTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 import org.carapaceproxy.EndpointMapper;
 import org.carapaceproxy.configstore.ConfigurationStore;
 import org.carapaceproxy.server.backends.BackendHealthManager;
-import org.carapaceproxy.server.certiticates.DynamicCertificatesManager;
+import org.carapaceproxy.server.certificates.DynamicCertificatesManager;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
@@ -17,8 +17,11 @@
  under the License.
 
  */
-package org.carapaceproxy.server.certiticates;
+package org.carapaceproxy.server.certificates;
 
+import org.carapaceproxy.server.certificates.ACMEClient;
+import org.carapaceproxy.server.certificates.DynamicCertificatesManager;
+import org.carapaceproxy.server.certificates.DynamicCertificateState;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.security.KeyPair;
@@ -33,14 +36,14 @@ import org.carapaceproxy.configstore.ConfigurationStore;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64EncodeCertificateChain;
 import org.carapaceproxy.configstore.PropertiesConfigurationStore;
 import org.carapaceproxy.server.RuntimeServerConfiguration;
-import static org.carapaceproxy.server.certiticates.DynamicCertificateState.AVAILABLE;
-import static org.carapaceproxy.server.certiticates.DynamicCertificateState.EXPIRED;
-import static org.carapaceproxy.server.certiticates.DynamicCertificateState.ORDERING;
-import static org.carapaceproxy.server.certiticates.DynamicCertificateState.REQUEST_FAILED;
-import static org.carapaceproxy.server.certiticates.DynamicCertificateState.VERIFIED;
-import static org.carapaceproxy.server.certiticates.DynamicCertificateState.VERIFYING;
-import static org.carapaceproxy.server.certiticates.DynamicCertificateState.WAITING;
-import static org.carapaceproxy.server.certiticates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.AVAILABLE;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.EXPIRED;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.ORDERING;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.REQUEST_FAILED;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.VERIFIED;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.VERIFYING;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.WAITING;
+import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
 import static org.carapaceproxy.utils.CertificatesTestUtils.generateSampleChain;
 import static org.junit.Assert.*;
 import org.junit.Test;
@@ -113,16 +116,16 @@ public class DynamicCertificatesManagerTest {
 
         // yet available certificate
         String d0 = "localhost0";
-        CertificateData cd0 = new CertificateData(d0, "", chain, AVAILABLE.name(), "", "", false);
+        CertificateData cd0 = new CertificateData(d0, "", chain, AVAILABLE, "", "", false);
         when(s.loadCertificateForDomain(eq(d0))).thenReturn(cd0);
         // certificate to order
         String d1 = "localhost1";
-        CertificateData cd1 = new CertificateData(d1, "", "", WAITING.name(), "", "", false);
+        CertificateData cd1 = new CertificateData(d1, "", "", WAITING, "", "", false);
         when(s.loadCertificateForDomain(eq(d1))).thenReturn(cd1);
         man.setConfigurationStore(s);
         // manual certificate
         String d2 = "notacme";
-        CertificateData cd2 = new CertificateData(d2, "", "", AVAILABLE.name(), "", "", true);
+        CertificateData cd2 = new CertificateData(d2, "", "", AVAILABLE, "", "", true);
         when(s.loadCertificateForDomain(eq(d2))).thenReturn(cd2);
 
         man.setConfigurationStore(s);

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
@@ -36,7 +36,7 @@ import org.carapaceproxy.server.HttpProxyServer;
 import static org.carapaceproxy.server.RequestHandler.PROPERTY_URI;
 import org.carapaceproxy.server.StaticContentsManager;
 import static org.carapaceproxy.server.StaticContentsManager.CLASSPATH_RESOURCE;
-import org.carapaceproxy.server.certiticates.DynamicCertificatesManager;
+import org.carapaceproxy.server.certificates.DynamicCertificatesManager;
 import org.carapaceproxy.server.config.ActionConfiguration;
 import org.carapaceproxy.server.config.BackendConfiguration;
 import org.carapaceproxy.server.config.DirectorConfiguration;

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/CertificatesTestUtils.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/CertificatesTestUtils.java
@@ -19,7 +19,6 @@
  */
 package org.carapaceproxy.utils;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
@@ -38,7 +37,7 @@ import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
-import static org.carapaceproxy.server.certiticates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
+import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
 import static org.carapaceproxy.utils.CertificatesUtils.createKeystore;
 import org.carapaceproxy.utils.RawHttpClient.BasicAuthCredentials;
 import org.carapaceproxy.utils.RawHttpClient.HttpResponse;
@@ -124,10 +123,10 @@ public class CertificatesTestUtils {
         return createKeystore(originalChain, endUserKeyPair.getPrivate());
     }
 
-    public static HttpResponse uploadCertificate(String domain, byte[] data, RawHttpClient client, BasicAuthCredentials credentials) throws Exception {
-
+    public static HttpResponse uploadCertificate(String domain, String params, byte[] data, RawHttpClient client, BasicAuthCredentials credentials) throws Exception {
         ByteArrayOutputStream oo = new ByteArrayOutputStream();
-        oo.write(("POST /api/certificates/" + domain + "/upload HTTP/1.1\r\n"
+        params = (params == null || params.isEmpty()) ? "" : "?" + params;
+        oo.write(("POST /api/certificates/" + domain + "/upload" + params + " HTTP/1.1\r\n"
                 + "Host: localhost\r\n"
                 + "Content-Type: application/octet-stream\r\n"
                 + "Content-Length: " + data.length + "\r\n"


### PR DESCRIPTION
Improved API for Certficates management with new optional parameter **type** [manual | acme] (default **_manual_**) for function POST _**api/certificates/{domain}/upload**_:

- use _**acme**_ to create an ACME certificate (automatically managed by Carapace)
- use _**manual**_ to create a MANUAL certificate (manage manually)

**Use cases:**

- To simply add an existing certificate to Carapace just make the request with by POSTing the "certificate-data".

- To create a brand new order for an ACME certificate just call _**api/certificates/{domain}/upload?type=acme**_ with no "certificate-data".

- Updating existing certificate is now available, even convert (switch) from _manual_ to _acme_ and vice versa.