### PR TITLE
Dinamic certs - request the certs before they are expiring #191

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
@@ -55,6 +55,8 @@ import static org.carapaceproxy.utils.APIUtils.stringToCertificateMode;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_DAYS_BEFORE_RENEWAL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Access to certificates
@@ -66,6 +68,7 @@ import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.D
 public class CertificatesResource {
 
     public static final Set<DynamicCertificateState> AVAILABLE_CERTIFICATES_STATES_FOR_UPLOAD = Set.of(AVAILABLE, WAITING);
+    private static final Logger LOG = Logger.getLogger(CertificatesResource.class.getName());
 
     @javax.ws.rs.core.Context
     ServletContext context;
@@ -164,7 +167,7 @@ public class CertificatesResource {
                         }
                     }
                 } catch (GeneralSecurityException e) {
-                    // unable to read the keystore
+                    LOG.log(Level.SEVERE, "Unable to read Keystore for certificate {0}. Reason: {1}", new Object[]{certificate.getId(), e});
                 }
             }
             res.put(certificateEntry.getKey(), certBean);
@@ -229,7 +232,7 @@ public class CertificatesResource {
                         certBean.setDaysBeforeRenewal(cert.getDaysBeforeRenewal() + "");
                     }
                 } catch (GeneralSecurityException e) {
-                    // unable to read the keystore
+                    LOG.log(Level.SEVERE, "Unable to read Keystore for certificate {0}. Reason: {1}", new Object[]{certificate.getId(), e});
                 }
             }
             return certBean;

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
@@ -40,7 +40,7 @@ public class CertificateData {
     private String pendingChallengeData;
     private boolean available;
     private boolean manual;
-    private int daysAdvanceRenewal;
+    private int daysBeforeRenewal;
 
     public CertificateData(String domain, String privateKey, String chain, DynamicCertificateState state,
                            String orderLocation, String challengeData, boolean available) {
@@ -125,24 +125,26 @@ public class CertificateData {
         this.manual = manual;
     }
 
-    public int getDaysAdvanceRenewal() {
-        return daysAdvanceRenewal;
+    public int getDaysBeforeRenewal() {
+        return daysBeforeRenewal;
     }
 
-    public void setDaysAdvanceRenewal(int daysAdvanceRenewal) {
-        this.daysAdvanceRenewal = daysAdvanceRenewal;
+    public void setDaysBeforeRenewal(int daysBeforeRenewal) {
+        this.daysBeforeRenewal = daysBeforeRenewal;
     }
 
     @Override
     public int hashCode() {
-        int hash = 5;
-        hash = 59 * hash + Objects.hashCode(this.domain);
-        hash = 59 * hash + Objects.hashCode(this.privateKey);
-        hash = 59 * hash + Objects.hashCode(this.chain);
-        hash = 59 * hash + Objects.hashCode(this.state);
-        hash = 59 * hash + Objects.hashCode(this.pendingOrderLocation);
-        hash = 59 * hash + Objects.hashCode(this.pendingChallengeData);
-        hash = 59 * hash + (this.available ? 1 : 0);
+        int hash = 7;
+        hash = 89 * hash + Objects.hashCode(this.domain);
+        hash = 89 * hash + Objects.hashCode(this.privateKey);
+        hash = 89 * hash + Objects.hashCode(this.chain);
+        hash = 89 * hash + Objects.hashCode(this.state);
+        hash = 89 * hash + Objects.hashCode(this.pendingOrderLocation);
+        hash = 89 * hash + Objects.hashCode(this.pendingChallengeData);
+        hash = 89 * hash + (this.available ? 1 : 0);
+        hash = 89 * hash + (this.manual ? 1 : 0);
+        hash = 89 * hash + this.daysBeforeRenewal;
         return hash;
     }
 
@@ -161,6 +163,12 @@ public class CertificateData {
         if (this.available != other.available) {
             return false;
         }
+        if (this.manual != other.manual) {
+            return false;
+        }
+        if (this.daysBeforeRenewal != other.daysBeforeRenewal) {
+            return false;
+        }
         if (!Objects.equals(this.domain, other.domain)) {
             return false;
         }
@@ -170,13 +178,13 @@ public class CertificateData {
         if (!Objects.equals(this.chain, other.chain)) {
             return false;
         }
-        if (!Objects.equals(this.state, other.state)) {
-            return false;
-        }
         if (!Objects.equals(this.pendingOrderLocation, other.pendingOrderLocation)) {
             return false;
         }
         if (!Objects.equals(this.pendingChallengeData, other.pendingChallengeData)) {
+            return false;
+        }
+        if (this.state != other.state) {
             return false;
         }
         return true;

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
@@ -40,6 +40,7 @@ public class CertificateData {
     private String pendingChallengeData;
     private boolean available;
     private boolean manual;
+    private int daysAdvanceRenewal;
 
     public CertificateData(String domain, String privateKey, String chain, DynamicCertificateState state,
                            String orderLocation, String challengeData, boolean available) {
@@ -122,6 +123,14 @@ public class CertificateData {
 
     public void setManual(boolean manual) {
         this.manual = manual;
+    }
+
+    public int getDaysAdvanceRenewal() {
+        return daysAdvanceRenewal;
+    }
+
+    public void setDaysAdvanceRenewal(int daysAdvanceRenewal) {
+        this.daysAdvanceRenewal = daysAdvanceRenewal;
     }
 
     @Override

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationStoreUtils.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationStoreUtils.java
@@ -31,7 +31,6 @@ import java.util.Base64;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import static org.carapaceproxy.utils.CertificatesUtils.createKeystore;
 import static org.carapaceproxy.utils.CertificatesUtils.readChainFromKeystore;
-import static org.carapaceproxy.utils.CertificatesUtils.readChainFromKeystore;
 
 public final class ConfigurationStoreUtils {
 
@@ -93,6 +92,9 @@ public final class ConfigurationStoreUtils {
     }
 
     public static Certificate[] base64DecodeCertificateChain(String chain) throws GeneralSecurityException {
+        if (chain == null || chain.isEmpty()) {
+            return null;
+        }
         byte[] data = Base64.getDecoder().decode(chain);
         return readChainFromKeystore(data);
     }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
@@ -582,8 +582,10 @@ public class HttpProxyServer implements AutoCloseable {
 
     private void performUpdate(Properties props, String key, CertificateData cert) {
         props.setProperty(key.replace("hostname", "mode"), cert.isManual() ? "manual" : "acme");
-        if (!cert.isManual()) {
-            props.setProperty(key.replace("hostname", "daysadvancerenewal"), cert.getDaysAdvanceRenewal() + "");
+        if (cert.isManual()) {
+            props.remove(key.replace("hostname", "daysbeforerenewal")); // type changed from acme to manual
+        } else {
+            props.setProperty(key.replace("hostname", "daysbeforerenewal"), cert.getDaysBeforeRenewal() + "");
         }
     }
     private void performCreate(Properties props, CertificateData cert) {
@@ -591,7 +593,7 @@ public class HttpProxyServer implements AutoCloseable {
         props.setProperty(prefix + "hostname", cert.getDomain());
         props.setProperty(prefix + "mode", cert.isManual() ? "manual" : "acme");
         if (!cert.isManual()) {
-            props.setProperty(prefix + "daysadvancerenewal", cert.getDaysAdvanceRenewal() + "");
+            props.setProperty(prefix + "daysbeforerenewal", cert.getDaysBeforeRenewal() + "");
         }
     }
 

--- a/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
@@ -565,21 +565,34 @@ public class HttpProxyServer implements AutoCloseable {
 
         // Configuration updating
         Properties props = dynamicConfigurationStore.asProperties(null);
-        boolean certificateForDomainAvailable = !dynamicConfigurationStore.anyPropertyMatches((k, v) -> {
+        boolean newCertificate = !dynamicConfigurationStore.anyPropertyMatches((k, v) -> {
             if (k.matches("certificate\\.[0-9]+\\.hostname") && v.equals(cert.getDomain())) {
-                props.setProperty(k.replace("hostname", "mode"), cert.isManual() ? "manual" : "acme"); // updating existing certificate with new type
+                performUpdate(props, k, cert); // updating existing certificate
                 return true;
             }
             return false;
         });
-        if (certificateForDomainAvailable) {
-            String prefix = "certificate." + dynamicConfigurationStore.nextIndexFor("certificate") + ".";
-            props.setProperty(prefix + "hostname", cert.getDomain());
-            props.setProperty(prefix + "mode", cert.isManual() ? "manual" : "acme");
+        if (newCertificate) {
+            performCreate(props, cert);
         }
 
         // Configuration reloading
         applyDynamicConfigurationFromAPI(new PropertiesConfigurationStore(props));
+    }
+
+    private void performUpdate(Properties props, String key, CertificateData cert) {
+        props.setProperty(key.replace("hostname", "mode"), cert.isManual() ? "manual" : "acme");
+        if (!cert.isManual()) {
+            props.setProperty(key.replace("hostname", "daysadvancerenewal"), cert.getDaysAdvanceRenewal() + "");
+        }
+    }
+    private void performCreate(Properties props, CertificateData cert) {
+        String prefix = "certificate." + dynamicConfigurationStore.nextIndexFor("certificate") + ".";
+        props.setProperty(prefix + "hostname", cert.getDomain());
+        props.setProperty(prefix + "mode", cert.isManual() ? "manual" : "acme");
+        if (!cert.isManual()) {
+            props.setProperty(prefix + "daysadvancerenewal", cert.getDaysAdvanceRenewal() + "");
+        }
     }
 
     /**

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
@@ -32,6 +32,7 @@ import org.carapaceproxy.configstore.ConfigurationStore;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.getClassname;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.getInt;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.getLong;
+import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_DAYS_ADVANCE_RENEWAL;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
@@ -302,6 +303,7 @@ public class RuntimeServerConfiguration {
             String file = properties.getProperty(prefix + "file", "");
             String pw = properties.getProperty(prefix + "password", "");
             String mode = properties.getProperty(prefix + "mode", "static");
+            int daysAdvanceRenewal = Integer.parseInt(properties.getProperty(prefix + "daysadvancerenewal", DEFAULT_DAYS_ADVANCE_RENEWAL + ""));
             try {
                 CertificateMode _mode = CertificateMode.valueOf(mode.toUpperCase());
                 LOG.log(Level.INFO,
@@ -309,6 +311,7 @@ public class RuntimeServerConfiguration {
                         new Object[]{prefix, hostname, file, pw, mode}
                 );
                 SSLCertificateConfiguration config = new SSLCertificateConfiguration(hostname, file, pw, _mode);
+                config.setDaysAdvanceRenewal(daysAdvanceRenewal);
                 this.addCertificate(config);
             } catch (IllegalArgumentException e) {
                 throw new ConfigurationNotValidException(

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
@@ -32,7 +32,6 @@ import org.carapaceproxy.configstore.ConfigurationStore;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.getClassname;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.getInt;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.getLong;
-import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_DAYS_ADVANCE_RENEWAL;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
@@ -44,6 +43,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import javax.net.ssl.SSLContext;
 import org.carapaceproxy.server.mapper.StandardEndpointMapper;
+import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_DAYS_BEFORE_RENEWAL;
 
 /**
  * Configuration
@@ -303,7 +303,7 @@ public class RuntimeServerConfiguration {
             String file = properties.getProperty(prefix + "file", "");
             String pw = properties.getProperty(prefix + "password", "");
             String mode = properties.getProperty(prefix + "mode", "static");
-            int daysAdvanceRenewal = Integer.parseInt(properties.getProperty(prefix + "daysadvancerenewal", DEFAULT_DAYS_ADVANCE_RENEWAL + ""));
+            int daysBeforeRenewal = Integer.parseInt(properties.getProperty(prefix + "daysbeforerenewal", DEFAULT_DAYS_BEFORE_RENEWAL + ""));
             try {
                 CertificateMode _mode = CertificateMode.valueOf(mode.toUpperCase());
                 LOG.log(Level.INFO,
@@ -311,7 +311,7 @@ public class RuntimeServerConfiguration {
                         new Object[]{prefix, hostname, file, pw, mode}
                 );
                 SSLCertificateConfiguration config = new SSLCertificateConfiguration(hostname, file, pw, _mode);
-                config.setDaysAdvanceRenewal(daysAdvanceRenewal);
+                config.setDaysBeforeRenewal(daysBeforeRenewal);
                 this.addCertificate(config);
             } catch (IllegalArgumentException e) {
                 throw new ConfigurationNotValidException(

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
@@ -311,7 +311,9 @@ public class RuntimeServerConfiguration {
                         new Object[]{prefix, hostname, file, pw, mode}
                 );
                 SSLCertificateConfiguration config = new SSLCertificateConfiguration(hostname, file, pw, _mode);
-                config.setDaysBeforeRenewal(daysBeforeRenewal);
+                if (config.isAcme()) {
+                    config.setDaysBeforeRenewal(daysBeforeRenewal);
+                }
                 this.addCertificate(config);
             } catch (IllegalArgumentException e) {
                 throw new ConfigurationNotValidException(

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
@@ -19,7 +19,6 @@
  */
 package org.carapaceproxy.server.certificates;
 
-import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64DecodeCertificateChain;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64EncodeCertificateChain;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.AVAILABLE;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.EXPIRED;
@@ -48,12 +47,11 @@ import org.carapaceproxy.server.RuntimeServerConfiguration;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.WAITING;
 import org.carapaceproxy.server.config.SSLCertificateConfiguration;
 import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.MANUAL;
+import static org.carapaceproxy.utils.CertificatesUtils.isCertificateExpired;
 import java.io.IOException;
 import java.net.URL;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
-import java.security.cert.CertificateExpiredException;
-import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.logging.Level;
@@ -78,9 +76,11 @@ public class DynamicCertificatesManager implements Runnable {
     public static final String THREAD_NAME = "dynamic-certificates-manager";
 
     // RSA key size of generated key pairs
-    public static final int DEFAULT_KEYPAIRS_SIZE = 2048;
-    private static final Logger LOG = Logger.getLogger(DynamicCertificatesManager.class.getName());
+    public static final int DEFAULT_KEYPAIRS_SIZE = Integer.getInteger("carapace.acme.default.keypairssize", 2048);
+    public static final int DEFAULT_DAYS_ADVANCE_RENEWAL = Integer.getInteger("carapace.acme.default.daysadvancerenewal", 30);
     private static final boolean TESTING_MODE = Boolean.getBoolean("carapace.acme.testmode");
+
+    private static final Logger LOG = Logger.getLogger(DynamicCertificatesManager.class.getName());
     private static final String EVENT_CERT_AVAIL_CHANGED = "certAvailChanged";
 
     private Map<String, CertificateData> certificates = new ConcurrentHashMap();
@@ -167,7 +167,7 @@ public class DynamicCertificatesManager implements Runnable {
                 if (config.isDynamic()) {
                     String domain = config.getHostname();
                     boolean forceManual = MANUAL == config.getMode();
-                    _certificates.put(domain, loadOrCreateDynamicCertificateForDomain(domain, forceManual));
+                    _certificates.put(domain, loadOrCreateDynamicCertificateForDomain(domain, forceManual, config.getDaysAdvanceRenewal()));
                 }
             }
             this.certificates = _certificates; // only certificates/domains specified in the config have to be managed.
@@ -176,12 +176,15 @@ public class DynamicCertificatesManager implements Runnable {
         }
     }
 
-    private CertificateData loadOrCreateDynamicCertificateForDomain(String domain, boolean forceManual) throws GeneralSecurityException, MalformedURLException {
+    private CertificateData loadOrCreateDynamicCertificateForDomain(String domain, boolean forceManual, int daysAdvanceRenewal) throws GeneralSecurityException, MalformedURLException {
         CertificateData cert = store.loadCertificateForDomain(domain);
         if (cert == null) {
             cert = new CertificateData(domain, "", "", WAITING, "", "", false);
         }
         cert.setManual(forceManual);
+        if (!forceManual) { // only for ACME
+            cert.setDaysAdvanceRenewal(daysAdvanceRenewal);
+        }
         return cert;
     }
 
@@ -227,16 +230,17 @@ public class DynamicCertificatesManager implements Runnable {
     }
 
     private void certificatesLifecycle() {
-        List<String> domains = certificates.entrySet().stream()
+        List<CertificateData> _certificates = certificates.entrySet().stream()
                 .filter(e -> !e.getValue().isManual())
-                .map(e -> e.getKey())
-                .sorted()
+                .sorted((e1, e2) -> e1.getKey().compareTo(e2.getKey()))
+                .map(e -> e.getValue())
                 .collect(Collectors.toList());
-        for (String domain : domains) {
+        for (CertificateData data : _certificates) {
             boolean updateDB = true;
             boolean notifyCertAvailChanged = false;
+            final String domain = data.getDomain();
             try {
-                CertificateData cert = loadOrCreateDynamicCertificateForDomain(domain, false);
+                CertificateData cert = loadOrCreateDynamicCertificateForDomain(domain, false, data.getDaysAdvanceRenewal());
                 switch (cert.getState()) {
                     case WAITING: { // certificate waiting to be issues/renew
                         LOG.log(Level.INFO, "Certificate ISSUING process for domain: {0} STARTED.", domain);
@@ -326,7 +330,7 @@ public class DynamicCertificatesManager implements Runnable {
                         break;
                     }
                     case AVAILABLE: { // certificate saved/available/not expired
-                        if (checkCertificateExpired(cert)) {
+                        if (isCertificateExpired(cert)) {
                             cert.setAvailable(false);
                             cert.setState(EXPIRED);
                             notifyCertAvailChanged = true; // all other peers need to know that this cert is expired.
@@ -407,20 +411,6 @@ public class DynamicCertificatesManager implements Runnable {
         }
     }
 
-    public static boolean checkCertificateExpired(CertificateData cert) throws GeneralSecurityException {
-        try {
-            Certificate[] chain = base64DecodeCertificateChain(cert.getChain());
-            if (chain != null && chain.length > 0) {
-                ((X509Certificate) chain[0]).checkValidity();
-            } else {
-                return true;
-            }
-        } catch (CertificateExpiredException | CertificateNotYetValidException ex) {
-            return true;
-        }
-        return false;
-    }
-
     /**
      *
      * @param domain
@@ -475,7 +465,7 @@ public class DynamicCertificatesManager implements Runnable {
                 String domain = entry.getKey();
                 CertificateData cert = entry.getValue();
                 // "manual" flag is not stored in db > has to be re-set from existing config
-                CertificateData freshCert = loadOrCreateDynamicCertificateForDomain(domain, cert.isManual());
+                CertificateData freshCert = loadOrCreateDynamicCertificateForDomain(domain, cert.isManual(), cert.getDaysAdvanceRenewal());
                 _certificates.put(domain, freshCert);
                 LOG.log(Level.INFO, "RELOADED certificate for domain {0}: {1}", new Object[]{domain, freshCert});
             }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/SSLCertificateConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/SSLCertificateConfiguration.java
@@ -38,6 +38,7 @@ public class SSLCertificateConfiguration {
     private final String password;
     private final boolean wildcard;
     private final CertificateMode mode;
+    private int daysAdvanceRenewal;
 
     public SSLCertificateConfiguration(String hostname, String file, String password, CertificateMode mode) {
         this.id = hostname;
@@ -86,6 +87,14 @@ public class SSLCertificateConfiguration {
 
     public boolean isMoreSpecific(SSLCertificateConfiguration other) {
         return hostname.length() > other.getHostname().length();
+    }
+
+    public void setDaysAdvanceRenewal(int daysAdvanceRenewal) {
+        this.daysAdvanceRenewal = daysAdvanceRenewal;
+    }
+
+    public int getDaysAdvanceRenewal() {
+        return daysAdvanceRenewal;
     }
 
     @Override

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/SSLCertificateConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/SSLCertificateConfiguration.java
@@ -38,7 +38,7 @@ public class SSLCertificateConfiguration {
     private final String password;
     private final boolean wildcard;
     private final CertificateMode mode;
-    private int daysAdvanceRenewal;
+    private int daysBeforeRenewal;
 
     public SSLCertificateConfiguration(String hostname, String file, String password, CertificateMode mode) {
         this.id = hostname;
@@ -89,12 +89,12 @@ public class SSLCertificateConfiguration {
         return hostname.length() > other.getHostname().length();
     }
 
-    public void setDaysAdvanceRenewal(int daysAdvanceRenewal) {
-        this.daysAdvanceRenewal = daysAdvanceRenewal;
+    public int getDaysBeforeRenewal() {
+        return daysBeforeRenewal;
     }
 
-    public int getDaysAdvanceRenewal() {
-        return daysAdvanceRenewal;
+    public void setDaysBeforeRenewal(int daysBeforeRenewal) {
+        this.daysBeforeRenewal = daysBeforeRenewal;
     }
 
     @Override

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/SSLCertificateConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/SSLCertificateConfiguration.java
@@ -19,6 +19,7 @@
  */
 package org.carapaceproxy.server.config;
 
+import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.ACME;
 import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.STATIC;
 
 /**
@@ -79,6 +80,10 @@ public class SSLCertificateConfiguration {
 
     public boolean isDynamic() {
         return !STATIC.equals(mode);
+    }
+
+    public boolean isAcme() {
+        return ACME.equals(mode);
     }
 
     public CertificateMode getMode() {

--- a/carapace-server/src/main/java/org/carapaceproxy/utils/CertificatesUtils.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/utils/CertificatesUtils.java
@@ -123,7 +123,7 @@ public final class CertificatesUtils {
             if (chain != null && chain.length > 0) {
                 Calendar cal = Calendar.getInstance();
                 cal.setTime(new Date());
-                cal.add(Calendar.DATE, cert.getDaysAdvanceRenewal());
+                cal.add(Calendar.DATE, cert.getDaysBeforeRenewal());
                 ((X509Certificate) chain[0]).checkValidity(cal.getTime());
             } else {
                 return true;

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesTest.java
@@ -24,6 +24,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.carapaceproxy.api.UseAdminServer.DEFAULT_ADMIN_PORT;
+import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_DAYS_ADVANCE_RENEWAL;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
 import static org.carapaceproxy.utils.CertificatesTestUtils.generateSampleChain;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -277,6 +278,49 @@ public class CertificatesTest extends UseAdminServer {
     }
 
     @Test
+    @Parameters({"acme", "manual"})
+    public void testUploadTypedCertificatesWithDaysAdvanceRenewal(String type) throws Exception {
+        configureAndStartServer();
+        int port = server.getLocalPort();
+        DynamicCertificatesManager dynCertsMan = server.getDynamicCertificatesManager();
+        KeyPair endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
+        Certificate[] chain = generateSampleChain(endUserKeyPair, false);
+        byte[] chainData = createKeystore(chain, endUserKeyPair.getPrivate());
+
+        try (RawHttpClient client = new RawHttpClient("localhost", DEFAULT_ADMIN_PORT)) {
+            // Create
+            HttpResponse resp = uploadCertificate("localhost2", "type=" + type + "&daysadvancerenewal=10", chainData, client, credentials);
+            if (type.equals("manual")) {
+                assertTrue(resp.getBodyString().contains("ERROR: param 'daysadvancerenewal' available for type 'acme' only"));
+            } else {
+                CertificateData data = dynCertsMan.getCertificateDataForDomain("localhost2");
+                assertNotNull(data);
+                assertEquals(10, data.getDaysAdvanceRenewal());
+            }
+            // default value
+            uploadCertificate("localhost-default", "type=" + type, chainData, client, credentials);
+            CertificateData data = dynCertsMan.getCertificateDataForDomain("localhost-default");
+            assertNotNull(data);
+            assertEquals(type.equals("manual") ? 0 : DEFAULT_DAYS_ADVANCE_RENEWAL, data.getDaysAdvanceRenewal());
+
+            // Update
+            uploadCertificate("localhost2", "type=" + type + "&daysadvancerenewal=45", chainData, client, credentials);
+            if (type.equals("manual")) {
+                assertTrue(resp.getBodyString().contains("ERROR: param 'daysadvancerenewal' available for type 'acme' only"));
+            } else {
+                data = dynCertsMan.getCertificateDataForDomain("localhost2");
+                assertNotNull(data);
+                assertEquals(45, data.getDaysAdvanceRenewal());
+            }
+            // default value
+            uploadCertificate("localhost2", "type=" + type, chainData, client, credentials);
+            data = dynCertsMan.getCertificateDataForDomain("localhost2");
+            assertNotNull(data);
+            assertEquals(type.equals("manual") ? 0 : DEFAULT_DAYS_ADVANCE_RENEWAL, data.getDaysAdvanceRenewal());
+        }
+    }
+
+    @Test
     public void testOCSP() throws Exception {
         configureAndStartServer();
         int port = server.getLocalPort();
@@ -348,13 +392,14 @@ public class CertificatesTest extends UseAdminServer {
         Certificate[] chain1 = generateSampleChain(endUserKeyPair, false);
         try (RawHttpClient client = new RawHttpClient("localhost", DEFAULT_ADMIN_PORT)) {
             byte[] chainData = createKeystore(chain1, endUserKeyPair.getPrivate());
-            HttpResponse resp = uploadCertificate("localhost", "type=acme", chainData, client, credentials);
+            HttpResponse resp = uploadCertificate("localhost", "type=acme&daysadvancerenewal=45", chainData, client, credentials);
             assertTrue(resp.getBodyString().contains("SUCCESS"));
             CertificateData data = dcMan.getCertificateDataForDomain("localhost");
             assertNotNull(data);
             assertTrue(data.isAvailable());
-            assertEquals(DynamicCertificateState.AVAILABLE, dcMan.getStateOfCertificate("localhost"));
-
+            assertEquals(DynamicCertificateState.AVAILABLE, data.getState());
+            assertEquals(45, data.getDaysAdvanceRenewal());
+            assertFalse(data.isManual());
             // check uploaded certificate
             try (RawHttpClient c = new RawHttpClient("localhost", port, true, "localhost")) {
                 RawHttpClient.HttpResponse r = c.get("https://localhost:" + port + "/index.html", credentials);
@@ -377,7 +422,7 @@ public class CertificatesTest extends UseAdminServer {
         store.saveCertificate(cert);
         assertEquals(DynamicCertificateState.ORDERING, dcMan.getStateOfCertificate("localhost"));
 
-        // ACME mocking        
+        // ACME mocking
         ACMEClient ac = mock(ACMEClient.class);
         Order o = mock(Order.class);
         when(ac.getLogin()).thenReturn(mock(Login.class));
@@ -390,7 +435,12 @@ public class CertificatesTest extends UseAdminServer {
 
         // Renew
         dcMan.run();
-        assertEquals(DynamicCertificateState.AVAILABLE, dcMan.getStateOfCertificate("localhost"));
+        CertificateData updated = dcMan.getCertificateDataForDomain("localhost");
+        assertNotNull(updated);
+        assertTrue(updated.isAvailable());
+        assertEquals(DynamicCertificateState.AVAILABLE, updated.getState());
+        assertEquals(45, updated.getDaysAdvanceRenewal());
+        assertFalse(updated.isManual());
 
         // Check renewed certificate
         try (RawHttpClient cl = new RawHttpClient("localhost", port, true, "localhost")) {

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesTest.java
@@ -76,6 +76,7 @@ import org.shredzone.acme4j.Login;
 import org.shredzone.acme4j.Order;
 import org.shredzone.acme4j.util.KeyPairUtils;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_DAYS_BEFORE_RENEWAL;
+import org.carapaceproxy.server.config.SSLCertificateConfiguration;
 
 /**
  * Test use cases for basic certificates management and client requests.
@@ -337,6 +338,16 @@ public class CertificatesTest extends UseAdminServer {
             data = dynCertsMan.getCertificateDataForDomain("localhost2");
             assertNotNull(data);
             assertEquals(other.equals("manual") ? 0 : DEFAULT_DAYS_BEFORE_RENEWAL, data.getDaysBeforeRenewal());
+            SSLCertificateConfiguration config = server.getCurrentConfiguration().getCertificates().get("localhost2");
+            assertEquals(other.equals("manual") ? 0 : DEFAULT_DAYS_BEFORE_RENEWAL, config.getDaysBeforeRenewal());
+            // checking for "certificate.X.daysbeforerenewal" property delete
+            ConfigurationStore store = server.getDynamicConfigurationStore();
+            assertEquals(other.equals("acme"), store.anyPropertyMatches((k, v) -> {
+                if (k.matches("certificate\\.[0-9]+\\.hostname") && v.equals("localhost2")) {
+                    return store.getProperty(k.replace("hostname", "daysbeforerenewal"), null) != null;
+                }
+                return false;
+            }));
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesUtilsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesUtilsTest.java
@@ -33,6 +33,8 @@ import java.util.Arrays;
 import org.junit.Test;
 import org.shredzone.acme4j.util.KeyPairUtils;
 import static org.carapaceproxy.utils.CertificatesUtils.compareChains;
+import org.carapaceproxy.configstore.CertificateData;
+import org.carapaceproxy.utils.CertificatesUtils;
 
 /**
  *
@@ -63,5 +65,33 @@ public class CertificatesUtilsTest {
         KeyPair endUserKeyPair2 = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
         Certificate[] otherChain = generateSampleChain(endUserKeyPair2, false);
         assertFalse(compareChains(originalChain, otherChain));
+    }
+
+    @Test
+    public void testCertificatesExpiration() throws Exception {
+        {
+            KeyPair endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
+            Certificate[] chain = generateSampleChain(endUserKeyPair, false); // not before == not after == today
+            String encodedChain = base64EncodeCertificateChain(chain, endUserKeyPair.getPrivate());
+            CertificateData cert = new CertificateData("localhost", null, encodedChain, DynamicCertificateState.AVAILABLE, null, null, true);
+            cert.setDaysAdvanceRenewal(0);
+            assertFalse(CertificatesUtils.isCertificateExpired(cert));
+            cert.setDaysAdvanceRenewal(-30);
+            assertTrue(CertificatesUtils.isCertificateExpired(cert)); // not before
+            cert.setDaysAdvanceRenewal(30);
+            assertTrue(CertificatesUtils.isCertificateExpired(cert)); // not after
+        }
+        {
+            KeyPair endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
+            Certificate[] chain = generateSampleChain(endUserKeyPair, true); // not before == not after == today
+            String encodedChain = base64EncodeCertificateChain(chain, endUserKeyPair.getPrivate());
+            CertificateData cert = new CertificateData("localhost", null, encodedChain, DynamicCertificateState.AVAILABLE, null, null, true);
+            cert.setDaysAdvanceRenewal(0);
+            assertTrue(CertificatesUtils.isCertificateExpired(cert));
+            cert.setDaysAdvanceRenewal(-30);
+            assertTrue(CertificatesUtils.isCertificateExpired(cert)); // not before
+            cert.setDaysAdvanceRenewal(30);
+            assertTrue(CertificatesUtils.isCertificateExpired(cert)); // not after
+        }
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesUtilsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesUtilsTest.java
@@ -74,11 +74,11 @@ public class CertificatesUtilsTest {
             Certificate[] chain = generateSampleChain(endUserKeyPair, false); // not before == not after == today
             String encodedChain = base64EncodeCertificateChain(chain, endUserKeyPair.getPrivate());
             CertificateData cert = new CertificateData("localhost", null, encodedChain, DynamicCertificateState.AVAILABLE, null, null, true);
-            cert.setDaysAdvanceRenewal(0);
+            cert.setDaysBeforeRenewal(0);
             assertFalse(CertificatesUtils.isCertificateExpired(cert));
-            cert.setDaysAdvanceRenewal(-30);
+            cert.setDaysBeforeRenewal(-30);
             assertTrue(CertificatesUtils.isCertificateExpired(cert)); // not before
-            cert.setDaysAdvanceRenewal(30);
+            cert.setDaysBeforeRenewal(30);
             assertTrue(CertificatesUtils.isCertificateExpired(cert)); // not after
         }
         {
@@ -86,11 +86,11 @@ public class CertificatesUtilsTest {
             Certificate[] chain = generateSampleChain(endUserKeyPair, true); // not before == not after == today
             String encodedChain = base64EncodeCertificateChain(chain, endUserKeyPair.getPrivate());
             CertificateData cert = new CertificateData("localhost", null, encodedChain, DynamicCertificateState.AVAILABLE, null, null, true);
-            cert.setDaysAdvanceRenewal(0);
+            cert.setDaysBeforeRenewal(0);
             assertTrue(CertificatesUtils.isCertificateExpired(cert));
-            cert.setDaysAdvanceRenewal(-30);
+            cert.setDaysBeforeRenewal(-30);
             assertTrue(CertificatesUtils.isCertificateExpired(cert)); // not before
-            cert.setDaysAdvanceRenewal(30);
+            cert.setDaysBeforeRenewal(30);
             assertTrue(CertificatesUtils.isCertificateExpired(cert)); // not after
         }
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
@@ -132,13 +132,13 @@ public class DynamicCertificatesManagerTest {
         Properties props = new Properties();
         props.setProperty("certificate.0.hostname", d0);
         props.setProperty("certificate.0.mode", "acme");
-        props.setProperty("certificate.0.daysadvancerenewal", "0");
+        props.setProperty("certificate.0.daysbeforerenewal", "0");
         props.setProperty("certificate.1.hostname", d1);
         props.setProperty("certificate.1.mode", "acme");
-        props.setProperty("certificate.1.daysadvancerenewal", "0");
+        props.setProperty("certificate.1.daysbeforerenewal", "0");
         props.setProperty("certificate.2.hostname", d2);
         props.setProperty("certificate.2.mode", "manual");
-        props.setProperty("certificate.2.daysadvancerenewal", "0");
+        props.setProperty("certificate.2.daysbeforerenewal", "0");
         ConfigurationStore configStore = new PropertiesConfigurationStore(props);
         RuntimeServerConfiguration conf = new RuntimeServerConfiguration();
         conf.configure(configStore);

--- a/carapace-ui/src/main/webapp/src/components/Certificate.vue
+++ b/carapace-ui/src/main/webapp/src/components/Certificate.vue
@@ -9,7 +9,9 @@
                         <li class="list-group-item"><strong>Hostname:</strong> {{certificate.hostname}}</li>
                         <li class="list-group-item"><strong>Mode:</strong> {{certificate.mode}}</li>
                         <li class="list-group-item"><strong>Dynamic:</strong> {{certificate.dynamic | symbolFormat}}</li>
-                        <li class="list-group-item"><strong>Status:</strong> {{certificate.status}}</li>                        
+                        <li class="list-group-item"><strong>Status:</strong> {{certificate.status}}</li>
+                        <li v-if="certificate.dynamic" class="list-group-item"><strong>Expiring Date:</strong> {{certificate.expiringDate}}</li>
+                        <li v-if="certificate.mode == 'acme'" class="list-group-item"><strong>Advance Renewal (days):</strong> {{certificate.daysAdvanceRenewal}}</li>
                         <li v-if="certificate.dynamic" class="p-2 text-center">
                             <b-button
                                 :href="'/api/certificates/' + certificate.id + '/download'"

--- a/carapace-ui/src/main/webapp/src/components/Certificate.vue
+++ b/carapace-ui/src/main/webapp/src/components/Certificate.vue
@@ -11,7 +11,7 @@
                         <li class="list-group-item"><strong>Dynamic:</strong> {{certificate.dynamic | symbolFormat}}</li>
                         <li class="list-group-item"><strong>Status:</strong> {{certificate.status}}</li>
                         <li v-if="certificate.dynamic" class="list-group-item"><strong>Expiring Date:</strong> {{certificate.expiringDate}}</li>
-                        <li v-if="certificate.mode == 'acme'" class="list-group-item"><strong>Advance Renewal (days):</strong> {{certificate.daysAdvanceRenewal}}</li>
+                        <li v-if="certificate.mode == 'acme'" class="list-group-item"><strong>Days Before Renewal:</strong> {{certificate.daysBeforeRenewal}}</li>
                         <li v-if="certificate.dynamic" class="p-2 text-center">
                             <b-button
                                 :href="'/api/certificates/' + certificate.id + '/download'"

--- a/carapace-ui/src/main/webapp/src/components/CertificatesStatus.vue
+++ b/carapace-ui/src/main/webapp/src/components/CertificatesStatus.vue
@@ -33,6 +33,8 @@ export default {
                     formatter: toBooleanSymbol
                 },
                 { key: "status", label: "Status", sortable: true },
+                { key: "expiringDate", label: "Expiring Date", sortable: true },
+                { key: "daysAdvanceRenewal", label: "Advance Renewal (days)", sortable: true },
                 {
                     key: "sslCertificateFile",
                     label: "SSL Certificate File",

--- a/carapace-ui/src/main/webapp/src/components/CertificatesStatus.vue
+++ b/carapace-ui/src/main/webapp/src/components/CertificatesStatus.vue
@@ -34,7 +34,7 @@ export default {
                 },
                 { key: "status", label: "Status", sortable: true },
                 { key: "expiringDate", label: "Expiring Date", sortable: true },
-                { key: "daysAdvanceRenewal", label: "Advance Renewal (days)", sortable: true },
+                { key: "daysBeforeRenewal", label: "Days Before Renewal", sortable: true },
                 {
                     key: "sslCertificateFile",
                     label: "SSL Certificate File",


### PR DESCRIPTION
Ref #191

 

- Configuration: new integer property **_certificate.x.daysbeforerenewal_** to set how many days before expiration the certificate has to be renew (**default 30 days**).

- Rest API: new query parameter **_daysbeforerenewal_** for ACME certificates uploading.

- UI added information about **_expiring date_** and the property **_daysbeforerenewal_** set, for ACME Certificates list and detail.

 - New system property **_carapace.acme.default.daysbeforerenewal_** to change the default value.