### PR TITLE
ClientConnectionHandler metrics #168

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
@@ -147,6 +147,8 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
             if (secure) {
                 detectSSLProperties(ctx);
             }
+            RUNNING_REQUESTS_GAUGE.inc();
+            totalRequests.inc();
             RequestHandler currentRequest = new RequestHandler(requestIdGenerator.incrementAndGet(),
                     request, filters, this, ctx, () -> RUNNING_REQUESTS_GAUGE.dec(), backendHealthManager, requestsLogger);
             addPendingRequest(currentRequest);
@@ -156,8 +158,6 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
             try {
                 RequestHandler currentRequest = pendingRequests.get(0);
                 currentRequest.clientRequestFinished(trailer);
-                totalRequests.inc();
-                RUNNING_REQUESTS_GAUGE.inc();
             } catch (java.lang.ArrayIndexOutOfBoundsException noMorePendingRequests) {
                 LOG.log(Level.INFO, "{0} swallow {1}, no more pending requests", new Object[]{this, msg});
                 refuseOtherRequests = true;


### PR DESCRIPTION
Fix for issue #168 
Increment 'listeners_running_requests' and 'listeners_requests_total' metrics at start of request instead of on LastHttpContent reception.