### PR TITLE
Configuration entries max size fixed

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationStore.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationStore.java
@@ -1,21 +1,21 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 package org.carapaceproxy.configstore;
 
@@ -120,28 +120,29 @@ public interface ConfigurationStore extends AutoCloseable {
 
     /**
      *
-     * @param prefix until index of property type
-     * @return last index for property name
+     * @param prefix before the index of the property.
+     * @return max index for the property or -1 if no property matches the prefix.
      */
-    default int nextIndexFor(String prefix) {
+    default int findMaxIndexForPrefix(String prefix) {
         Set<Integer> usedIndexes = new HashSet<>();
-        this.forEach(prefix, (k, v) -> {
+        this.forEach(prefix + ".", (k, v) -> {
             String[] split = k.split("\\.");
             try {
-                if (split.length > 2) {
-                    usedIndexes.add(Integer.parseInt(split[1]));
+                if (split.length > 0) {
+                    usedIndexes.add(Integer.parseInt(split[0]));
                 }
             } catch (NumberFormatException e) {
 
             }
         });
-        return 1 + usedIndexes.stream().max(Comparator.naturalOrder()).orElse(-1);
+
+        return usedIndexes.stream().max(Comparator.naturalOrder()).orElse(-1);
     }
 
     /**
      *
      * @param predicate
-     * @return  whether exist at least one property matching to passed predicate.
+     * @return whether exist at least one property matching to passed predicate.
      */
     default boolean anyPropertyMatches(BiPredicate<String, String> predicate) {
         BooleanHolder any = new BooleanHolder(false);

--- a/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
@@ -1,21 +1,21 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 package org.carapaceproxy.server;
 
@@ -587,8 +587,10 @@ public class HttpProxyServer implements AutoCloseable {
             props.setProperty(key.replace("hostname", "daysbeforerenewal"), cert.getDaysBeforeRenewal() + "");
         }
     }
+
     private void performCreate(Properties props, CertificateData cert) {
-        String prefix = "certificate." + dynamicConfigurationStore.nextIndexFor("certificate") + ".";
+        int index = dynamicConfigurationStore.findMaxIndexForPrefix("certificate") + 1;
+        String prefix = "certificate." + index + ".";
         props.setProperty(prefix + "hostname", cert.getDomain());
         props.setProperty(prefix + "mode", cert.isManual() ? "manual" : "acme");
         if (!cert.isManual()) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
@@ -289,10 +289,9 @@ public class RuntimeServerConfiguration {
     }
 
     private void tryConfigureCertificates(ConfigurationStore properties) throws ConfigurationNotValidException {
-        String prefix = "certificate.";
-        int max = properties.nextIndexFor(prefix);
-        for (int i = 0; i < max; i++) {
-            prefix = "certificate." + i + ".";
+        int max = properties.findMaxIndexForPrefix("certificate");
+        for (int i = 0; i <= max; i++) {
+            String prefix = "certificate." + i + ".";
             String hostname = properties.getString(prefix + "hostname", "");
             if (!hostname.isEmpty()) {
                 String file = properties.getString(prefix + "file", "");
@@ -320,10 +319,9 @@ public class RuntimeServerConfiguration {
     }
 
     private void tryConfigureListeners(ConfigurationStore properties) throws ConfigurationNotValidException {
-        String prefix = "listener.";
-        int max = properties.nextIndexFor(prefix);
-        for (int i = 0; i < max; i++) {
-            prefix = "listener." + i + ".";
+        int max = properties.findMaxIndexForPrefix("listener");
+        for (int i = 0; i <= max; i++) {
+            String prefix = "listener." + i + ".";
             String host = properties.getString(prefix + "host", "0.0.0.0");
             int port = properties.getInt(prefix + "port", 0);
             if (port > 0) {
@@ -345,10 +343,9 @@ public class RuntimeServerConfiguration {
     }
 
     private void tryConfigureFilters(ConfigurationStore properties) throws ConfigurationNotValidException {
-        String prefix = "filter.";
-        int max = properties.nextIndexFor(prefix);
-        for (int i = 0; i < max; i++) {
-            prefix = "filter." + i + ".";
+        int max = properties.findMaxIndexForPrefix("filter");
+        for (int i = 0; i <= max; i++) {
+            String prefix = "filter." + i + ".";
             String type = properties.getString(prefix + "type", "");
             if (!type.isEmpty()) {
                 Map<String, String> filterConfig = new HashMap<>();

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -117,8 +117,8 @@ public class StandardEndpointMapper extends EndpointMapper {
         /**
          * HEADERS
          */
-        int max = properties.nextIndexFor("header.");
-        for (int i = 0; i < max; i++) {
+        int max = properties.findMaxIndexForPrefix("header");
+        for (int i = 0; i <= max; i++) {
             String prefix = "header." + i + ".";
             String id = properties.getString(prefix + "id", "");
             String name = properties.getString(prefix + "name", "");
@@ -133,8 +133,8 @@ public class StandardEndpointMapper extends EndpointMapper {
         /**
          * ACTIONS
          */
-        max = properties.nextIndexFor("action.");
-        for (int i = 0; i < max; i++) {
+        max = properties.findMaxIndexForPrefix("action");
+        for (int i = 0; i <= max; i++) {
             String prefix = "action." + i + ".";
             String id = properties.getString(prefix + "id", "");
             boolean enabled = properties.getBoolean(prefix + "enabled", false);
@@ -191,8 +191,8 @@ public class StandardEndpointMapper extends EndpointMapper {
         /**
          * BACKENDS
          */
-        max = properties.nextIndexFor("backend.");
-        for (int i = 0; i < max; i++) {
+        max = properties.findMaxIndexForPrefix("backend");
+        for (int i = 0; i <= max; i++) {
             String prefix = "backend." + i + ".";
             String id = properties.getString(prefix + "id", "");
             if (!id.isEmpty()) {
@@ -211,8 +211,8 @@ public class StandardEndpointMapper extends EndpointMapper {
         /**
          * DIRECTORS
          */
-        max = properties.nextIndexFor("director.");
-        for (int i = 0; i < max; i++) {
+        max = properties.findMaxIndexForPrefix("director");
+        for (int i = 0; i <= max; i++) {
             String prefix = "director." + i + ".";
             String id = properties.getString(prefix + "id", "");
             if (!id.isEmpty()) {
@@ -235,8 +235,8 @@ public class StandardEndpointMapper extends EndpointMapper {
         /**
          * ROUTES
          */
-        max = properties.nextIndexFor("route.");
-        for (int i = 0; i < max; i++) {
+        max = properties.findMaxIndexForPrefix("route");
+        for (int i = 0; i <= max; i++) {
             String prefix = "route." + i + ".";
             String id = properties.getString(prefix + "id", "");
             if (id.isEmpty()) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -1,21 +1,21 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 package org.carapaceproxy.server.mapper;
 
@@ -75,7 +75,6 @@ public class StandardEndpointMapper extends EndpointMapper {
     private String forceDirectorParameter = "x-director";
     private String forceBackendParameter = "x-backend";
 
-    private static final int MAX_IDS = 200;
     private static final Logger LOG = Logger.getLogger(StandardEndpointMapper.class.getName());
     private static final String ACME_CHALLENGE_URI_PATTERN = "/\\.well-known/acme-challenge/";
     private DynamicCertificatesManager dynamicCertificateManger;
@@ -118,7 +117,8 @@ public class StandardEndpointMapper extends EndpointMapper {
         /**
          * HEADERS
          */
-        for (int i = 0; i < MAX_IDS; i++) {
+        int max = properties.nextIndexFor("header.");
+        for (int i = 0; i < max; i++) {
             String prefix = "header." + i + ".";
             String id = properties.getString(prefix + "id", "");
             String name = properties.getString(prefix + "name", "");
@@ -133,7 +133,8 @@ public class StandardEndpointMapper extends EndpointMapper {
         /**
          * ACTIONS
          */
-        for (int i = 0; i < MAX_IDS; i++) {
+        max = properties.nextIndexFor("action.");
+        for (int i = 0; i < max; i++) {
             String prefix = "action." + i + ".";
             String id = properties.getString(prefix + "id", "");
             boolean enabled = properties.getBoolean(prefix + "enabled", false);
@@ -190,7 +191,8 @@ public class StandardEndpointMapper extends EndpointMapper {
         /**
          * BACKENDS
          */
-        for (int i = 0; i < MAX_IDS; i++) {
+        max = properties.nextIndexFor("backend.");
+        for (int i = 0; i < max; i++) {
             String prefix = "backend." + i + ".";
             String id = properties.getString(prefix + "id", "");
             if (!id.isEmpty()) {
@@ -209,7 +211,8 @@ public class StandardEndpointMapper extends EndpointMapper {
         /**
          * DIRECTORS
          */
-        for (int i = 0; i < MAX_IDS; i++) {
+        max = properties.nextIndexFor("director.");
+        for (int i = 0; i < max; i++) {
             String prefix = "director." + i + ".";
             String id = properties.getString(prefix + "id", "");
             if (!id.isEmpty()) {
@@ -232,7 +235,8 @@ public class StandardEndpointMapper extends EndpointMapper {
         /**
          * ROUTES
          */
-        for (int i = 0; i < MAX_IDS; i++) {
+        max = properties.nextIndexFor("route.");
+        for (int i = 0; i < max; i++) {
             String prefix = "route." + i + ".";
             String id = properties.getString(prefix + "id", "");
             if (id.isEmpty()) {


### PR DESCRIPTION
In order to manage a greater amount of certificates we need to drop the limit of 100 entries for property index in configuration file.

By this improve, now configuration properties are fetched by iterating from index 0 to the max for that property prefix-name.