### PR TITLE
Let's Encrypt: possibility to order wildcard certificates with Route53 API #188

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -267,6 +267,11 @@
             <scope>test</scope>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>route53</artifactId>
+            <version>2.13.13</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
@@ -164,7 +164,7 @@ public class CertificatesResource {
                     certificate.getFile()
             );
             if (certificate.isDynamic()) {
-                certBean.setStatus(certificateStateToString(null)); // unknown
+                certBean.setStatus(certificateStateToString(dynamicCertificateManager.getStateOfCertificate(certificate.getId())));
                 try {
                     CertificateData cert = dynamicCertificateManager.getCertificateDataForDomain(certificate.getId());
                     fillDynamicCertificateBean(certBean, cert);
@@ -182,7 +182,6 @@ public class CertificatesResource {
         if (cert == null) {
             return;
         }
-        bean.setStatus(certificateStateToString(cert.getState()));
         Certificate[] chain = base64DecodeCertificateChain(cert.getChain());
         if (chain != null && chain.length > 0) {
             X509Certificate _cert = ((X509Certificate) chain[0]);
@@ -230,7 +229,7 @@ public class CertificatesResource {
                     certificate.getFile()
             );
             if (certificate.isDynamic()) {
-                certBean.setStatus(certificateStateToString(null)); // unknown
+                certBean.setStatus(certificateStateToString(server.getDynamicCertificatesManager().getStateOfCertificate(certificate.getId())));
                 try {
                     CertificateData cert = server.getDynamicCertificatesManager().getCertificateDataForDomain(certificate.getId());
                     fillDynamicCertificateBean(certBean, cert);

--- a/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
@@ -166,7 +166,7 @@ public class CertificatesResource {
             if (certificate.isDynamic()) {
                 certBean.setStatus(certificateStateToString(null)); // unknown
                 try {
-                    CertificateData cert = dynamicCertificateManager.getCertificateDataForDomain(certificate.getHostname());
+                    CertificateData cert = dynamicCertificateManager.getCertificateDataForDomain(certificate.getId());
                     fillDynamicCertificateBean(certBean, cert);
                 } catch (GeneralSecurityException e) {
                     LOG.log(Level.SEVERE, "Unable to read Keystore for certificate {0}. Reason: {1}", new Object[]{certificate.getId(), e});
@@ -214,7 +214,7 @@ public class CertificatesResource {
 
         return Response
                 .ok(data, MediaType.APPLICATION_OCTET_STREAM)
-                .header("content-disposition", "attachment; filename = " + cert.hostname + ".p12")
+                .header("content-disposition", "attachment; filename = " + cert.getId() + ".p12")
                 .build();
     }
 

--- a/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
@@ -209,7 +209,7 @@ public class CertificatesResource {
         if (cert != null && cert.isDynamic()) {
             HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
             DynamicCertificatesManager dynamicCertificateManager = server.getDynamicCertificatesManager();
-            data = dynamicCertificateManager.getCertificateForDomain(cert.hostname);
+            data = dynamicCertificateManager.getCertificateForDomain(cert.getId());
         }
 
         return Response
@@ -220,10 +220,8 @@ public class CertificatesResource {
 
     private CertificateBean findCertificateById(String certId) {
         HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
-        RuntimeServerConfiguration conf = server.getCurrentConfiguration();
-        Map<String, SSLCertificateConfiguration> certificateList = conf.getCertificates();
-        if (certificateList.containsKey(certId)) {
-            SSLCertificateConfiguration certificate = certificateList.get(certId);
+        SSLCertificateConfiguration certificate = server.getCurrentConfiguration().getCertificates().get(certId);
+        if (certificate != null) {
             CertificateBean certBean = new CertificateBean(
                     certificate.getId(),
                     certificate.getHostname(),
@@ -231,11 +229,10 @@ public class CertificatesResource {
                     certificate.isDynamic(),
                     certificate.getFile()
             );
-
             if (certificate.isDynamic()) {
                 certBean.setStatus(certificateStateToString(null)); // unknown
                 try {
-                    CertificateData cert = server.getDynamicCertificatesManager().getCertificateDataForDomain(certificate.getHostname());
+                    CertificateData cert = server.getDynamicCertificatesManager().getCertificateDataForDomain(certificate.getId());
                     fillDynamicCertificateBean(certBean, cert);
                 } catch (GeneralSecurityException e) {
                     LOG.log(Level.SEVERE, "Unable to read Keystore for certificate {0}. Reason: {1}", new Object[]{certificate.getId(), e});

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
@@ -1,21 +1,21 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 package org.carapaceproxy.configstore;
 
@@ -39,6 +39,9 @@ public class CertificateData {
     private String pendingOrderLocation;
     private String pendingChallengeData;
     private boolean available;
+
+    // Data available at run-time only
+    private boolean wildcard;
     private boolean manual;
     private int daysBeforeRenewal;
 
@@ -115,6 +118,14 @@ public class CertificateData {
 
     public void setPendingChallengeData(JSON challengeData) {
         this.pendingChallengeData = challengeData.toString();
+    }
+
+    public boolean isWildcard() {
+        return wildcard;
+    }
+
+    public void setWildcard(boolean wildcard) {
+        this.wildcard = wildcard;
     }
 
     public boolean isManual() {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/Listeners.java
@@ -132,9 +132,8 @@ public class Listeners {
 
         try {
             KeyManagerFactory keyFactory;
-            String domain = certificate.getHostname();
             // Try to find certificate data on db
-            byte[] keystoreContent = parent.getDynamicCertificatesManager().getCertificateForDomain(domain);
+            byte[] keystoreContent = parent.getDynamicCertificatesManager().getCertificateForDomain(certificate.getId());
             Certificate[] chain;
             if (keystoreContent != null) {
                 LOG.log(Level.INFO, "start SSL with dynamic certificate id " + certificate.getId() + ", on listener " + listener.getHost() + ":" + port + " OCSP " + listener.isOcsp());

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
@@ -78,6 +78,8 @@ public class RuntimeServerConfiguration {
     private int keyPairsSize = DEFAULT_KEYPAIRS_SIZE;
     private List<String> supportedSSLProtocols = null;
     private int ocspStaplingManagerPeriod = 0;
+    private String awsAccessKey;
+    private String awsSecretKey;
 
     public String getAccessLogPath() {
         return accessLogPath;
@@ -225,8 +227,16 @@ public class RuntimeServerConfiguration {
         return ocspStaplingManagerPeriod;
     }
 
+    public String getAwsAccessKey() {
+        return awsAccessKey;
+    }
+
+    public String getAwsSecretKey() {
+        return awsSecretKey;
+    }
+
     public void configure(ConfigurationStore properties) throws ConfigurationNotValidException {
-        LOG.log(Level.INFO, "configuring from " + properties);
+        LOG.log(Level.INFO, "configuring from {0}", properties);
         this.maxConnectionsPerEndpoint = properties.getInt("connectionsmanager.maxconnectionsperendpoint", maxConnectionsPerEndpoint);
         this.idleTimeout = properties.getInt("connectionsmanager.idletimeout", idleTimeout);
         if (this.idleTimeout <= 0) {
@@ -262,9 +272,9 @@ public class RuntimeServerConfiguration {
         } catch (Exception err) {
             throw new ConfigurationNotValidException("Invalid accesslog.format.timestamp='" + accessLogTimestampFormat + ": " + err);
         }
-        LOG.info("accesslog.path=" + accessLogPath);
-        LOG.info("accesslog.format.timestamp=" + accessLogTimestampFormat + " (example: " + tsFormatExample + ")");
-        LOG.info("accesslog.format=" + accessLogFormat);
+        LOG.log(Level.INFO, "accesslog.path={0}", accessLogPath);
+        LOG.log(Level.INFO, "accesslog.format.timestamp={0} (example: {1})", new Object[]{accessLogTimestampFormat, tsFormatExample});
+        LOG.log(Level.INFO, "accesslog.format={0}", accessLogFormat);
         LOG.info("accesslog.queue.maxcapacity=" + accessLogMaxQueueCapacity);
         LOG.info("accesslog.flush.interval=" + accessLogFlushInterval);
         LOG.info("accesslog.failure.wait=" + accessLogWaitBetweenFailures);
@@ -286,6 +296,11 @@ public class RuntimeServerConfiguration {
 
         ocspStaplingManagerPeriod = properties.getInt("ocspstaplingmanager.period", 0);
         LOG.info("ocspstaplingmanager.period=" + ocspStaplingManagerPeriod);
+
+        awsAccessKey = properties.getString("aws.accesskey", null);
+        LOG.log(Level.INFO, "aws.accesskey={0}", awsAccessKey);
+        awsSecretKey = properties.getString("aws.secretkey", null);
+        LOG.log(Level.INFO, "aws.secretkey={0}", awsSecretKey);
     }
 
     private void tryConfigureCertificates(ConfigurationStore properties) throws ConfigurationNotValidException {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/ACMEClient.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/ACMEClient.java
@@ -162,7 +162,7 @@ public class ACMEClient {
             throw new AcmeException("Found no " + Dns01Challenge.TYPE + " challenge, don't know what to do...");
         }
 
-        LOG.debug("DNS-challenge _acme-challenge.{}. to save as TXT-record with content {}", auth.getIdentifier().getDomain(), challenge.getDigest());
+        LOG.info("DNS-challenge _acme-challenge.{}. to save as TXT-record with content {}", auth.getIdentifier().getDomain(), challenge.getDigest());
 
         return challenge;
     }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/ACMEClient.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/ACMEClient.java
@@ -1,21 +1,21 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 package org.carapaceproxy.server.certificates;
 
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.security.KeyPair;
 import java.security.Security;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.shredzone.acme4j.Account;
 import org.shredzone.acme4j.AccountBuilder;
@@ -33,6 +35,7 @@ import org.shredzone.acme4j.Order;
 import org.shredzone.acme4j.Session;
 import org.shredzone.acme4j.Status;
 import org.shredzone.acme4j.challenge.Challenge;
+import org.shredzone.acme4j.challenge.Dns01Challenge;
 import org.shredzone.acme4j.challenge.Http01Challenge;
 import org.shredzone.acme4j.exception.AcmeException;
 import org.shredzone.acme4j.util.CSRBuilder;
@@ -41,7 +44,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  *
- * A simple Let's Encrypt ACME client for automatic ssl certificate issuing.
+ * Let's Encrypt ACME client for automatic SSL certificate issuing.
  *
  * @author paolo.venturi
  *
@@ -56,7 +59,7 @@ public class ACMEClient {
     // For testing server use
     public static final String TESTING_CA = "https://acme-staging-v02.api.letsencrypt.org/directory"; //"acme://letsencrypt.org/staging";
 
-    private boolean testingModeOn;
+    private final boolean testingModeOn;
     private final KeyPair userKey;
 
     public enum ChallengeType {
@@ -70,12 +73,9 @@ public class ACMEClient {
     }
 
     /**
-     * Finds your {@link Account} at the ACME server.It will be found by your user's public key.If your key is not known
-     * to the server yet, a new account will be created.<p>
-     * This is a simple way of finding your {@link Account}. A better way is to get the URL and KeyIdentifier of your
-     * new account with {@link Account#getLocation()}
-     * {@link Session#getKeyIdentifier()} and store it somewhere. If you need to get access to your account later,
-     * reconnect to it via {@link Account#bind(Session, URI)} by using the stored location.
+     * Finds your {@link Account} at the ACME server.It will be found by your user's public key.If your key is not known to the server yet, a new account will be created.<p>
+     * This is a simple way of finding your {@link Account}. A better way is to get the URL and KeyIdentifier of your new account with {@link Account#getLocation()}
+     * {@link Session#getKeyIdentifier()} and store it somewhere. If you need to get access to your account later, reconnect to it via {@link Account#bind(Session, URI)} by using the stored location.
      *
      * @return
      * @throws java.io.IOException
@@ -93,7 +93,7 @@ public class ACMEClient {
     /*
      * Methods for step-by-step certificate issuing
      */
-    public Order createOrderForDomain(String domains) throws AcmeException, IOException {
+    public Order createOrderForDomain(String... domains) throws AcmeException, IOException {
         // Get the Account.
         // If there is no account yet, create a new one.
         Account acct = getLogin().getAccount();
@@ -102,18 +102,18 @@ public class ACMEClient {
         return acct.newOrder().domains(domains).create();
     }
 
-    public Http01Challenge getHTTPChallengeForOrder(Order order) throws AcmeException {
+    public Challenge getChallengeForOrder(Order order, boolean dnsChallenge) throws AcmeException {
         Authorization auth = order.getAuthorizations().get(0);
         String domain = auth.getIdentifier().getDomain();
         LOG.debug("Authorization for domain {} status:{}", domain, auth.getStatus());
-        
+
         // The authorization is already valid. No need to process a challenge.
         if (auth.getStatus() == Status.VALID) {
             return null;
         }
-        
+
         LOG.debug("Retrieving challenge...");
-        Http01Challenge challenge = httpChallenge(auth);
+        Challenge challenge = dnsChallenge ? dnsChallenge(auth) : httpChallenge(auth);
 
         if (challenge == null) {
             throw new AcmeException("No challenge found");
@@ -131,12 +131,8 @@ public class ACMEClient {
     /**
      * Prepares a HTTP challenge.
      * <p>
-     * The verification of this challenge expects a file with a certain content to be reachable at a given path under
-     * the domain to be tested.
-     * <p>
-     * This example outputs instructions that need to be executed manually. In a production environment, you would
-     * rather generate this file automatically, or maybe use a servlet that returns
-     * {@link Http01Challenge#getAuthorization()}.
+     * The verification of this challenge expects a file with a certain content to be reachable at a given path under the domain to be tested.
+     * </p>
      *
      * @param auth {@link Authorization} to find the challenge in
      * @return {@link Http01Challenge} to verify
@@ -146,11 +142,34 @@ public class ACMEClient {
         Http01Challenge challenge = auth.findChallenge(Http01Challenge.TYPE);
         if (challenge == null) {
             throw new AcmeException("Found no " + Http01Challenge.TYPE + " challenge, don't know what to do...");
-        }        
+        }
 
         // Output the challenge, wait for acknowledge...
         LOG.debug("It must be reachable at: http://{}/.well-known/acme-challenge/{}",
                 auth.getIdentifier().getDomain(), challenge.getToken());
+
+        return challenge;
+    }
+
+    /**
+     * Prepares a DNS challenge.
+     * <p>
+     * The verification of this challenge expects a TXT record with a certain content.
+     * </p>
+     *
+     * @param auth {@link Authorization} to find the challenge in
+     * @return {@link Challenge} to verify
+     */
+    public Challenge dnsChallenge(Authorization auth) throws AcmeException {
+        // Find a single dns-01 challenge
+        Dns01Challenge challenge = auth.findChallenge(Dns01Challenge.TYPE);
+        if (challenge == null) {
+            throw new AcmeException("Found no " + Dns01Challenge.TYPE + " challenge, don't know what to do...");
+        }
+
+        // Output the challenge, wait for acknowledge...
+        LOG.info("Please create a TXT record:");
+        LOG.info("_acme-challenge.{}. IN TXT {}", auth.getIdentifier().getDomain(), challenge.getDigest());
 
         return challenge;
     }
@@ -178,21 +197,15 @@ public class ACMEClient {
      * @throws AcmeException
      */
     public void orderCertificate(Order order, KeyPair domainKeyPair) throws IOException, AcmeException {
-        String domain = order.getIdentifiers().get(0).getDomain();
+        List<String> domains = order.getIdentifiers().stream().map(e -> e.getDomain()).collect(Collectors.toList());
 
         // Generate a CSR (Certificate signing request) for all of the domains, and sign it with the domain key pair.
         CSRBuilder csrb = new CSRBuilder();
-        csrb.addDomain(domain);
-        //csrb.setOrganization("The Example Organization")
+        csrb.addDomains(domains);
         csrb.sign(domainKeyPair);
 
-        // Write the CSR to a file, for later use (p.e. renewal of the certificate)                     
-//        File file = new File(basePath, domain + CSR_FILE);
-//        try (Writer out = new OutputStreamWriter(new FileOutputStream(file), "UTF-8")) {
-//            csrb.write(out);
-//        }
         // Order the certificate
-        LOG.info("Certificate ordering for domain {}", domain);
+        LOG.info("Certificate ordering for domains {}", domains);
         order.execute(csrb.getEncoded());
     }
 
@@ -210,7 +223,7 @@ public class ACMEClient {
     }
 
     public Certificate fetchCertificateForOrder(Order order) throws AcmeException, IOException {
-        // Get the certificate        
+        // Get the certificate
         Certificate certificate = order.getCertificate();
         String domain = order.getIdentifiers().get(0).getDomain();
         if (certificate == null) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificateState.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificateState.java
@@ -25,6 +25,7 @@ package org.carapaceproxy.server.certificates;
  */
 public enum DynamicCertificateState {
     WAITING, // certificate waiting for issuing/renews
+    DNS_CHALLENGE_WAIT, // for dns-challenge, wait for dns propagation
     VERIFYING, // challenge verification by LE pending
     VERIFIED, // challenge succeded
     ORDERING, // certificate order pending

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
@@ -1,26 +1,27 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 package org.carapaceproxy.server.certificates;
 
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64EncodeCertificateChain;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.AVAILABLE;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.DNS_CHALLENGE_WAIT;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.EXPIRED;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.ORDERING;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.REQUEST_FAILED;
@@ -60,6 +61,8 @@ import org.carapaceproxy.server.HttpProxyServer;
 import org.glassfish.jersey.internal.guava.ThreadFactoryBuilder;
 import org.shredzone.acme4j.Order;
 import org.shredzone.acme4j.Status;
+import org.shredzone.acme4j.challenge.Challenge;
+import org.shredzone.acme4j.challenge.Dns01Challenge;
 import org.shredzone.acme4j.challenge.Http01Challenge;
 import org.shredzone.acme4j.exception.AcmeException;
 import org.shredzone.acme4j.toolbox.JSON;
@@ -80,11 +83,15 @@ public class DynamicCertificatesManager implements Runnable {
     public static final int DEFAULT_DAYS_BEFORE_RENEWAL = Integer.getInteger("carapace.acme.default.daysbeforerenewal", 30);
     private static final boolean TESTING_MODE = Boolean.getBoolean("carapace.acme.testmode");
 
+    private static final int DNS_CHALLENGE_CREATION_CHECKS_LIMIT = Integer.getInteger("carapace.acme.dnschallengecreationcheck.limit", 10);
+
     private static final Logger LOG = Logger.getLogger(DynamicCertificatesManager.class.getName());
     private static final String EVENT_CERT_AVAIL_CHANGED = "certAvailChanged";
 
     private Map<String, CertificateData> certificates = new ConcurrentHashMap();
-    private ACMEClient client; // Let's Encrypt client
+    private ACMEClient acmeClient; // Let's Encrypt client
+    private Route53Client r53Client;
+    private Map<String, DnsChallengeCreationStatus> dnsChallegesCreationStatus = new ConcurrentHashMap();
 
     private ScheduledExecutorService scheduler;
     private ScheduledFuture<?> scheduledFuture;
@@ -126,7 +133,7 @@ public class DynamicCertificatesManager implements Runnable {
 
     @VisibleForTesting
     public void setACMEClient(ACMEClient client) {
-        this.client = client;
+        this.acmeClient = client;
     }
 
     public synchronized void reloadConfiguration(RuntimeServerConfiguration configuration) {
@@ -134,8 +141,15 @@ public class DynamicCertificatesManager implements Runnable {
             throw new DynamicCertificatesManagerException("ConfigurationStore not set.");
         }
         keyPairsSize = configuration.getKeyPairsSize();
-        if (client == null) {
-            client = new ACMEClient(loadOrCreateAcmeUserKeyPair(), TESTING_MODE);
+        if (acmeClient == null) {
+            acmeClient = new ACMEClient(loadOrCreateAcmeUserKeyPair(), TESTING_MODE);
+        }
+        if (r53Client == null) {
+            String awsAccessKey = configuration.getAwsAccessKey();
+            String awsSecretKey = configuration.getAwsSecretKey();
+            if (awsAccessKey != null && awsSecretKey != null) {
+                r53Client = new Route53Client(awsAccessKey, awsSecretKey);
+            }
         }
         loadCertificates(configuration.getCertificates());
         period = configuration.getDynamicCertificatesManagerPeriod();
@@ -165,9 +179,12 @@ public class DynamicCertificatesManager implements Runnable {
             for (Entry<String, SSLCertificateConfiguration> e : certificates.entrySet()) {
                 SSLCertificateConfiguration config = e.getValue();
                 if (config.isDynamic()) {
-                    String domain = config.getHostname();
+                    String domain = config.getId(); // hostname or *.hostname
+                    boolean wildcard = config.isWildcard();
                     boolean forceManual = MANUAL == config.getMode();
-                    _certificates.put(domain, loadOrCreateDynamicCertificateForDomain(domain, forceManual, config.getDaysBeforeRenewal()));
+                    _certificates.put(domain, loadOrCreateDynamicCertificateForDomain(
+                            domain, wildcard, forceManual, config.getDaysBeforeRenewal()
+                    ));
                 }
             }
             this.certificates = _certificates; // only certificates/domains specified in the config have to be managed.
@@ -176,11 +193,15 @@ public class DynamicCertificatesManager implements Runnable {
         }
     }
 
-    private CertificateData loadOrCreateDynamicCertificateForDomain(String domain, boolean forceManual, int daysBeforeRenewal) throws GeneralSecurityException, MalformedURLException {
+    private CertificateData loadOrCreateDynamicCertificateForDomain(String domain,
+                                                                    boolean wildcard,
+                                                                    boolean forceManual,
+                                                                    int daysBeforeRenewal) throws GeneralSecurityException, MalformedURLException {
         CertificateData cert = store.loadCertificateForDomain(domain);
         if (cert == null) {
             cert = new CertificateData(domain, "", "", WAITING, "", "", false);
         }
+        cert.setWildcard(wildcard);
         cert.setManual(forceManual);
         if (!forceManual) { // only for ACME
             cert.setDaysBeforeRenewal(daysBeforeRenewal);
@@ -209,6 +230,9 @@ public class DynamicCertificatesManager implements Runnable {
                 scheduler.awaitTermination(10, TimeUnit.SECONDS);
                 scheduler = null;
                 scheduledFuture = null;
+                if (r53Client != null) {
+                    r53Client.close();
+                }
             } catch (InterruptedException err) {
                 Thread.currentThread().interrupt();
             }
@@ -240,44 +264,40 @@ public class DynamicCertificatesManager implements Runnable {
             boolean notifyCertAvailChanged = false;
             final String domain = data.getDomain();
             try {
-                CertificateData cert = loadOrCreateDynamicCertificateForDomain(domain, false, data.getDaysBeforeRenewal());
+                CertificateData cert = loadOrCreateDynamicCertificateForDomain(domain, data.isWildcard(), false, data.getDaysBeforeRenewal());
                 switch (cert.getState()) {
                     case WAITING: { // certificate waiting to be issues/renew
                         LOG.log(Level.INFO, "Certificate ISSUING process for domain: {0} STARTED.", domain);
-                        Order order = client.createOrderForDomain(domain);
-                        cert.setPendingOrderLocation(order.getLocation());
-                        LOG.log(Level.INFO, "Pending order location for domain {0}: {1}", new Object[]{domain, order.getLocation()});
-                        Http01Challenge challenge = client.getHTTPChallengeForOrder(order);
-                        if (challenge == null) {
-                            cert.setState(VERIFIED);
-                        } else {
-                            LOG.log(Level.INFO, "Pending challenge data for domain {0}: {1}", new Object[]{domain, challenge.getJSON()});
-                            triggerChallenge(challenge);
-                            cert.setPendingChallengeData(challenge.getJSON());
-                            cert.setState(VERIFYING);
+                        Order order = createOrderForCertificate(cert);
+                        createChallengeForCertificateOrder(cert, order);
+                        break;
+                    }
+                    case DNS_CHALLENGE_WAIT: { // waiting for full dns propagation
+                        LOG.log(Level.INFO, "DNS_CHALLENGE_WAIT for domain {0}.", domain);
+                        Dns01Challenge pendingChallenge = (Dns01Challenge) getChallengeFromCertificate(cert);
+                        if (pendingChallenge == null) {
+                            LOG.log(Level.SEVERE, "Unable to get pending challenge data for domain " + domain);
+                            cert.setState(REQUEST_FAILED);
+                            break;
                         }
+                        // creation of the acme dns-record-challenge failed
+                        DnsChallengeCreationStatus status = dnsChallegesCreationStatus.computeIfAbsent(domain, d -> new DnsChallengeCreationStatus());
+                        if (status.isDnsChallengeError()) {
+                            cert.setState(REQUEST_FAILED);
+                            break;
+                        }
+                        // check dns visibility
+                        checkDNSChallengeAvailabilityForCertificate(pendingChallenge, cert, status);
                         break;
                     }
                     case VERIFYING: { // challenge verification by LE pending
                         LOG.log(Level.INFO, "VERIFYING certificate for domain {0}.", domain);
-                        JSON challengeData = null;
-                        try {
-                            challengeData = JSON.parse(cert.getPendingChallengeData());
-                        } catch (Exception e) {
-                            LOG.log(Level.SEVERE, "Unable to get pending challenge data for domain " + domain, e);
+                        Challenge pendingChallenge = getChallengeFromCertificate(cert);
+                        if (pendingChallenge == null) {
+                            LOG.log(Level.SEVERE, "Unable to get pending challenge data for domain {0}", domain);
                             cert.setState(REQUEST_FAILED);
-                            break;
-                        }
-                        LOG.log(Level.INFO, "CHALLENGE: {0}.", cert.getPendingChallengeData());
-                        Http01Challenge pendingChallenge = new Http01Challenge(client.getLogin(), challengeData);
-                        Status status = client.checkResponseForChallenge(pendingChallenge); // checks response and updates the challenge
-                        cert.setPendingChallengeData(pendingChallenge.getJSON());
-                        if (status == Status.VALID) {
-                            cert.setState(VERIFIED);
-                            store.deleteAcmeChallengeToken(pendingChallenge.getToken());
-                        } else if (status == Status.INVALID) {
-                            cert.setState(REQUEST_FAILED);
-                            store.deleteAcmeChallengeToken(pendingChallenge.getToken());
+                        } else {
+                            checkChallengeResponseForCertificate(pendingChallenge, cert);
                         }
                         break;
                     }
@@ -291,10 +311,9 @@ public class DynamicCertificatesManager implements Runnable {
                             cert.setState(REQUEST_FAILED);
                             break;
                         }
-                        Order pendingOrder = client.getLogin().bindOrder(orderLocation);
+                        Order pendingOrder = acmeClient.getLogin().bindOrder(orderLocation);
                         KeyPair keys = loadOrCreateKeyPairForDomain(domain);
-                        cert.setPrivateKey(domain);
-                        client.orderCertificate(pendingOrder, keys);
+                        acmeClient.orderCertificate(pendingOrder, keys);
                         cert.setState(ORDERING);
                         break;
                     }
@@ -308,10 +327,10 @@ public class DynamicCertificatesManager implements Runnable {
                             cert.setState(REQUEST_FAILED);
                             break;
                         }
-                        Order order = client.getLogin().bindOrder(orderLocation);
-                        Status status = client.checkResponseForOrder(order);
+                        Order order = acmeClient.getLogin().bindOrder(orderLocation);
+                        Status status = acmeClient.checkResponseForOrder(order);
                         if (status == Status.VALID) {
-                            List<X509Certificate> certificateChain = client.fetchCertificateForOrder(order).getCertificateChain();
+                            List<X509Certificate> certificateChain = acmeClient.fetchCertificateForOrder(order).getCertificateChain();
                             PrivateKey key = loadOrCreateKeyPairForDomain(domain).getPrivate();
                             String chain = base64EncodeCertificateChain(certificateChain.toArray(new Certificate[0]), key);
                             cert.setChain(chain);
@@ -362,9 +381,101 @@ public class DynamicCertificatesManager implements Runnable {
         }
     }
 
-    private void triggerChallenge(Http01Challenge challenge) throws AcmeException {
-        store.saveAcmeChallengeToken(challenge.getToken(), challenge.getAuthorization());
-        challenge.trigger();
+    private Order createOrderForCertificate(CertificateData cert) throws AcmeException, IOException {
+        Order order = acmeClient.createOrderForDomain(cert.getDomain());
+        cert.setPendingOrderLocation(order.getLocation());
+        LOG.log(Level.INFO, "Pending order location for domain {0}: {1}", new Object[]{cert.getDomain(), order.getLocation()});
+
+        return order;
+    }
+
+    private void createChallengeForCertificateOrder(CertificateData cert, Order order) throws AcmeException {
+        Challenge challenge = acmeClient.getChallengeForOrder(order, cert.isWildcard());
+        if (challenge == null) {
+            cert.setState(VERIFIED);
+        } else {
+            LOG.log(Level.INFO, "Pending challenge data for domain {0}: {1}", new Object[]{cert.getDomain(), challenge.getJSON()});
+            if (cert.isWildcard()) {
+                dnsChallegesCreationStatus.put(cert.getDomain(), new DnsChallengeCreationStatus());
+                Dns01Challenge ch = (Dns01Challenge) challenge;
+                r53Client.createDNSChallengeForDomain(cert.getDomain(), ch.getDigest(),
+                        res -> LOG.log(Level.INFO, "Create new TXT DNS challenge-record for domain {0}. Details: {1}", new Object[]{cert.getDomain(), res.responseMetadata()}), (Throwable err) -> {
+                            DnsChallengeCreationStatus status = dnsChallegesCreationStatus.get(cert.getDomain());
+                            if (status != null) {
+                                status.setDnsChallengeError();
+                            }
+                            LOG.log(Level.INFO, "Creation of TXT DNS challenge-record for domain {0} FAILED. Reason: {1}", new Object[]{cert.getDomain(), err});
+                        });
+                cert.setState(DNS_CHALLENGE_WAIT);
+            } else {
+                Http01Challenge ch = (Http01Challenge) challenge;
+                store.saveAcmeChallengeToken(ch.getToken(), ch.getAuthorization()); // used for incoming acme-challenge requests
+                challenge.trigger();
+                cert.setState(VERIFYING);
+            }
+            cert.setPendingChallengeData(challenge.getJSON());
+        }
+    }
+
+    private Challenge getChallengeFromCertificate(CertificateData cert) throws AcmeException {
+        try {
+            JSON challengeData = JSON.parse(cert.getPendingChallengeData());
+            LOG.log(Level.INFO, "CHALLENGE: {0}.", challengeData);
+            return cert.isWildcard()
+                    ? new Dns01Challenge(acmeClient.getLogin(), challengeData)
+                    : new Http01Challenge(acmeClient.getLogin(), challengeData);
+        } catch (IOException | AcmeException e) {
+            return null;
+        }
+    }
+
+    private void checkDNSChallengeAvailabilityForCertificate(Dns01Challenge challenge, CertificateData cert, DnsChallengeCreationStatus status) throws AcmeException {
+        String domain = cert.getDomain();
+        if (status.isDnsChallengeReady()) {
+            cert.setState(VERIFYING);
+            dnsChallegesCreationStatus.remove(domain);
+            challenge.trigger();
+        } else if (status.testDnsChecksLimit()) {
+            cert.setState(REQUEST_FAILED);
+            dnsChallegesCreationStatus.remove(domain);
+            cleanupChallengeForCertificate(challenge, cert);
+        } else {
+            r53Client.isDNSChallengeForDomainAvailable(domain, challenge.getDigest(),
+                    available -> {
+                        DnsChallengeCreationStatus s = dnsChallegesCreationStatus.get(domain);
+                        if (s != null) {
+                            s.setDnsChallengeReady();
+                        }
+                    },
+                    err -> LOG.log(Level.INFO, "Creation of TXT DNS challenge-record for domain {0} FAILED. Reason: {1}", new Object[]{domain, err})
+            );
+        }
+
+    }
+
+    private void checkChallengeResponseForCertificate(Challenge challenge, CertificateData cert) throws AcmeException, IOException {
+        Status status = acmeClient.checkResponseForChallenge(challenge); // checks response and updates the challenge
+        cert.setPendingChallengeData(challenge.getJSON());
+        if (status == Status.VALID) {
+            cert.setState(VERIFIED);
+            cleanupChallengeForCertificate(challenge, cert);
+        } else if (status == Status.INVALID) {
+            cert.setState(REQUEST_FAILED);
+            cleanupChallengeForCertificate(challenge, cert);
+        }
+    }
+
+    private void cleanupChallengeForCertificate(Challenge challenge, CertificateData cert) {
+        if (cert.isWildcard()) {
+            Dns01Challenge ch = (Dns01Challenge) challenge;
+            r53Client.deleteDNSChallengeForDomain(cert.getDomain(), ch.getDigest(),
+                    res -> LOG.log(Level.INFO, "DELETE TXT DNS challenge-record for domain {0}. Details: {1}", new Object[]{cert.getDomain(), res.responseMetadata()}),
+                    err -> LOG.log(Level.INFO, "Deletion of TXT DNS challenge-record for domain {0} FAILED. Reason: {1}", new Object[]{cert.getDomain(), err})
+            );
+        } else {
+            Http01Challenge ch = (Http01Challenge) challenge;
+            store.deleteAcmeChallengeToken(ch.getToken());
+        }
     }
 
     public String getChallengeToken(String tokenName) {
@@ -404,7 +515,7 @@ public class DynamicCertificatesManager implements Runnable {
                 store.saveCertificate(cert);
                 // remember that events  are not delivered to the local JVM
                 reloadCertificatesFromDB();
-                if (prevAvail != cert.isAvailable() && groupMembershipHandler!= null) {
+                if (prevAvail != cert.isAvailable() && groupMembershipHandler != null) {
                     groupMembershipHandler.fireEvent(EVENT_CERT_AVAIL_CHANGED);
                 }
             }
@@ -460,11 +571,11 @@ public class DynamicCertificatesManager implements Runnable {
         LOG.log(Level.INFO, "Reloading certificates from db");
         try {
             Map<String, CertificateData> _certificates = new ConcurrentHashMap<>();
-            for (Entry<String, CertificateData> entry: certificates.entrySet()) {
+            for (Entry<String, CertificateData> entry : certificates.entrySet()) {
                 String domain = entry.getKey();
                 CertificateData cert = entry.getValue();
-                // "manual" flag is not stored in db > has to be re-set from existing config
-                CertificateData freshCert = loadOrCreateDynamicCertificateForDomain(domain, cert.isManual(), cert.getDaysBeforeRenewal());
+                // "wildcard" and "manual" flags and "daysBeforeRenewal" are not stored in db > have to be re-set from existing config
+                CertificateData freshCert = loadOrCreateDynamicCertificateForDomain(domain, cert.isWildcard(), cert.isManual(), cert.getDaysBeforeRenewal());
                 _certificates.put(domain, freshCert);
                 LOG.log(Level.INFO, "RELOADED certificate for domain {0}: {1}", new Object[]{domain, freshCert});
             }
@@ -473,6 +584,34 @@ public class DynamicCertificatesManager implements Runnable {
         } catch (GeneralSecurityException | MalformedURLException | InterruptedException e) {
             throw new DynamicCertificatesManagerException("Unable to load dynamic certificates from db.", e);
         }
+    }
+
+    public static final class DnsChallengeCreationStatus {
+
+        private volatile boolean dnsChallengeError;
+        private volatile boolean dnsChallengeReady;
+        private volatile int dnsChecksCount;
+
+        public boolean isDnsChallengeError() {
+            return dnsChallengeError;
+        }
+
+        public void setDnsChallengeError() {
+            this.dnsChallengeError = true;
+        }
+
+        public boolean isDnsChallengeReady() {
+            return dnsChallengeReady;
+        }
+
+        public void setDnsChallengeReady() {
+            this.dnsChallengeReady = true;
+        }
+
+        public boolean testDnsChecksLimit() {
+            return ++dnsChecksCount > DNS_CHALLENGE_CREATION_CHECKS_LIMIT;
+        }
+
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/Route53Client.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/Route53Client.java
@@ -23,8 +23,10 @@ import static org.carapaceproxy.server.certificates.Route53Client.DnsChallengeAc
 import static org.carapaceproxy.server.certificates.Route53Client.DnsChallengeAction.DELETE;
 import static org.carapaceproxy.server.certificates.Route53Client.DnsChallengeAction.UPSERT;
 import static org.carapaceproxy.server.config.SSLCertificateConfiguration.WILDCARD_SYMBOL;
-import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -33,7 +35,6 @@ import software.amazon.awssdk.services.route53.model.Change;
 import software.amazon.awssdk.services.route53.model.ChangeAction;
 import software.amazon.awssdk.services.route53.model.ChangeBatch;
 import software.amazon.awssdk.services.route53.model.ChangeResourceRecordSetsRequest;
-import software.amazon.awssdk.services.route53.model.ChangeResourceRecordSetsResponse;
 import software.amazon.awssdk.services.route53.model.HostedZone;
 import software.amazon.awssdk.services.route53.model.ListHostedZonesByNameRequest;
 import software.amazon.awssdk.services.route53.model.ListHostedZonesByNameResponse;
@@ -66,6 +67,8 @@ public class Route53Client {
     private static final String DNS_CHALLENGE_PREFIX = "_acme-challenge.";
     private static final String HOSTEDZONE_ID_PREFIX = "/hostedzone/";
 
+    private static final Logger LOG = Logger.getLogger(Route53Client.class.getName());
+
     private final Route53AsyncClient client;
 
     public Route53Client(String awsAccessKey, String awsSecretKey) {
@@ -82,84 +85,88 @@ public class Route53Client {
         client.close();
     }
 
-    public void createDnsChallengeForDomain(String domain, String digest, DnsChallengeRequestCallback<ChangeResourceRecordSetsResponse> callback) {
-        performActionOnDnsChallengeForDomain(domain, digest, UPSERT, callback);
+    public boolean createDnsChallengeForDomain(String domain, String digest) {
+        return performActionOnDnsChallengeForDomain(domain, digest, UPSERT);
     }
 
-    public void deleteDnsChallengeForDomain(String domain, String digest, DnsChallengeRequestCallback<ChangeResourceRecordSetsResponse> callback) {
-        performActionOnDnsChallengeForDomain(domain, digest, DELETE, callback);
+    public boolean deleteDnsChallengeForDomain(String domain, String digest) {
+        return performActionOnDnsChallengeForDomain(domain, digest, DELETE);
     }
 
-    public void isDnsChallengeForDomainAvailable(String domain, String digest, DnsChallengeRequestCallback<Boolean> callback) {
-        DnsChallengeRequestCallback<TestDnsAnswerResponse> check = (TestDnsAnswerResponse res, Throwable err) -> {
-            if (err == null) {
-                callback.onComplete(res.recordData().size() == 1 && res.recordData().get(0).equals("\"" + digest + "\""), null);
-            } else {
-                callback.onComplete(null, err);
-            }
-        };
-        performActionOnDnsChallengeForDomain(domain, null, CHECK, check);
+    public boolean isDnsChallengeForDomainAvailable(String domain, String digest) {
+        return performActionOnDnsChallengeForDomain(domain, digest, CHECK);
     }
 
-    private void performActionOnDnsChallengeForDomain(String domain, String digest, DnsChallengeAction action, DnsChallengeRequestCallback callback) {
+    private boolean performActionOnDnsChallengeForDomain(String domain, String digest, DnsChallengeAction action) {
         String dnsName = domain.replace(WILDCARD_SYMBOL, "") + ".";
         String challengeName = DNS_CHALLENGE_PREFIX + dnsName;
 
-        // find out the hostedzone where to update the acme dns-challenge txt record
-        CompletableFuture<ListHostedZonesByNameResponse> futureFindHZ = client.listHostedZonesByName(
-                ListHostedZonesByNameRequest.builder().dnsName(dnsName).build()
-        );
+        try {
+            // find out the hostedzone where to update the acme dns-challenge txt record
+            ListHostedZonesByNameResponse res = client.listHostedZonesByName(
+                    ListHostedZonesByNameRequest.builder().dnsName(dnsName).build()
+            ).exceptionally(ext -> {
+                LOG.log(Level.SEVERE, "ERROR performing {0} action for dns name {1}. Reason: {2}", new Object[]{action, dnsName, ext});
+                return null;
+            }).get();
 
-        futureFindHZ.whenComplete((resFindHZ, excFindHZ) -> {
-            if (excFindHZ == null && resFindHZ.sdkHttpResponse().isSuccessful()) {
-                if (resFindHZ.hostedZones().isEmpty()) {
-                    callback.onComplete(null, new NoSuchElementException("No hostedzones found for dns: " + dnsName));
-                    return;
-                }
-                HostedZone hostedzone = resFindHZ.hostedZones().get(0);
-                if (!hostedzone.name().equals(dnsName)) {
-                    callback.onComplete(null, new NoSuchElementException("Unable to find hostedzone for dns: " + dnsName));
-                    return;
-                }
-                String idhostedzone = hostedzone.id().replace(HOSTEDZONE_ID_PREFIX, "");
-                CompletableFuture<? extends Route53Response> future;
-                switch (action) {
-                    case UPSERT:
-                        // ACME DNS-challenge TXT record upsert
-                        future = client.changeResourceRecordSets(
-                                acmeDnsChallengeUpdateRequest(idhostedzone, challengeName, digest, ChangeAction.UPSERT)
-                        );
-                        break;
-                    case DELETE:
-                        // ACME DNS-challenge TXT record delete
-                        future = client.changeResourceRecordSets(
-                                acmeDnsChallengeUpdateRequest(idhostedzone, challengeName, digest, ChangeAction.DELETE)
-                        );
-                        break;
-                    case CHECK:
-                        // ACME DNS-challenge TXT record availability check
-                        future = client.testDNSAnswer(TestDnsAnswerRequest.builder()
-                                .hostedZoneId(idhostedzone)
-                                .recordName(challengeName)
-                                .recordType(RRType.TXT)
-                                .build()
-                        );
-                        break;
-                    default:
-                        callback.onComplete(null, new IllegalArgumentException("Unexpected value for action: " + action));
-                        return;
-                }
-                future.whenComplete((res, exc) -> {
-                    if (exc == null && res.sdkHttpResponse().isSuccessful()) {
-                        callback.onComplete(res, null);
-                    } else {
-                        callback.onComplete(null, exc);
-                    }
-                });
-            } else {
-                callback.onComplete(null, excFindHZ);
+            if (res == null || !res.sdkHttpResponse().isSuccessful()) {
+                return false;
             }
-        });
+            if (res.hostedZones().isEmpty()) {
+                LOG.log(Level.SEVERE, "No hostedzones found for dns name {0}", dnsName);
+                return false;
+            }
+            HostedZone hostedzone = res.hostedZones().get(0);
+            if (!hostedzone.name().equals(dnsName)) {
+                LOG.log(Level.SEVERE, "Unable to find hostedzone for dns name {0}", dnsName);
+                return false;
+            }
+
+            String idhostedzone = hostedzone.id().replace(HOSTEDZONE_ID_PREFIX, "");
+            CompletableFuture<? extends Route53Response> future;
+            switch (action) {
+                case UPSERT:
+                    // ACME DNS-challenge TXT record upsert
+                    future = client.changeResourceRecordSets(
+                            acmeDnsChallengeUpdateRequest(idhostedzone, challengeName, digest, ChangeAction.UPSERT)
+                    );
+                    break;
+                case DELETE:
+                    // ACME DNS-challenge TXT record delete
+                    future = client.changeResourceRecordSets(
+                            acmeDnsChallengeUpdateRequest(idhostedzone, challengeName, digest, ChangeAction.DELETE)
+                    );
+                    break;
+                case CHECK:
+                    // ACME DNS-challenge TXT record availability check
+                    future = client.testDNSAnswer(TestDnsAnswerRequest.builder()
+                            .hostedZoneId(idhostedzone)
+                            .recordName(challengeName)
+                            .recordType(RRType.TXT)
+                            .build()
+                    );
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unexpected value for action: " + action);
+            }
+            Route53Response actionResult;
+            actionResult = future.exceptionally(ext -> {
+                LOG.log(Level.SEVERE, "ERROR performing {0} action for dns name {1}. Reason: {2}", new Object[]{action, dnsName, ext});
+                return null;
+            }).get();
+            if (actionResult != null && actionResult.sdkHttpResponse().isSuccessful()) {
+                if (action == CHECK) {
+                    TestDnsAnswerResponse check = (TestDnsAnswerResponse) actionResult;
+                    return check.recordData().size() == 1 && check.recordData().get(0).equals("\"" + digest + "\"");
+                }
+                return true;
+            }
+        } catch (InterruptedException | ExecutionException ex) {
+            LOG.log(Level.SEVERE, "ERROR performing {0} action for dns name {1}. Reason: {2}", new Object[]{action, dnsName, ex});
+        }
+
+        return false;
     }
 
     private static ChangeResourceRecordSetsRequest acmeDnsChallengeUpdateRequest(String idhostedzone, String challengeName, String digest, ChangeAction action) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/Route53Client.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/Route53Client.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.carapaceproxy.server.certificates;
+
+import static org.carapaceproxy.server.certificates.Route53Client.DNSChallengeAction.CHECK;
+import static org.carapaceproxy.server.certificates.Route53Client.DNSChallengeAction.DELETE;
+import static org.carapaceproxy.server.certificates.Route53Client.DNSChallengeAction.UPSERT;
+import static org.carapaceproxy.server.config.SSLCertificateConfiguration.WILDCARD_SYMBOL;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.route53.Route53AsyncClient;
+import software.amazon.awssdk.services.route53.model.Change;
+import software.amazon.awssdk.services.route53.model.ChangeAction;
+import software.amazon.awssdk.services.route53.model.ChangeBatch;
+import software.amazon.awssdk.services.route53.model.ChangeResourceRecordSetsRequest;
+import software.amazon.awssdk.services.route53.model.ListHostedZonesByNameRequest;
+import software.amazon.awssdk.services.route53.model.ListHostedZonesByNameResponse;
+import software.amazon.awssdk.services.route53.model.RRType;
+import software.amazon.awssdk.services.route53.model.ResourceRecord;
+import software.amazon.awssdk.services.route53.model.ResourceRecordSet;
+import software.amazon.awssdk.services.route53.model.Route53Response;
+import software.amazon.awssdk.services.route53.model.TestDnsAnswerRequest;
+import software.amazon.awssdk.services.route53.model.TestDnsAnswerResponse;
+
+/**
+ * Client for AWS Route53.
+ *
+ * @author paolo.venturi
+ */
+public final class Route53Client {
+
+    public enum DNSChallengeAction {
+        UPSERT,
+        DELETE,
+        CHECK
+    }
+
+    private static final String DNS_CHALLENGE_PREFIX = "_acme-challenge.";
+    private static final String HOSTEDZONE_ID_PREFIX = "/hostedzone/";
+
+    private final Route53AsyncClient client;
+
+    public Route53Client(String awsAccessKey, String awsSecretKey) {
+
+        AwsBasicCredentials awsCreds = AwsBasicCredentials.create(awsAccessKey, awsSecretKey);
+
+        client = Route53AsyncClient.builder()
+                .region(Region.AWS_GLOBAL)
+                .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
+                .build();
+    }
+
+    public void close() {
+        client.close();
+    }
+
+    public void createDNSChallengeForDomain(String domain, String digest, Consumer<Route53Response> onRequestComplete, Consumer<Throwable> onRequestFail) {
+        performActionOnDNSChallengeForDomain(domain, digest, UPSERT, onRequestComplete, onRequestFail);
+    }
+
+    public void deleteDNSChallengeForDomain(String domain, String digest, Consumer<Route53Response> onRequestComplete, Consumer<Throwable> onRequestFail) {
+        performActionOnDNSChallengeForDomain(domain, digest, DELETE, onRequestComplete, onRequestFail);
+    }
+
+    public void isDNSChallengeForDomainAvailable(String domain, String digest, Consumer<Boolean> onRequestComplete, Consumer<Throwable> onRequestFail) {
+        Consumer<Route53Response> check = res -> {
+            TestDnsAnswerResponse r = (TestDnsAnswerResponse) res;
+            onRequestComplete.accept(r.recordData().size() == 1 && r.recordData().get(0).equals("\"" + digest + "\""));
+        };
+        performActionOnDNSChallengeForDomain(domain, null, CHECK, check, onRequestFail);
+    }
+
+    private void performActionOnDNSChallengeForDomain(String domain, String digest, DNSChallengeAction action, Consumer<Route53Response> onRequestComplete,
+                                                      Consumer<Throwable> onRequestFail) {
+        String challengeName = DNS_CHALLENGE_PREFIX + domain.replace(WILDCARD_SYMBOL, "");
+
+        // find out the hostedzone where to update the acme dns-challenge txt record
+        CompletableFuture<ListHostedZonesByNameResponse> futureFindHZ = client.listHostedZonesByName(
+                ListHostedZonesByNameRequest.builder().dnsName(domain).build()
+        );
+
+        futureFindHZ.whenComplete((resFindHZ, excFindHZ) -> {
+            if (excFindHZ == null && resFindHZ.sdkHttpResponse().isSuccessful() && !resFindHZ.hostedZones().isEmpty()) {
+                String idhostedzone = resFindHZ.hostedZones().get(0).id().replace(HOSTEDZONE_ID_PREFIX, "");
+                CompletableFuture<? extends Route53Response> future;
+                switch (action) {
+                    case UPSERT:
+                        // ACME DNS-challenge TXT record upsert
+                        future = client.changeResourceRecordSets(
+                                acmeDNSChallengeUpdateRequest(idhostedzone, challengeName, digest, ChangeAction.UPSERT)
+                        );
+                        break;
+                    case DELETE:
+                        // ACME DNS-challenge TXT record delete
+                        future = client.changeResourceRecordSets(
+                                acmeDNSChallengeUpdateRequest(idhostedzone, challengeName, digest, ChangeAction.DELETE)
+                        );
+                        break;
+                    case CHECK:
+                        // ACME DNS-challenge TXT record availability check
+                        future = client.testDNSAnswer(TestDnsAnswerRequest.builder()
+                                .hostedZoneId(idhostedzone)
+                                .recordName(challengeName)
+                                .recordType(RRType.TXT)
+                                .build()
+                        );
+                        break;
+                    default:
+                        onRequestFail.accept(new IllegalArgumentException("Unexpected value for action: " + action));
+                        return;
+                }
+                future.whenComplete((res, exc) -> {
+                    if (exc == null && res.sdkHttpResponse().isSuccessful()) {
+                        onRequestComplete.accept(res);
+                    } else {
+                        onRequestFail.accept(exc);
+                    }
+                });
+            } else {
+                onRequestFail.accept(excFindHZ);
+            }
+        });
+    }
+
+    private static ChangeResourceRecordSetsRequest acmeDNSChallengeUpdateRequest(String idhostedzone, String challengeName, String digest, ChangeAction action) {
+        ResourceRecordSet txtRecord = ResourceRecordSet.builder()
+                .name(challengeName)
+                .ttl(3600L) // an hour
+                .type(RRType.TXT)
+                .resourceRecords(ResourceRecord.builder().value("\"" + digest + "\"").build())
+                .build();
+
+        Change txtRecordCreateRequest = Change.builder()
+                .action(action)
+                .resourceRecordSet(txtRecord)
+                .build();
+
+        ChangeBatch changeBatch = ChangeBatch.builder()
+                .changes(txtRecordCreateRequest)
+                .build();
+
+        return ChangeResourceRecordSetsRequest.builder()
+                .hostedZoneId(idhostedzone)
+                .changeBatch(changeBatch)
+                .build();
+    }
+
+}

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/SSLCertificateConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/SSLCertificateConfiguration.java
@@ -29,6 +29,8 @@ import static org.carapaceproxy.server.config.SSLCertificateConfiguration.Certif
  */
 public class SSLCertificateConfiguration {
 
+    public static final String WILDCARD_SYMBOL = "*.";
+
     public static enum CertificateMode {
         STATIC, ACME, MANUAL
     }
@@ -46,7 +48,7 @@ public class SSLCertificateConfiguration {
         if (hostname.equals("*")) {
             this.hostname = "";
             this.wildcard = true;
-        } else if (hostname.startsWith("*.")) {
+        } else if (hostname.startsWith(WILDCARD_SYMBOL)) {
             this.hostname = hostname.substring(2);
             this.wildcard = true;
         } else {

--- a/carapace-server/src/main/java/org/carapaceproxy/utils/APIUtils.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/utils/APIUtils.java
@@ -1,25 +1,26 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 package org.carapaceproxy.utils;
 
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.AVAILABLE;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.DNS_CHALLENGE_WAIT;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.EXPIRED;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.ORDERING;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.REQUEST_FAILED;
@@ -52,6 +53,8 @@ public abstract class APIUtils {
         switch (state) {
             case WAITING:
                 return "waiting"; // certificate waiting for issuing/renews
+            case DNS_CHALLENGE_WAIT:
+                return "dns-challenge-wait"; // dns challenge waiting to be visible before CA checking
             case VERIFYING:
                 return "verifying"; // challenge verification by LE pending
             case VERIFIED:
@@ -76,6 +79,8 @@ public abstract class APIUtils {
         switch (state.toLowerCase()) {
             case "waiting":
                 return WAITING;
+            case "dns-challenge-wait":
+                return DNS_CHALLENGE_WAIT;
             case "verifying":
                 return VERIFYING;
             case "verified":

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesTest.java
@@ -78,6 +78,7 @@ import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.D
 import static org.carapaceproxy.utils.CertificatesUtils.createKeystore;
 import java.util.Base64;
 import org.carapaceproxy.server.config.SSLCertificateConfiguration;
+import org.powermock.reflect.Whitebox;
 
 /**
  * Test use cases for basic certificates management and client requests.
@@ -512,7 +513,7 @@ public class CertificatesTest extends UseAdminServer {
         X509Certificate renewed = (X509Certificate) generateSampleChain(keyPair, false)[0];
         when(_cert.getCertificateChain()).thenReturn(Arrays.asList(renewed));
         when(ac.fetchCertificateForOrder(any())).thenReturn(_cert);
-        dcMan.setACMEClient(ac);
+        Whitebox.setInternalState(dcMan, ac);
 
         // Renew
         dcMan.run();

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesTest.java
@@ -32,7 +32,6 @@ import java.security.cert.Certificate;
 import java.util.Properties;
 import org.carapaceproxy.api.UseAdminServer;
 import static org.carapaceproxy.utils.CertificatesTestUtils.uploadCertificate;
-import static org.carapaceproxy.utils.CertificatesUtils.createKeystore;
 import org.carapaceproxy.utils.RawHttpClient;
 import org.carapaceproxy.utils.RawHttpClient.HttpResponse;
 import static org.junit.Assert.assertEquals;
@@ -76,6 +75,8 @@ import org.shredzone.acme4j.Login;
 import org.shredzone.acme4j.Order;
 import org.shredzone.acme4j.util.KeyPairUtils;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_DAYS_BEFORE_RENEWAL;
+import static org.carapaceproxy.utils.CertificatesUtils.createKeystore;
+import java.util.Base64;
 import org.carapaceproxy.server.config.SSLCertificateConfiguration;
 
 /**
@@ -90,6 +91,55 @@ public class CertificatesTest extends UseAdminServer {
     public WireMockRule wireMockRule = new WireMockRule(0);
 
     private Properties config;
+
+    private void configureAndStartServer() throws Exception {
+        HttpUtils.overideJvmWideHttpsVerifier();
+
+        stubFor(get(urlEqualTo("/index.html"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/html")
+                        .withBody("it <b>works</b> !!")));
+
+        config = new Properties(HTTP_ADMIN_SERVER_CONFIG);
+        config.put("config.type", "database");
+        config.put("db.jdbc.url", "jdbc:herddb:localhost");
+        config.put("db.server.base.dir", tmpDir.newFolder().getAbsolutePath());
+        startServer(config);
+
+        // Default certificate
+        String defaultCertificate = TestUtils.deployResource("localhost.p12", tmpDir.getRoot());
+        config.put("certificate.1.hostname", "*");
+        config.put("certificate.1.file", defaultCertificate);
+        config.put("certificate.1.password", "testproxy");
+
+        // SSL Listener
+        config.put("listener.1.host", "localhost");
+        config.put("listener.1.port", "8443");
+        config.put("listener.1.ssl", "true");
+        config.put("listener.1.ocsp", "true");
+        config.put("listener.1.enabled", "true");
+        config.put("listener.1.defaultcertificate", "*");
+
+        // Backend
+        config.put("backend.1.id", "localhost");
+        config.put("backend.1.enabled", "true");
+        config.put("backend.1.host", "localhost");
+        config.put("backend.1.port", wireMockRule.port() + "");
+
+        // Default director
+        config.put("director.1.id", "*");
+        config.put("director.1.backends", "*");
+        config.put("director.1.enabled", "true");
+
+        // Default route
+        config.put("route.100.id", "default");
+        config.put("route.100.enabled", "true");
+        config.put("route.100.match", "all");
+        config.put("route.100.action", "proxy-all");
+
+        changeDynamicConfiguration(config);
+    }
 
     /**
      * Test case: - Start server with a default certificate - Make request expected default certificate
@@ -363,7 +413,7 @@ public class CertificatesTest extends UseAdminServer {
         Certificate[] uploadedChain;
         KeyPair endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
         uploadedChain = generateSampleChain(endUserKeyPair, false);
-        OCSPResp ocspResp = generateOCSPResponse(uploadedChain,CertificateStatus.GOOD);
+        OCSPResp ocspResp = generateOCSPResponse(uploadedChain, CertificateStatus.GOOD);
         when(ocspMan.getOcspResponseForCertificate(uploadedChain[0])).thenReturn(ocspResp.getEncoded());
         byte[] chainData = createKeystore(uploadedChain, endUserKeyPair.getPrivate());
         try (RawHttpClient client = new RawHttpClient("localhost", DEFAULT_ADMIN_PORT)) {
@@ -401,7 +451,7 @@ public class CertificatesTest extends UseAdminServer {
 
             CertificateID certId = new CertificateID(digCalcProv.get(CertificateID.HASH_SHA1), caCert, cert.getSerialNumber());
             basicBuilder.addResponse(certId, status);
-            BasicOCSPResp resp = basicBuilder.build(new JcaContentSignerBuilder("SHA256withRSA").build(KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE).getPrivate()),null, new Date());
+            BasicOCSPResp resp = basicBuilder.build(new JcaContentSignerBuilder("SHA256withRSA").build(KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE).getPrivate()), null, new Date());
 
             OCSPRespBuilder builder = new OCSPRespBuilder();
             return builder.build(OCSPRespBuilder.SUCCESSFUL, resp);
@@ -483,53 +533,41 @@ public class CertificatesTest extends UseAdminServer {
         }
     }
 
-    private void configureAndStartServer() throws Exception {
-        HttpUtils.overideJvmWideHttpsVerifier();
+    @Test
+    public void testWildcardsCertificates() throws Exception {
+        configureAndStartServer();
+        DynamicCertificatesManager dynCertsMan = server.getDynamicCertificatesManager();
 
-        stubFor(get(urlEqualTo("/index.html"))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withHeader("Content-Type", "text/html")
-                        .withBody("it <b>works</b> !!")));
+        try (RawHttpClient client = new RawHttpClient("localhost", DEFAULT_ADMIN_PORT)) {
 
-        config = new Properties(HTTP_ADMIN_SERVER_CONFIG);
-        config.put("config.type", "database");
-        config.put("db.jdbc.url", "jdbc:herddb:localhost");
-        config.put("db.server.base.dir", tmpDir.newFolder().getAbsolutePath());
-        startServer(config);
+            // upload exact
+            KeyPair endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
+            Certificate[] chain = generateSampleChain(endUserKeyPair, false);
+            byte[] chainData = createKeystore(chain, endUserKeyPair.getPrivate());
+            String chain1 = Base64.getEncoder().encodeToString(chainData);
+            uploadCertificate("localhost2", null, chainData, client, credentials);
+            CertificateData data = dynCertsMan.getCertificateDataForDomain("localhost2");
+            assertNotNull(data);
+            assertEquals(chain1, data.getChain());
+            assertFalse(data.isWildcard());
 
-        // Default certificate
-        String defaultCertificate = TestUtils.deployResource("localhost.p12", tmpDir.getRoot());
-        config.put("certificate.1.hostname", "*");
-        config.put("certificate.1.file", defaultCertificate);
-        config.put("certificate.1.password", "testproxy");
+            // upload wildcard
+            endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
+            chain = generateSampleChain(endUserKeyPair, false);
+            chainData = createKeystore(chain, endUserKeyPair.getPrivate());
+            String chain2 = Base64.getEncoder().encodeToString(chainData);
+            uploadCertificate("*.localhost2", null, chainData, client, credentials);
+            data = dynCertsMan.getCertificateDataForDomain("*.localhost2");
+            assertNotNull(data);
+            assertEquals(chain2, data.getChain());
+            assertTrue(data.isWildcard());
 
-        // SSL Listener
-        config.put("listener.1.host", "localhost");
-        config.put("listener.1.port", "8443");
-        config.put("listener.1.ssl", "true");
-        config.put("listener.1.ocsp", "true");
-        config.put("listener.1.enabled", "true");
-        config.put("listener.1.defaultcertificate", "*");
-
-        // Backend
-        config.put("backend.1.id", "localhost");
-        config.put("backend.1.enabled", "true");
-        config.put("backend.1.host", "localhost");
-        config.put("backend.1.port", wireMockRule.port() + "");
-
-        // Default director
-        config.put("director.1.id", "*");
-        config.put("director.1.backends", "*");
-        config.put("director.1.enabled", "true");
-
-        // Default route
-        config.put("route.100.id", "default");
-        config.put("route.100.enabled", "true");
-        config.put("route.100.match", "all");
-        config.put("route.100.action", "proxy-all");
-
-        changeDynamicConfiguration(config);
+            // exact still different from wildcard
+            data = dynCertsMan.getCertificateDataForDomain("localhost2");
+            assertNotNull(data);
+            assertEquals(chain1, data.getChain());
+            assertFalse(data.isWildcard());
+        }
     }
 
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
@@ -1,21 +1,21 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 package org.carapaceproxy.server.certificates;
 
@@ -91,7 +91,7 @@ public class DynamicCertificatesManagerTest {
                 "{\"url\": \"https://localhost/index\", \"type\": \"http-01\", \"token\": \"mytoken\"}"
         ));
         when(c.getAuthorization()).thenReturn("");
-        when(ac.getHTTPChallengeForOrder(any())).thenReturn(runCase.equals("challenge_null") ? null : c);
+        when(ac.getChallengeForOrder(any(), false)).thenReturn(runCase.equals("challenge_null") ? null : c);
         when(ac.checkResponseForChallenge(any())).thenReturn(runCase.equals("challenge_status_invalid") ? INVALID : VALID);
         when(ac.checkResponseForOrder(any())).thenReturn(runCase.equals("order_response_error") ? INVALID : VALID);
 
@@ -109,7 +109,7 @@ public class DynamicCertificatesManagerTest {
 
         // Store mocking
         ConfigurationStore store = mock(ConfigurationStore.class);
-        String chain = base64EncodeCertificateChain(generateSampleChain(keyPair,false), keyPair.getPrivate());
+        String chain = base64EncodeCertificateChain(generateSampleChain(keyPair, false), keyPair.getPrivate());
         when(store.loadKeyPairForDomain(anyString())).thenReturn(keyPair);
 
         // yet available certificate

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
@@ -33,6 +33,7 @@ import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64Encode
 import org.carapaceproxy.configstore.PropertiesConfigurationStore;
 import org.carapaceproxy.server.RuntimeServerConfiguration;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.AVAILABLE;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.DNS_CHALLENGE_WAIT;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.EXPIRED;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.ORDERING;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.REQUEST_FAILED;
@@ -41,12 +42,14 @@ import static org.carapaceproxy.server.certificates.DynamicCertificateState.VERI
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.WAITING;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
 import static org.carapaceproxy.utils.CertificatesTestUtils.generateSampleChain;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -56,11 +59,19 @@ import org.shredzone.acme4j.Login;
 import org.shredzone.acme4j.Order;
 import static org.shredzone.acme4j.Status.INVALID;
 import static org.shredzone.acme4j.Status.VALID;
+import java.util.Map;
+import java.util.function.Consumer;
 import org.carapaceproxy.server.HttpProxyServer;
 import org.carapaceproxy.server.Listeners;
+import org.carapaceproxy.server.certificates.DynamicCertificatesManager.DnsChallengeCreationStatus;
+import org.powermock.reflect.Whitebox;
+import org.shredzone.acme4j.Session;
+import org.shredzone.acme4j.challenge.Dns01Challenge;
 import org.shredzone.acme4j.challenge.Http01Challenge;
+import org.shredzone.acme4j.connector.Connection;
 import org.shredzone.acme4j.toolbox.JSON;
 import org.shredzone.acme4j.util.KeyPairUtils;
+import software.amazon.awssdk.services.route53.model.Route53Response;
 
 /**
  * Test for DynamicCertificatesManager.
@@ -91,7 +102,7 @@ public class DynamicCertificatesManagerTest {
                 "{\"url\": \"https://localhost/index\", \"type\": \"http-01\", \"token\": \"mytoken\"}"
         ));
         when(c.getAuthorization()).thenReturn("");
-        when(ac.getChallengeForOrder(any(), false)).thenReturn(runCase.equals("challenge_null") ? null : c);
+        when(ac.getChallengeForOrder(any(), eq(false))).thenReturn(runCase.equals("challenge_null") ? null : c);
         when(ac.checkResponseForChallenge(any())).thenReturn(runCase.equals("challenge_status_invalid") ? INVALID : VALID);
         when(ac.checkResponseForOrder(any())).thenReturn(runCase.equals("order_response_error") ? INVALID : VALID);
 
@@ -105,7 +116,7 @@ public class DynamicCertificatesManagerTest {
         when(parent.getListeners()).thenReturn(mock(Listeners.class));
         DynamicCertificatesManager man = new DynamicCertificatesManager(parent);
         man.attachGroupMembershipHandler(new NullGroupMembershipHandler());
-        man.setACMEClient(ac);
+        Whitebox.setInternalState(man, ac);
 
         // Store mocking
         ConfigurationStore store = mock(ConfigurationStore.class);
@@ -191,6 +202,154 @@ public class DynamicCertificatesManagerTest {
                 verify(store, times(saveCounter)).saveCertificate(any());
             }
         }
+    }
+
+    //@Test
+    // A) record not created -> request failed
+    // B) record not created + reboot -> request failed after LIMIT attempts
+    // C) record created but not ready -> request failed after LIMIT attempts
+    // D) record created and ready -> VERIFYING
+    // E) challenge verified -> record deleted
+    // F) challenge failed -> record deleted
+    @Parameters({
+        "challenge_creation_failed",
+        "challenge_creation_failed_n_reboot",
+        "challenge_check_limit_expired",
+        "challenge_ready"
+//        "challenge_verified",
+//        "challenge_failed"
+    })
+    public void testWidlcardCertificateStateManagement(String runCase) throws Exception {
+        System.setProperty("carapace.acme.dnschallengereachabilitycheck.limit", "1");
+
+        Session session = mock(Session.class);
+        when(session.connect()).thenReturn(mock(Connection.class));
+        Login login = mock(Login.class);
+        when(login.getKeyPair()).thenReturn(KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE));
+        when(login.getSession()).thenReturn(mock(Session.class));
+
+        // ACME mocking
+        ACMEClient ac = mock(ACMEClient.class);
+        Order o = mock(Order.class);
+        when(o.getLocation()).thenReturn(new URL("https://localhost/index"));
+        when(ac.getLogin()).thenReturn(login);
+        when(ac.createOrderForDomain(any())).thenReturn(o);
+
+        Dns01Challenge c = mock(Dns01Challenge.class);
+        when(c.getDigest()).thenReturn("");
+        when(c.getJSON()).thenReturn(JSON.parse(
+                "{\"url\": \"https://localhost/index\", \"type\": \"dns-01\", \"token\": \"mytoken\"}"
+        ));
+
+        when(ac.getChallengeForOrder(any(), eq(true))).thenReturn(c);
+        when(ac.checkResponseForChallenge(any())).thenReturn(runCase.equals("challenge_failed") ? INVALID : VALID);
+
+        KeyPair keyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
+        Certificate cert = mock(Certificate.class);
+        X509Certificate _cert = (X509Certificate) generateSampleChain(keyPair, false)[0];
+        when(cert.getCertificateChain()).thenReturn(Arrays.asList(_cert));
+        when(ac.fetchCertificateForOrder(any())).thenReturn(cert);
+
+        HttpProxyServer parent = mock(HttpProxyServer.class);
+        when(parent.getListeners()).thenReturn(mock(Listeners.class));
+        DynamicCertificatesManager man = new DynamicCertificatesManager(parent);
+        man.attachGroupMembershipHandler(new NullGroupMembershipHandler());
+        Whitebox.setInternalState(man, ac);
+
+        // Route53Cliente mocking
+        Route53Client r53Client = mock(Route53Client.class);
+        doAnswer(inv -> {
+            if (runCase.startsWith("challenge_creation_failed")) {
+                Consumer<Throwable> onFail = (Consumer<Throwable>) inv.getArgument(3);
+                onFail.accept(new RuntimeException());
+            } else {
+                Consumer<Route53Response> onComplete = (Consumer<Route53Response>) inv.getArgument(2);
+                onComplete.accept(mock(Route53Response.class));
+            }
+            return null;
+        }).when(r53Client).createDNSChallengeForDomain(any(), any(), any(), any());
+        doAnswer(inv -> {
+            Consumer<Boolean> onComplete = (Consumer<Boolean>) inv.getArgument(2);
+            onComplete.accept(!(runCase.equals("challenge_creation_failed_n_reboot") || runCase.equals("challenge_check_limit_expired")));
+            return null;
+        }).when(r53Client).isDNSChallengeForDomainAvailable(any(), any(), any(), any());
+        Whitebox.setInternalState(man, r53Client);
+
+        // Store mocking
+        ConfigurationStore store = mock(ConfigurationStore.class);
+        String chain = base64EncodeCertificateChain(generateSampleChain(keyPair, false), keyPair.getPrivate());
+        when(store.loadKeyPairForDomain(anyString())).thenReturn(keyPair);
+
+        // certificate to order
+        String domain = "*.localhost";
+        CertificateData cd1 = new CertificateData(domain, "", "", WAITING, "", "", false);
+        when(store.loadCertificateForDomain(eq(domain))).thenReturn(cd1);
+        man.setConfigurationStore(store);
+
+        // Manager setup
+        Properties props = new Properties();
+        props.setProperty("certificate.1.hostname", domain);
+        props.setProperty("certificate.1.mode", "acme");
+        props.setProperty("certificate.1.daysbeforerenewal", "0");
+        props.setProperty("aws.accesskey", "access");
+        props.setProperty("aws.secretkey", "secret");
+        ConfigurationStore configStore = new PropertiesConfigurationStore(props);
+        RuntimeServerConfiguration conf = new RuntimeServerConfiguration();
+        conf.configure(configStore);
+        man.reloadConfiguration(conf);
+
+        CertificateData certData = man.getCertificateDataForDomain(domain);
+        assertThat(certData.isWildcard(), is(true));
+
+        int saveCounter = 0; // at every run the certificate has to be saved to the db (whether not AVAILABLE).
+
+        // WAITING -> dns-challeng-record creation
+        assertEquals(WAITING, man.getStateOfCertificate(domain));
+        man.run();
+        verify(store, times(++saveCounter)).saveCertificate(any());
+        assertThat(man.getStateOfCertificate(domain), is(DNS_CHALLENGE_WAIT));
+
+        // simulate reboot -> challenges creation status erased.
+        if (runCase.equals("challenge_creation_failed_n_reboot")) {
+            Map<String, DnsChallengeCreationStatus> status = (Map<String, DnsChallengeCreationStatus>) Whitebox.getInternalState(man, "dnsChallegesCreationStatus");
+            status.clear();
+        }
+
+        man.run();
+        verify(store, times(++saveCounter)).saveCertificate(any());
+        if (runCase.equals("challenge_creation_failed")) { // REQUEST_FAILED
+            assertThat(man.getStateOfCertificate(domain), is(REQUEST_FAILED));
+        } else { // DNS_CHALLENGE_WAIT
+            assertThat(man.getStateOfCertificate(domain), is(DNS_CHALLENGE_WAIT));
+            man.run();
+            verify(store, times(++saveCounter)).saveCertificate(any());
+            DynamicCertificateState expected =
+                    runCase.equals("challenge_creation_failed_n_reboot") || runCase.equals("challenge_check_limit_expired")
+                    ? REQUEST_FAILED : VERIFYING;
+            assertThat(man.getStateOfCertificate(domain), is(expected));
+        }
+//        // ORDERING
+//        if (!runCase.equals("challenge_status_invalid")) {
+//            man.run();
+//            assertEquals(runCase.equals("order_response_error") ? REQUEST_FAILED : AVAILABLE, man.getStateOfCertificate(domain));
+//            verify(store, times(++saveCounter)).saveCertificate(any());
+//            man.run();
+//            if (runCase.equals("order_response_error")) { // REQUEST_FAILED
+//                assertEquals(WAITING, man.getStateOfCertificate(domain));
+//                verify(store, times(++saveCounter)).saveCertificate(any());
+//            } else { // AVAILABLE
+//                DynamicCertificateState state = man.getStateOfCertificate(domain);
+//                assertEquals(runCase.equals("available_to_expired") ? EXPIRED : AVAILABLE, state);
+//                saveCounter += AVAILABLE.equals(state) ? 0 : 1; // only with state AVAILABLE the certificate hasn't to be saved.
+//                verify(store, times(saveCounter)).saveCertificate(any());
+//
+//                man.run();
+//                state = man.getStateOfCertificate(domain);
+//                assertEquals(runCase.equals("available_to_expired") ? WAITING : AVAILABLE, state);
+//                saveCounter += AVAILABLE.equals(state) ? 0 : 1; // only with state AVAILABLE the certificate hasn't to be saved.
+//                verify(store, times(saveCounter)).saveCertificate(any());
+//            }
+//        }
     }
 
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/Route53ClientTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/Route53ClientTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.carapaceproxy.server.certificates;
+
+import org.junit.Test;
+
+/**
+ *
+ * @author paolo.venturi
+ */
+public class Route53ClientTest {
+
+    @Test
+    public void testCRUD() throws InterruptedException {
+        Route53Client r53Client = new Route53Client(
+                null, null
+        );
+
+        r53Client.createDNSChallengeForDomain(
+                "testcara.tld",
+                "digest",
+                res -> System.out.println("RES: " + res),
+                err -> System.out.println("ERR: " + err)
+        );
+        Thread.sleep(1_000 * 5);
+        r53Client.isDNSChallengeForDomainAvailable(
+                "testcara.tld",
+                "digest",
+                res -> System.out.println("RES: " + res),
+                err -> System.out.println("ERR: " + err)
+        );
+
+        r53Client.deleteDNSChallengeForDomain(
+                "testcara.tld",
+                "digest",
+                res -> System.out.println("RES: " + res),
+                err -> System.out.println("ERR: " + err)
+        );
+
+        Thread.sleep(1_000 * 5);
+        r53Client.isDNSChallengeForDomainAvailable(
+                "testcara.tld",
+                "digest",
+                res -> System.out.println("RES: " + res),
+                err -> System.out.println("ERR: " + err)
+        );
+        Thread.sleep(1_000 * 60);
+    }
+}

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/Route53ClientTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/Route53ClientTest.java
@@ -20,6 +20,7 @@
 package org.carapaceproxy.server.certificates;
 
 /**
+ * Class for testing real AWS Route53 calls.
  *
  * @author paolo.venturi
  */
@@ -31,33 +32,53 @@ public class Route53ClientTest {
                 null, null
         );
 
-        r53Client.createDNSChallengeForDomain(
-                "testcara.tld",
+        r53Client.createDnsChallengeForDomain(
+                "*.testcara.tld",
                 "digest",
-                res -> System.out.println("RES: " + res),
-                err -> System.out.println("ERR: " + err)
+                (res, err) -> {
+                    if (err == null) {
+                        System.out.println("RES: " + res);
+                    } else {
+                        System.out.println("ERR: " + err);
+                    }
+                }
         );
         Thread.sleep(1_000 * 5);
-        r53Client.isDNSChallengeForDomainAvailable(
-                "testcara.tld",
+        r53Client.isDnsChallengeForDomainAvailable(
+                "*.testcara.tld",
                 "digest",
-                res -> System.out.println("RES: " + res),
-                err -> System.out.println("ERR: " + err)
+                (res, err) -> {
+                    if (err == null) {
+                        System.out.println("RES: " + res);
+                    } else {
+                        System.out.println("ERR: " + err);
+                    }
+                }
         );
 
-        r53Client.deleteDNSChallengeForDomain(
-                "testcara.tld",
+        r53Client.deleteDnsChallengeForDomain(
+                "*.testcara.tld",
                 "digest",
-                res -> System.out.println("RES: " + res),
-                err -> System.out.println("ERR: " + err)
+                (res, err) -> {
+                    if (err == null) {
+                        System.out.println("RES: " + res);
+                    } else {
+                        System.out.println("ERR: " + err);
+                    }
+                }
         );
 
         Thread.sleep(1_000 * 5);
-        r53Client.isDNSChallengeForDomainAvailable(
-                "testcara.tld",
+        r53Client.isDnsChallengeForDomainAvailable(
+                "*.testcara.tld",
                 "digest",
-                res -> System.out.println("RES: " + res),
-                err -> System.out.println("ERR: " + err)
+                (res, err) -> {
+                    if (err == null) {
+                        System.out.println("RES: " + res);
+                    } else {
+                        System.out.println("ERR: " + err);
+                    }
+                }
         );
         Thread.sleep(1_000 * 60);
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/Route53ClientTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/Route53ClientTest.java
@@ -32,54 +32,11 @@ public class Route53ClientTest {
                 null, null
         );
 
-        r53Client.createDnsChallengeForDomain(
-                "*.testcara.tld",
-                "digest",
-                (res, err) -> {
-                    if (err == null) {
-                        System.out.println("RES: " + res);
-                    } else {
-                        System.out.println("ERR: " + err);
-                    }
-                }
-        );
-        Thread.sleep(1_000 * 5);
-        r53Client.isDnsChallengeForDomainAvailable(
-                "*.testcara.tld",
-                "digest",
-                (res, err) -> {
-                    if (err == null) {
-                        System.out.println("RES: " + res);
-                    } else {
-                        System.out.println("ERR: " + err);
-                    }
-                }
-        );
+        System.out.println("RES: " + r53Client.createDnsChallengeForDomain("*.testcara.tld", "digest"));
 
-        r53Client.deleteDnsChallengeForDomain(
-                "*.testcara.tld",
-                "digest",
-                (res, err) -> {
-                    if (err == null) {
-                        System.out.println("RES: " + res);
-                    } else {
-                        System.out.println("ERR: " + err);
-                    }
-                }
-        );
+        System.out.println("RES: " + r53Client.isDnsChallengeForDomainAvailable("*.testcara.tld", "digest"));
 
-        Thread.sleep(1_000 * 5);
-        r53Client.isDnsChallengeForDomainAvailable(
-                "*.testcara.tld",
-                "digest",
-                (res, err) -> {
-                    if (err == null) {
-                        System.out.println("RES: " + res);
-                    } else {
-                        System.out.println("ERR: " + err);
-                    }
-                }
-        );
-        Thread.sleep(1_000 * 60);
+        System.out.println("RES: " + r53Client.deleteDnsChallengeForDomain("*.testcara.tld", "digest"));
     }
+
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/Route53ClientTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/Route53ClientTest.java
@@ -19,15 +19,13 @@
  */
 package org.carapaceproxy.server.certificates;
 
-import org.junit.Test;
-
 /**
  *
  * @author paolo.venturi
  */
 public class Route53ClientTest {
 
-    @Test
+    //@Test
     public void testCRUD() throws InterruptedException {
         Route53Client r53Client = new Route53Client(
                 null, null

--- a/carapace-ui/src/main/webapp/src/components/Configuration.vue
+++ b/carapace-ui/src/main/webapp/src/components/Configuration.vue
@@ -5,7 +5,7 @@
             id="status-alert"
             fade
             dismissible
-            :show="opMessage ? 5 : 0"
+            :show="showAlert"
             @dismissed="opMessage = ''"
             :variant="opSuccess ? 'success' : 'danger'"
         >{{opMessage}}</b-alert>
@@ -42,6 +42,14 @@ export default {
     created() {
         this.fetch();
     },
+    computed: {
+        showAlert() {
+            if (!this.opSuccess) {
+                return true;
+            }
+            return this.opMessage ? 5 : 0;
+        }
+    },
     methods: {
         save() {
             doPost(
@@ -51,7 +59,7 @@ export default {
                     this.opSuccess = data.ok;
                     this.opMessage = data.ok
                         ? "Configuration saved successfully."
-                        : "Error: unable to save the configuration.";
+                        : "Error: unable to save the configuration. Reason: " + data.error;
                 },
                 error => {
                     this.opSuccess = false;
@@ -87,7 +95,7 @@ export default {
                     this.opSuccess = data.ok;
                     this.opMessage = data.ok
                         ? "Configuration is ok."
-                        : "Error: configuration contains some errors, check it out before save it.";
+                        : "Error: configuration contains some errors. Details: " + data.error;
                 },
                 error => {
                     this.opSuccess = false;

--- a/carapace-ui/src/main/webapp/src/components/Configuration.vue
+++ b/carapace-ui/src/main/webapp/src/components/Configuration.vue
@@ -5,7 +5,7 @@
             id="status-alert"
             fade
             dismissible
-            :show="showAlert"
+            :show="opMessage ? 10 : 0"
             @dismissed="opMessage = ''"
             :variant="opSuccess ? 'success' : 'danger'"
         >{{opMessage}}</b-alert>
@@ -41,14 +41,6 @@ export default {
     },
     created() {
         this.fetch();
-    },
-    computed: {
-        showAlert() {
-            if (!this.opSuccess) {
-                return true;
-            }
-            return this.opMessage ? 5 : 0;
-        }
     },
     methods: {
         save() {


### PR DESCRIPTION
Now can be ordered wildcard certificates in form of *.mydomain.com by Let's Encrypt CA