### PR TITLE
Route error messages customization #185

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/EndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/EndpointMapper.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.carapaceproxy.client.EndpointKey;
 import org.carapaceproxy.configstore.ConfigurationStore;
 import org.carapaceproxy.server.RequestHandler;
+import org.carapaceproxy.server.StaticContentsManager;
 import org.carapaceproxy.server.backends.BackendHealthManager;
 import org.carapaceproxy.server.certificates.DynamicCertificatesManager;
 import org.carapaceproxy.server.config.ActionConfiguration;
@@ -53,12 +54,12 @@ public abstract class EndpointMapper {
 
     public abstract MapResult map(HttpRequest request, String userId, String sessionId, BackendHealthManager backendHealthManager, RequestHandler requestHandler);
 
-    public MapResult mapInternalError(HttpRequest request, String routeid) {
-        return MapResult.INTERNAL_ERROR(routeid);
+    public SimpleHTTPResponse mapPageNotFound(String routeid) {
+        return SimpleHTTPResponse.NOT_FOUND(StaticContentsManager.DEFAULT_NOT_FOUND);
     }
 
-    public MapResult mapPageNotFound(HttpRequest request, String routeid) {
-        return MapResult.NOT_FOUND(routeid);
+    public SimpleHTTPResponse mapInternalError(String routeid) {
+        return SimpleHTTPResponse.INTERNAL_ERROR(StaticContentsManager.DEFAULT_INTERNAL_SERVER_ERROR);
     }
 
     public void endpointFailed(EndpointKey key, Throwable error) {

--- a/carapace-server/src/main/java/org/carapaceproxy/EndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/EndpointMapper.java
@@ -53,11 +53,11 @@ public abstract class EndpointMapper {
 
     public abstract MapResult map(HttpRequest request, String userId, String sessionId, BackendHealthManager backendHealthManager, RequestHandler requestHandler);
 
-    public MapResult mapDefaultInternalError(HttpRequest request, String routeid) {
+    public MapResult mapInternalError(HttpRequest request, String routeid) {
         return MapResult.INTERNAL_ERROR(routeid);
     }
 
-    public MapResult mapDefaultPageNotFound(HttpRequest request, String routeid) {
+    public MapResult mapPageNotFound(HttpRequest request, String routeid) {
         return MapResult.NOT_FOUND(routeid);
     }
 

--- a/carapace-server/src/main/java/org/carapaceproxy/SimpleHTTPResponse.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/SimpleHTTPResponse.java
@@ -19,7 +19,6 @@
  */
 package org.carapaceproxy;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.carapaceproxy.server.mapper.CustomHeader;
@@ -38,7 +37,7 @@ public class SimpleHTTPResponse {
     public SimpleHTTPResponse(int errorcode, String resource, List<CustomHeader> customHeaders) {
         this.errorcode = errorcode;
         this.resource = resource;
-        this.customHeaders = Collections.unmodifiableList(customHeaders == null ? new ArrayList() : customHeaders);
+        this.customHeaders = customHeaders == null ? Collections.emptyList() : Collections.unmodifiableList(customHeaders);
     }
 
     public int getErrorcode() {

--- a/carapace-server/src/main/java/org/carapaceproxy/SimpleHTTPResponse.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/SimpleHTTPResponse.java
@@ -19,6 +19,11 @@
  */
 package org.carapaceproxy;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.carapaceproxy.server.mapper.CustomHeader;
+
 /**
  * Static response to sent to clients.
  *
@@ -28,10 +33,12 @@ public class SimpleHTTPResponse {
 
     private final int errorcode;
     private final String resource;
+    private final List<CustomHeader> customHeaders;
 
-    public SimpleHTTPResponse(int errorcode, String resource) {
+    public SimpleHTTPResponse(int errorcode, String resource, List<CustomHeader> customHeaders) {
         this.errorcode = errorcode;
         this.resource = resource;
+        this.customHeaders = Collections.unmodifiableList(customHeaders == null ? new ArrayList() : customHeaders);
     }
 
     public int getErrorcode() {
@@ -42,17 +49,21 @@ public class SimpleHTTPResponse {
         return resource;
     }
 
+    public List<CustomHeader> getCustomHeaders() {
+        return customHeaders;
+    }
+
     public static final SimpleHTTPResponse NOT_FOUND(String res) {
-        return new SimpleHTTPResponse(404, res);
+        return new SimpleHTTPResponse(404, res, null);
     }
 
     public static final SimpleHTTPResponse INTERNAL_ERROR(String res) {
-        return new SimpleHTTPResponse(500, res);
+        return new SimpleHTTPResponse(500, res, null);
     }
 
     @Override
     public String toString() {
-        return "SimpleHTTPResponse{" + "errorcode=" + errorcode + ", resource=" + resource + '}';
+        return "SimpleHTTPResponse{" + "errorcode=" + errorcode + ", resource=" + resource + ", customHeaders=" + customHeaders + '}';
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/SimpleHTTPResponse.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/SimpleHTTPResponse.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.carapaceproxy;
+
+/**
+ * Static response to sent to clients.
+ *
+ * @author paolo.venturi
+ */
+public class SimpleHTTPResponse {
+
+    private final int errorcode;
+    private final String resource;
+
+    public SimpleHTTPResponse(int errorcode, String resource) {
+        this.errorcode = errorcode;
+        this.resource = resource;
+    }
+
+    public int getErrorcode() {
+        return errorcode;
+    }
+
+    public String getResource() {
+        return resource;
+    }
+
+    public static final SimpleHTTPResponse NOT_FOUND(String res) {
+        return new SimpleHTTPResponse(404, res);
+    }
+
+    public static final SimpleHTTPResponse INTERNAL_ERROR(String res) {
+        return new SimpleHTTPResponse(500, res);
+    }
+
+    @Override
+    public String toString() {
+        return "SimpleHTTPResponse{" + "errorcode=" + errorcode + ", resource=" + resource + '}';
+    }
+
+}

--- a/carapace-server/src/main/java/org/carapaceproxy/api/RoutesResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/RoutesResource.java
@@ -43,12 +43,14 @@ public class RoutesResource {
     public static final class RouteBean {
         private final String id;
         private final String action;
+        private final String errorAction;
         private final boolean enabled;
         private final String matcher;
 
-        public RouteBean(String id, String action, boolean enabled, String matcher) {
+        public RouteBean(String id, String action, String errorAction, boolean enabled, String matcher) {
             this.id = id;
             this.action = action;
+            this.errorAction = errorAction;
             this.enabled = enabled;
             this.matcher = matcher;
         }
@@ -59,6 +61,10 @@ public class RoutesResource {
 
         public String getAction() {
             return action;
+        }
+
+        public String getErrorAction() {
+            return errorAction;
         }
 
         public boolean isEnabled() {
@@ -76,9 +82,14 @@ public class RoutesResource {
         HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
         server.getMapper().getRoutes().stream()
                 .filter(r -> !r.getId().equals(ACME_CHALLENGE_ROUTE_ACTION_ID))
-                .forEach(route -> {            
-            routes.add(new RouteBean(route.getId(), route.getAction(), route.isEnabled(), route.getMatcher().getDescription()));
-        });
+                .forEach(route -> {
+                    routes.add(new RouteBean(
+                            route.getId(),
+                            route.getAction(),
+                            route.getErrorAction(),
+                            route.isEnabled(),
+                            route.getMatcher().getDescription()));
+                });
 
         return routes;
     }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
@@ -107,8 +107,8 @@ public class RequestHandler implements MatchingContext {
     }
 
     public RequestHandler(long id, HttpRequest request, List<RequestFilter> filters,
-            ClientConnectionHandler parent, ChannelHandlerContext channelToClient, Runnable onRequestFinished,
-            BackendHealthManager backendHealthManager, RequestsLogger requestsLogger) {
+                          ClientConnectionHandler parent, ChannelHandlerContext channelToClient, Runnable onRequestFinished,
+                          BackendHealthManager backendHealthManager, RequestsLogger requestsLogger) {
         this.id = id;
         this.uri = request.uri();
         this.request = request;
@@ -233,10 +233,10 @@ public class RequestHandler implements MatchingContext {
             }
             case CACHE: {
                 cacheSender = connectionToClient.cache.serveFromCache(this);
-                    if (cacheSender != null) {
+                if (cacheSender != null) {
                     return;
                 }
-                    EndpointConnection connection;
+                EndpointConnection connection;
                 try {
 //                    LOG.log(Level.SEVERE, "TIME"+TIME_TRACKER.incrementAndGet()+" startc " + this + " thread " + Thread.currentThread().getName());
                     connection = connectionToClient.connectionsManager.getConnection(new EndpointKey(
@@ -348,7 +348,7 @@ public class RequestHandler implements MatchingContext {
     private final StringBuilder output = new StringBuilder();
 
     private void serveNotFoundMessage() {
-        MapResult fromDefault = connectionToClient.mapper.mapDefaultPageNotFound(request, action.routeid);
+        MapResult fromDefault = connectionToClient.mapper.mapPageNotFound(request, action.routeid);
         int code = 0;
         String resource = null;
         if (fromDefault != null) {
@@ -374,7 +374,7 @@ public class RequestHandler implements MatchingContext {
     }
 
     private void serveInternalErrorMessage(boolean forceClose) {
-        MapResult fromDefault = connectionToClient.mapper.mapDefaultInternalError(request, action.routeid);
+        MapResult fromDefault = connectionToClient.mapper.mapInternalError(request, action.routeid);
         int code = 0;
         String resource = null;
         if (fromDefault != null) {
@@ -398,8 +398,7 @@ public class RequestHandler implements MatchingContext {
     }
 
     private void serveStaticMessage() {
-        FullHttpResponse response
-                = connectionToClient.staticContentsManager.buildResponse(action.errorcode, action.resource);
+        FullHttpResponse response = connectionToClient.staticContentsManager.buildResponse(action.errorcode, action.resource);
         addCustomResponseHeaders(response);
         if (!writeSimpleResponse(response)) {
             // If keep-alive is off, close the connection once the content is fully written.
@@ -545,8 +544,7 @@ public class RequestHandler implements MatchingContext {
 
     private void sendServiceNotAvailable() {
 //        LOG.info(this + " sendServiceNotAvailable due to " + cause + " to " + ctx);
-        FullHttpResponse response
-                = connectionToClient.staticContentsManager.buildResponse(500, DEFAULT_INTERNAL_SERVER_ERROR);
+        FullHttpResponse response = connectionToClient.staticContentsManager.buildResponse(500, DEFAULT_INTERNAL_SERVER_ERROR);
         clientState = RequestHandlerState.WRITING;
         channelToClient.writeAndFlush(response).addListener(new GenericFutureListener<Future<? super Void>>() {
             @Override
@@ -597,7 +595,7 @@ public class RequestHandler implements MatchingContext {
     }
 
     public boolean errorSendingRequest(EndpointConnectionImpl connection, Throwable cause) {
-        LOG.log(Level.INFO,"errorSendingRequest to " + connection, cause);
+        LOG.log(Level.INFO, "errorSendingRequest to " + connection, cause);
         boolean ok = releaseConnectionToEndpoint(true, connection);
         if (ok) {
             connectionToClient.errorSendingRequest(this, connection, channelToClient, cause);
@@ -619,7 +617,6 @@ public class RequestHandler implements MatchingContext {
                 cleanResponseForCachedData(httpMessage);
             }
         }
-
 
         // endpoint finished his work, we can release the connection
         if (msg instanceof LastHttpContent) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
@@ -62,6 +62,7 @@ import org.carapaceproxy.server.backends.BackendHealthManager;
 import org.carapaceproxy.server.cache.ContentsCache;
 import org.carapaceproxy.server.filters.UrlEncodedQueryString;
 import static org.carapaceproxy.server.StaticContentsManager.DEFAULT_INTERNAL_SERVER_ERROR;
+import org.carapaceproxy.SimpleHTTPResponse;
 import org.carapaceproxy.server.mapper.CustomHeader.HeaderMode;
 import org.carapaceproxy.server.mapper.requestmatcher.MatchingContext;
 import org.carapaceproxy.utils.PrometheusUtils;
@@ -348,12 +349,12 @@ public class RequestHandler implements MatchingContext {
     private final StringBuilder output = new StringBuilder();
 
     private void serveNotFoundMessage() {
-        MapResult fromDefault = connectionToClient.mapper.mapPageNotFound(request, action.routeid);
+        SimpleHTTPResponse res = connectionToClient.mapper.mapPageNotFound(action.routeid);
         int code = 0;
         String resource = null;
-        if (fromDefault != null) {
-            code = fromDefault.getErrorcode();
-            resource = fromDefault.getResource();
+        if (res != null) {
+            code = res.getErrorcode();
+            resource = res.getResource();
         }
         if (resource == null) {
             resource = StaticContentsManager.DEFAULT_NOT_FOUND;
@@ -374,12 +375,12 @@ public class RequestHandler implements MatchingContext {
     }
 
     private void serveInternalErrorMessage(boolean forceClose) {
-        MapResult fromDefault = connectionToClient.mapper.mapInternalError(request, action.routeid);
+        SimpleHTTPResponse res = connectionToClient.mapper.mapInternalError(action.routeid);
         int code = 0;
         String resource = null;
-        if (fromDefault != null) {
-            code = fromDefault.getErrorcode();
-            resource = fromDefault.getResource();
+        if (res != null) {
+            code = res.getErrorcode();
+            resource = res.getResource();
         }
         if (resource == null) {
             resource = StaticContentsManager.DEFAULT_INTERNAL_SERVER_ERROR;

--- a/carapace-server/src/main/java/org/carapaceproxy/server/StaticContentsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/StaticContentsManager.java
@@ -53,20 +53,15 @@ public class StaticContentsManager {
         if (code <= 0) {
             code = 500;
         }
-        ByteBuf content;
-        if (resource != null) {
-            content = contents.computeIfAbsent(resource, StaticContentsManager::loadResource);
-            content = content.retainedDuplicate();
-        } else {
-            content = null;
-        }
         DefaultFullHttpResponse res;
+        ByteBuf content = resource == null ? null : contents.computeIfAbsent(resource, StaticContentsManager::loadResource);
         if (content != null) {
+            content = content.retainedDuplicate();
             int contentType = content.readableBytes();
             res = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.valueOf(code), content);
             res.headers().set(HttpHeaderNames.CONTENT_LENGTH, contentType);
         } else {
-            res = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.valueOf(code));
+            res = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.valueOf(404));
         }
         res.headers().set(HttpHeaderNames.CACHE_CONTROL, "no-cache");
         return res;

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
@@ -40,7 +40,7 @@ public class ActionConfiguration {
     private final String director;
     private final String file;
     private final int errorcode;
-    private List<CustomHeader> customHeaders = Collections.EMPTY_LIST; // it's a list to keep ordering
+    private List<CustomHeader> customHeaders = Collections.emptyList(); // it's a list to keep ordering
     private String redirectLocation;
     private String redirectProto;
     private String redirectHost;

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
@@ -40,7 +40,7 @@ public class ActionConfiguration {
     private final String director;
     private final String file;
     private final int errorcode;
-    private List<CustomHeader> customHeaders = Collections.emptyList(); // it's a list to keep ordering
+    private List<CustomHeader> customHeaders = Collections.EMPTY_LIST; // it's a list to keep ordering
     private String redirectLocation;
     private String redirectProto;
     private String redirectHost;

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/RouteConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/RouteConfiguration.java
@@ -28,9 +28,10 @@ import org.carapaceproxy.server.RequestHandler;
 public class RouteConfiguration {
 
     private final String id;
-    private final String action;
     private final boolean enabled;
     private final RequestMatcher matcher;
+    private final String action;
+    private String errorAction;
 
     public RouteConfiguration(String id, String action, boolean enabled, RequestMatcher matcher) {
         this.id = id;
@@ -45,6 +46,14 @@ public class RouteConfiguration {
 
     public String getAction() {
         return action;
+    }
+
+    public String getErrorAction() {
+        return errorAction;
+    }
+
+    public void setErrorAction(String errorAction) {
+        this.errorAction = errorAction;
     }
 
     public boolean isEnabled() {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -48,6 +48,7 @@ import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.config.DirectorConfiguration;
 import static org.carapaceproxy.server.config.DirectorConfiguration.ALL_BACKENDS;
 import java.util.Optional;
+import org.carapaceproxy.SimpleHTTPResponse;
 import org.carapaceproxy.server.mapper.requestmatcher.RequestMatcher;
 import org.carapaceproxy.server.config.RouteConfiguration;
 import org.carapaceproxy.server.mapper.requestmatcher.RegexpRequestMatcher;
@@ -475,7 +476,7 @@ public class StandardEndpointMapper extends EndpointMapper {
     }
 
     @Override
-    public MapResult mapInternalError(HttpRequest request, String routeid) {
+    public SimpleHTTPResponse mapInternalError(String routeid) {
         ActionConfiguration errorAction = null;
         // custom for route
         Optional<RouteConfiguration> config = routes.stream().filter(r -> r.getId().equalsIgnoreCase(routeid)).findFirst();
@@ -490,29 +491,23 @@ public class StandardEndpointMapper extends EndpointMapper {
             errorAction = actions.get(defaultInternalErrorAction);
         }
         if (errorAction != null) {
-            return new MapResult(null, 0, Action.INTERNAL_ERROR, routeid)
-                    .setResource(errorAction.getFile())
-                    .setErrorcode(errorAction.getErrorcode())
-                    .setCustomHeaders(errorAction.getCustomHeaders());
+            return new SimpleHTTPResponse(errorAction.getErrorcode(), errorAction.getFile());
         }
         // fallback
-        return super.mapInternalError(request, routeid);
+        return super.mapInternalError(routeid);
     }
 
     @Override
-    public MapResult mapPageNotFound(HttpRequest request, String routeid) {
+    public SimpleHTTPResponse mapPageNotFound(String routeid) {
         // custom global
         if (defaultNotFoundAction != null) {
             ActionConfiguration actionError = actions.get(defaultNotFoundAction);
             if (actionError != null) {
-                return new MapResult(null, 0, Action.NOTFOUND, routeid)
-                        .setResource(actionError.getFile())
-                        .setErrorcode(actionError.getErrorcode())
-                        .setCustomHeaders(actionError.getCustomHeaders());
+                return new SimpleHTTPResponse(actionError.getErrorcode(), actionError.getFile());
             }
         }
         // fallback
-        return super.mapPageNotFound(request, routeid);
+        return super.mapPageNotFound(routeid);
     }
 
     public String getForceDirectorParameter() {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -491,7 +491,7 @@ public class StandardEndpointMapper extends EndpointMapper {
             errorAction = actions.get(defaultInternalErrorAction);
         }
         if (errorAction != null) {
-            return new SimpleHTTPResponse(errorAction.getErrorcode(), errorAction.getFile());
+            return new SimpleHTTPResponse(errorAction.getErrorcode(), errorAction.getFile(), errorAction.getCustomHeaders());
         }
         // fallback
         return super.mapInternalError(routeid);
@@ -501,9 +501,9 @@ public class StandardEndpointMapper extends EndpointMapper {
     public SimpleHTTPResponse mapPageNotFound(String routeid) {
         // custom global
         if (defaultNotFoundAction != null) {
-            ActionConfiguration actionError = actions.get(defaultNotFoundAction);
-            if (actionError != null) {
-                return new SimpleHTTPResponse(actionError.getErrorcode(), actionError.getFile());
+            ActionConfiguration errorAction = actions.get(defaultNotFoundAction);
+            if (errorAction != null) {
+                return new SimpleHTTPResponse(errorAction.getErrorcode(), errorAction.getFile(), errorAction.getCustomHeaders());
             }
         }
         // fallback

--- a/carapace-server/src/main/resources/bin/setenv.sh
+++ b/carapace-server/src/main/resources/bin/setenv.sh
@@ -2,7 +2,7 @@
 
 #JAVA_HOME=
 JDK_JAVA_OPTIONS="--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED"
-JAVA_OPTS="-XX:+UseG1GC -Duser.language=en -Xmx4g -Xms4g -XX:+AggressiveOpts -Djava.net.preferIPv4Stack=true -XX:MaxDirectMemorySize=4g  -Djava.util.logging.config.file=conf/logging.properties"
+JAVA_OPTS="-XX:+UseG1GC -Duser.language=en -Xmx4g -Xms4g -Djava.net.preferIPv4Stack=true -XX:MaxDirectMemorySize=4g  -Djava.util.logging.config.file=conf/logging.properties"
 
 if [ -z "$JAVA_HOME" ]; then
   JAVA_PATH=`which java 2>/dev/null`

--- a/carapace-ui/src/main/webapp/src/components/Routes.vue
+++ b/carapace-ui/src/main/webapp/src/components/Routes.vue
@@ -36,6 +36,7 @@ export default {
                 { key: "id", label: "ID", sortable: true },
                 { key: "matcher", label: "Request Matcher", sortable: true },
                 { key: "action", label: "Action", sortable: true },
+                { key: "errorAction", label: "Error Action", sortable: true },
                 {
                     key: "enabled",
                     label: "Enabled",


### PR DESCRIPTION
- Now it's possible to attach a custom action/message to routes, in order to serve the proper response/code in case of error (see #185).

- Fixed a NPE in response building by static content (now will be return 404 for resources unable to find)

- Added Error-Action column to Routes UI

- Fixed custom headers support for Error Actions