### PR TITLE
Carapace pre-release fixes

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
@@ -473,6 +473,12 @@ public class HttpProxyServer implements AutoCloseable {
         LOG.info("admin.advertised.host=" + adminAdvertisedServerHost);
         LOG.info("listener.offset.port=" + listenersOffsetPort);
         LOG.info("userrealm.class=" + userRealmClassname);
+
+        String awsAccessKey = properties.getString("aws.accesskey", null);
+        LOG.log(Level.INFO, "aws.accesskey={0}", awsAccessKey);
+        String awsSecretKey = properties.getString("aws.secretkey", null);
+        LOG.log(Level.INFO, "aws.secretkey={0}", awsSecretKey);
+        this.dynamicCertificatesManager.initAWSClient(awsAccessKey, awsSecretKey);
     }
 
     private static List<RequestFilter> buildFilters(RuntimeServerConfiguration currentConfiguration) throws ConfigurationNotValidException {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
@@ -78,8 +78,6 @@ public class RuntimeServerConfiguration {
     private int keyPairsSize = DEFAULT_KEYPAIRS_SIZE;
     private List<String> supportedSSLProtocols = null;
     private int ocspStaplingManagerPeriod = 0;
-    private String awsAccessKey;
-    private String awsSecretKey;
 
     public String getAccessLogPath() {
         return accessLogPath;
@@ -227,14 +225,6 @@ public class RuntimeServerConfiguration {
         return ocspStaplingManagerPeriod;
     }
 
-    public String getAwsAccessKey() {
-        return awsAccessKey;
-    }
-
-    public String getAwsSecretKey() {
-        return awsSecretKey;
-    }
-
     public void configure(ConfigurationStore properties) throws ConfigurationNotValidException {
         LOG.log(Level.INFO, "configuring from {0}", properties);
         this.maxConnectionsPerEndpoint = properties.getInt("connectionsmanager.maxconnectionsperendpoint", maxConnectionsPerEndpoint);
@@ -279,11 +269,6 @@ public class RuntimeServerConfiguration {
         LOG.info("accesslog.flush.interval=" + accessLogFlushInterval);
         LOG.info("accesslog.failure.wait=" + accessLogWaitBetweenFailures);
 
-        awsAccessKey = properties.getString("aws.accesskey", null);
-        LOG.log(Level.INFO, "aws.accesskey={0}", awsAccessKey);
-        awsSecretKey = properties.getString("aws.secretkey", null);
-        LOG.log(Level.INFO, "aws.secretkey={0}", awsSecretKey);
-
         tryConfigureCertificates(properties);
         tryConfigureListeners(properties);
         tryConfigureFilters(properties);
@@ -323,11 +308,6 @@ public class RuntimeServerConfiguration {
                     SSLCertificateConfiguration config = new SSLCertificateConfiguration(hostname, file, pw, _mode);
                     if (config.isAcme()) {
                         config.setDaysBeforeRenewal(daysBeforeRenewal);
-                        if (config.isWildcard() && (awsAccessKey == null || awsSecretKey == null)) {
-                            throw new ConfigurationNotValidException(
-                                    "For ACME wildcards certificates AWS Route53 credentials has to be set"
-                            );
-                        }
                     }
                     this.addCertificate(config);
                 } catch (IllegalArgumentException e) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/ACMEClient.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/ACMEClient.java
@@ -78,10 +78,9 @@ public class ACMEClient {
      * {@link Session#getKeyIdentifier()} and store it somewhere. If you need to get access to your account later, reconnect to it via {@link Account#bind(Session, URI)} by using the stored location.
      *
      * @return
-     * @throws java.io.IOException
      * @throws org.shredzone.acme4j.exception.AcmeException
      */
-    public Login getLogin() throws IOException, AcmeException {
+    public Login getLogin() throws AcmeException {
         Session session = new Session(testingModeOn ? TESTING_CA : PRODUCTION_CA);
 
         return new AccountBuilder()
@@ -93,7 +92,7 @@ public class ACMEClient {
     /*
      * Methods for step-by-step certificate issuing
      */
-    public Order createOrderForDomain(String... domains) throws AcmeException, IOException {
+    public Order createOrderForDomain(String... domains) throws AcmeException {
         Account acct = getLogin().getAccount();
 
         return acct.newOrder().domains(domains).create();
@@ -167,7 +166,7 @@ public class ACMEClient {
         return challenge;
     }
 
-    public Status checkResponseForChallenge(Challenge challenge) throws AcmeException, IOException {
+    public Status checkResponseForChallenge(Challenge challenge) throws AcmeException {
         Status status = challenge.getStatus();
 
         // The authorization is already valid. No need to process a challenge.
@@ -200,7 +199,7 @@ public class ACMEClient {
         order.execute(csrb.getEncoded());
     }
 
-    public Status checkResponseForOrder(Order order) throws IOException, AcmeException {
+    public Status checkResponseForOrder(Order order) throws AcmeException {
         LOG.info("Certificate order checking for domain {}", order.getIdentifiers().get(0).getDomain());
         Status status = order.getStatus();
 
@@ -213,7 +212,7 @@ public class ACMEClient {
         return status;
     }
 
-    public Certificate fetchCertificateForOrder(Order order) throws AcmeException, IOException {
+    public Certificate fetchCertificateForOrder(Order order) throws AcmeException {
         Certificate certificate = order.getCertificate();
         String domain = order.getIdentifiers().get(0).getDomain();
         if (certificate == null) {

--- a/carapace-server/src/main/resources/conf/cluster.properties
+++ b/carapace-server/src/main/resources/conf/cluster.properties
@@ -33,3 +33,7 @@ admin.accesslog.path=admin.access.log
 admin.accesslog.format.timezone=GMT
 #number of days after wich rotated log files will be deleted
 admin.accesslog.retention.days=90
+
+# AWS Credentials
+#aws.accesskey=
+#aws.secretkey=

--- a/carapace-server/src/main/resources/conf/server.properties
+++ b/carapace-server/src/main/resources/conf/server.properties
@@ -18,3 +18,7 @@ admin.accesslog.retention.days=90
 # User Realm
 #userrealm.class=org.carapaceproxy.user.FileUserRealm
 #userrealm.path=conf/user.properties
+
+# AWS Credentials
+#aws.accesskey=
+#aws.secretkey=

--- a/carapace-server/src/test/java/org/carapaceproxy/ApplyConfigurationTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/ApplyConfigurationTest.java
@@ -98,6 +98,8 @@ public class ApplyConfigurationTest {
             {
                 Properties configuration = new Properties();
                 configuration.put("mapper.class", StaticEndpointMapper.class.getName());
+                configuration.put("aws.accesskey", "accesskey");
+                configuration.put("aws.secretkey", "secretkey");
                 server.configureAtBoot(new PropertiesConfigurationStore(configuration));
             }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/ManagersExecutionTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/ManagersExecutionTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -93,7 +94,7 @@ public class ManagersExecutionTest {
     }
 
     @Test
-    public void testDynamicCertificatesManagerExecution() {
+    public void testDynamicCertificatesManagerExecution() throws ConfigurationNotValidException {
         RuntimeServerConfiguration config = new RuntimeServerConfiguration();
         DynamicCertificatesManager man = new DynamicCertificatesManager(null);
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesTest.java
@@ -106,6 +106,8 @@ public class CertificatesTest extends UseAdminServer {
         config.put("config.type", "database");
         config.put("db.jdbc.url", "jdbc:herddb:localhost");
         config.put("db.server.base.dir", tmpDir.newFolder().getAbsolutePath());
+        config.put("aws.accesskey", "accesskey");
+        config.put("aws.secretkey", "secretkey");
         startServer(config);
 
         // Default certificate

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
@@ -285,8 +285,8 @@ public class DynamicCertificatesManagerTest {
         man.run();
         verify(store, times(++saveCounter)).saveCertificate(any());
         if (runCase.equals("challenge_creation_failed")) {
-            // REQUEST_FAILED
-            assertThat(man.getStateOfCertificate(domain), is(REQUEST_FAILED));
+            // WAITING
+            assertThat(man.getStateOfCertificate(domain), is(WAITING));
         } else {
             // DNS_CHALLENGE_WAIT
             assertThat(man.getStateOfCertificate(domain), is(DNS_CHALLENGE_WAIT));

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
@@ -250,6 +250,7 @@ public class DynamicCertificatesManagerTest {
         Whitebox.setInternalState(man, ac);
 
         // Route53Cliente mocking
+        man.initAWSClient("access", "secret");
         Route53Client r53Client = mock(Route53Client.class);
         when(r53Client.createDnsChallengeForDomain(any(), any())).thenReturn(!runCase.startsWith("challenge_creation_failed"));
         when(r53Client.isDnsChallengeForDomainAvailable(any(), any())).thenReturn(!(runCase.equals("challenge_creation_failed_n_reboot") || runCase.equals("challenge_check_limit_expired")));
@@ -270,8 +271,6 @@ public class DynamicCertificatesManagerTest {
         props.setProperty("certificate.1.hostname", domain);
         props.setProperty("certificate.1.mode", "acme");
         props.setProperty("certificate.1.daysbeforerenewal", "0");
-        props.setProperty("aws.accesskey", "access");
-        props.setProperty("aws.secretkey", "secret");
         ConfigurationStore configStore = new PropertiesConfigurationStore(props);
         RuntimeServerConfiguration conf = new RuntimeServerConfiguration();
         conf.configure(configStore);


### PR DESCRIPTION
- Now aws secret/access keys has to be set in static configuration

- AcmeExceptions (ex network errors) does not set certificate state to request failed anymore: all previous states stuff are stored on db or cached on Let's Encrypt, so redoing a request from scratch is just a waste of time/resources.