### PR TITLE
Connections management improvement

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,26 @@
+Is this a question, a feature request or a bug report?
+
+
+**FEATURE REQUEST**
+
+1. Please describe the feature you are requesting.
+
+2. Indicate the importance of this issue to you (blocker, must-have, should-have, nice-to-have). Are you currently using any workarounds to address this issue?
+
+3. Provide any additional detail on your proposed use case for this feature.
+
+4. If there are some sub-tasks using -[] for each subtask and create a corresponding issue to map to the sub task:
+- [ ] [sub-task1-issue-number](example_sub_issue1_link_here): sub-task1 discription here, 
+- [ ] [sub-task2-issue-number](example_sub_issue2_link_here): sub-task2 discription here,
+- ...
+
+
+**BUG REPORT**
+
+1. Please describe the issue you observed:
+
+- What did you do?
+
+- What did you expect to see?
+
+- What did you see instead?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+Following this checklist to help us incorporate your 
+contribution quickly and easily:
+
+ - [ ] Each commit in the pull request should have a meaningful subject line and body.
+ - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
+ - [ ] Rember to add the correct license header to new files.
+ - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
+       be performed on your pull request automatically.
+
+To make clear that you license your contribution under 
+the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
+you have to acknowledge this by using the following check-box.
+
+ - [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership.  The ASF licenses this file to you
+# under the Apache License, Version 2.0 (the # "License"); you may not use this
+# file except in compliance with the License.  You may obtain a copy of the License
+# at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+name: Java CI - Code validation and tests (checkstyle,rat,spotbugs)
+on: [pull_request]
+env:
+  MAVEN_OPTS: -Dmaven.artifact.threads=4 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn  -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v2
+      - name: 'Set up JDK 11'
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: 'Cache Maven packages'
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: 'cache'
+          restore-keys: 'cache'
+      - name: 'Build with Maven'
+        run: mvn -B checkstyle:check install spotbugs:check -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml
+      - name: 'Remove Snapshots Before Caching'
+        run: find ~/.m2 -name '*SNAPSHOT' | xargs rm -Rf

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -13,7 +13,7 @@
 # CONDITIONS OF ANY KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations under the License.
 #
-name: Java CI - Code validation and tests (checkstyle,rat,spotbugs)
+name: Java CI - Code tests
 on: [pull_request]
 env:
   MAVEN_OPTS: -Dmaven.artifact.threads=4 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn  -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
@@ -37,6 +37,6 @@ jobs:
           key: 'cache'
           restore-keys: 'cache'
       - name: 'Build with Maven'
-        run: mvn -B checkstyle:check install spotbugs:check -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false --file pom.xml
+        run: mvn verify -Pproduction -Dmaven.test.redirectTestOutputToFile=true -Dsurefire.rerunFailingTestsCount=3
       - name: 'Remove Snapshots Before Caching'
         run: find ~/.m2 -name '*SNAPSHOT' | xargs rm -Rf

--- a/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
@@ -164,7 +164,7 @@ public class EndpointConnectionImpl implements EndpointConnection {
             }
         });
         try {
-            connectFuture.get(parent.getConnectTimeout() * 2, TimeUnit.MILLISECONDS);
+            connectFuture.get(parent.getConnectTimeout() * 2, TimeUnit.MILLISECONDS); // we need to wait for socket timeout first and not for future one
         } catch (InterruptedException err) {
             Thread.currentThread().interrupt();
             throw new IOException(err);

--- a/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
@@ -164,7 +164,7 @@ public class EndpointConnectionImpl implements EndpointConnection {
             }
         });
         try {
-            connectFuture.get(parent.getConnectTimeout(), TimeUnit.MILLISECONDS);
+            connectFuture.get(parent.getConnectTimeout() * 2, TimeUnit.MILLISECONDS);
         } catch (InterruptedException err) {
             Thread.currentThread().interrupt();
             throw new IOException(err);

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
@@ -58,6 +58,7 @@ public class RuntimeServerConfiguration {
     private int maxConnectionsPerEndpoint = 10;
     private int idleTimeout = 60000;
     private int stuckRequestTimeout = 120000;
+    private boolean backendsUnreachableOnStuckRequests = true;
     private int connectTimeout = 10000;
     private int borrowTimeout = 60000;
     private long cacheMaxSize = 0;
@@ -167,6 +168,14 @@ public class RuntimeServerConfiguration {
         this.stuckRequestTimeout = stuckRequestTimeout;
     }
 
+    public boolean isBackendsUnreachableOnStuckRequests() {
+        return backendsUnreachableOnStuckRequests;
+    }
+
+    public void setBackendsUnreachableOnStuckRequests(boolean backendsUnreachableOnStuckRequests) {
+        this.backendsUnreachableOnStuckRequests = backendsUnreachableOnStuckRequests;
+    }
+
     public int getConnectTimeout() {
         return connectTimeout;
     }
@@ -233,11 +242,13 @@ public class RuntimeServerConfiguration {
             throw new ConfigurationNotValidException("Invalid value '" + this.idleTimeout + "' for connectionsmanager.idletimeout");
         }
         this.stuckRequestTimeout = properties.getInt("connectionsmanager.stuckrequesttimeout", stuckRequestTimeout);
+        this.backendsUnreachableOnStuckRequests = properties.getBoolean("connectionsmanager.backendsunreachableonstuckrequests", backendsUnreachableOnStuckRequests);
         this.connectTimeout = properties.getInt("connectionsmanager.connecttimeout", connectTimeout);
         this.borrowTimeout = properties.getInt("connectionsmanager.borrowtimeout", borrowTimeout);
         LOG.info("connectionsmanager.maxconnectionsperendpoint=" + maxConnectionsPerEndpoint);
         LOG.info("connectionsmanager.idletimeout=" + idleTimeout);
         LOG.info("connectionsmanager.stuckrequesttimeout=" + stuckRequestTimeout);
+        LOG.info("connectionsmanager.backendsunreachableonstuckrequests=" + backendsUnreachableOnStuckRequests);
         LOG.info("connectionsmanager.connecttimeout=" + connectTimeout);
         LOG.info("connectionsmanager.borrowtimeout=" + borrowTimeout);
 

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
@@ -58,7 +58,7 @@ public class RuntimeServerConfiguration {
     private int maxConnectionsPerEndpoint = 10;
     private int idleTimeout = 60000;
     private int stuckRequestTimeout = 120000;
-    private boolean backendsUnreachableOnStuckRequests = true;
+    private boolean backendsUnreachableOnStuckRequests = false;
     private int connectTimeout = 10000;
     private int borrowTimeout = 60000;
     private long cacheMaxSize = 0;

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/StuckRequestsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/StuckRequestsTest.java
@@ -1,0 +1,139 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package org.carapaceproxy.backends;
+
+import org.carapaceproxy.utils.TestUtils;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.carapaceproxy.server.RequestHandler.PROPERTY_URI;
+import static org.junit.Assert.assertEquals;
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.util.Properties;
+import org.carapaceproxy.client.ConnectionsManagerStats;
+import org.carapaceproxy.client.EndpointKey;
+import org.carapaceproxy.client.impl.ConnectionsManagerImpl;
+import org.carapaceproxy.configstore.PropertiesConfigurationStore;
+import org.carapaceproxy.server.HttpProxyServer;
+import org.carapaceproxy.server.config.NetworkListenerConfiguration;
+import org.carapaceproxy.utils.RawHttpClient;
+import static org.junit.Assert.assertTrue;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.carapaceproxy.server.config.ActionConfiguration;
+import org.carapaceproxy.server.config.BackendConfiguration;
+import org.carapaceproxy.server.config.DirectorConfiguration;
+import org.carapaceproxy.server.config.RouteConfiguration;
+import org.carapaceproxy.server.mapper.StandardEndpointMapper;
+import org.carapaceproxy.server.mapper.requestmatcher.RegexpRequestMatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitParamsRunner.class)
+public class StuckRequestsTest {
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(0);
+
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
+
+
+    @Test
+    @Parameters({"true", "false"})
+    public void testBackendUnreachableOnStuckRequest(boolean backendsUnreachableOnStuckRequests) throws Exception {
+
+        stubFor(get(urlEqualTo("/index.html"))
+                .willReturn(aResponse()
+                        .withFault(Fault.EMPTY_RESPONSE)));
+
+        stubFor(get(urlEqualTo("/good-index.html"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/html")
+                        .withHeader("Content-Length", "it <b>works</b> !!".length() + "")
+                        .withBody("it <b>works</b> !!")));
+
+        final int theport =  wireMockRule.port();
+        EndpointKey key = new EndpointKey("localhost", theport);
+
+        StandardEndpointMapper mapper = new StandardEndpointMapper();
+        mapper.addBackend(new BackendConfiguration("backend-a", "localhost", theport, "/"));
+        mapper.addDirector(new DirectorConfiguration("director-1").addBackend("backend-a"));
+        mapper.addAction(new ActionConfiguration("proxy-1", ActionConfiguration.TYPE_PROXY, "director-1", null, -1));
+        mapper.addRoute(new RouteConfiguration("route-1", "proxy-1", true, new RegexpRequestMatcher(PROPERTY_URI, ".*index.html.*")));
+
+        ConnectionsManagerStats stats;
+        try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.newFolder());) {
+            Properties properties = new Properties();
+            properties.put("connectionsmanager.stuckrequesttimeout", "100"); // ms
+            properties.put("connectionsmanager.backendsunreachableonstuckrequests", backendsUnreachableOnStuckRequests + "");
+            // configure resets all listeners configurations
+            server.configureAtBoot(new PropertiesConfigurationStore(properties));
+            server.addListener(new NetworkListenerConfiguration("localhost", 0));
+            server.setMapper(mapper);
+            assertEquals(100, server.getCurrentConfiguration().getStuckRequestTimeout());
+            assertEquals(backendsUnreachableOnStuckRequests, server.getCurrentConfiguration().isBackendsUnreachableOnStuckRequests());
+            server.start();
+            stats = server.getConnectionsManager().getStats();
+            int port = server.getLocalPort();
+            assertTrue(port > 0);
+
+            try (RawHttpClient client = new RawHttpClient("localhost", port)) {
+                RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+                String s = resp.toString();
+                System.out.println("s:" + s);
+                assertEquals("HTTP/1.1 500 Internal Server Error\r\n", resp.getStatusLine());
+                assertEquals("<html>\n"
+                        + "    <body>\n"
+                        + "        An internal error occurred\n"
+                        + "    </body>        \n"
+                        + "</html>\n", resp.getBodyString());
+            }
+            TestUtils.waitForCondition(TestUtils.ALL_CONNECTIONS_CLOSED(stats), 100);
+
+            Double value = ((ConnectionsManagerImpl) server.getConnectionsManager()).getPENDING_REQUESTS_GAUGE().get();
+            assertEquals(0, value.intValue());
+
+            assertEquals(backendsUnreachableOnStuckRequests, !server.getBackendHealthManager().isAvailable(key.getHostPort()));
+
+            try (RawHttpClient client = new RawHttpClient("localhost", port)) {
+                RawHttpClient.HttpResponse resp = client.executeRequest("GET /good-index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+                String s = resp.toString();
+                System.out.println("s:" + s);
+                if (backendsUnreachableOnStuckRequests) {
+                    assertEquals("HTTP/1.1 500 Internal Server Error\r\n", resp.getStatusLine());
+                    assertEquals("<html>\n"
+                            + "    <body>\n"
+                            + "        An internal error occurred\n"
+                            + "    </body>        \n"
+                            + "</html>\n", resp.getBodyString());
+                } else {
+                    assertEquals("HTTP/1.1 200 OK\r\n", resp.getStatusLine());
+                    assertEquals("it <b>works</b> !!", resp.getBodyString());
+                }
+            }
+        }
+    }
+}

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendTest.java
@@ -70,14 +70,16 @@ public class UnreachableBackendTest {
     @Rule
     public TemporaryFolder tmpDir = new TemporaryFolder();
 
-    private boolean variant = false;
+    private boolean testCaseTrue = false;
 
-    public UnreachableBackendTest(boolean variant) {
-        this.variant = variant;
+    public UnreachableBackendTest(boolean testCaseTrue) {
+        this.testCaseTrue = testCaseTrue;
     }
 
     @Test
     public void testWithUnreachableBackend() throws Exception {
+
+        final boolean useCache = testCaseTrue;
 
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
@@ -88,7 +90,7 @@ public class UnreachableBackendTest {
 
         int dummyport = wireMockRule.port();
         wireMockRule.stop();
-        TestEndpointMapper mapper = new TestEndpointMapper("localhost", dummyport, variant);
+        TestEndpointMapper mapper = new TestEndpointMapper("localhost", dummyport, useCache);
         EndpointKey key = new EndpointKey("localhost", dummyport);
 
         ConnectionsManagerStats stats;
@@ -116,12 +118,14 @@ public class UnreachableBackendTest {
     @Test
     public void testEmptyResponse() throws Exception {
 
+        final boolean useCache = testCaseTrue;
+
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withFault(Fault.EMPTY_RESPONSE)));
 
         int dummyport = wireMockRule.port();
-        TestEndpointMapper mapper = new TestEndpointMapper("localhost", dummyport, variant);
+        TestEndpointMapper mapper = new TestEndpointMapper("localhost", dummyport, useCache);
         EndpointKey key = new EndpointKey("localhost", dummyport);
 
         ConnectionsManagerStats stats;
@@ -161,12 +165,14 @@ public class UnreachableBackendTest {
     @Test
     public void testConnectionResetByPeer() throws Exception {
 
+        final boolean useCache = testCaseTrue;
+
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withFault(Fault.CONNECTION_RESET_BY_PEER)));
 
         int dummyport = wireMockRule.port();
-        TestEndpointMapper mapper = new TestEndpointMapper("localhost", dummyport, variant);
+        TestEndpointMapper mapper = new TestEndpointMapper("localhost", dummyport, useCache);
         EndpointKey key = new EndpointKey("localhost", dummyport);
 
         ConnectionsManagerStats stats;
@@ -195,12 +201,14 @@ public class UnreachableBackendTest {
     @Test
     public void testNonHttpResponseThenClose() throws Exception {
 
+        final boolean useCache = testCaseTrue;
+
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withFault(Fault.RANDOM_DATA_THEN_CLOSE)));
 
         int dummyport = wireMockRule.port();
-        TestEndpointMapper mapper = new TestEndpointMapper("localhost", dummyport, variant);
+        TestEndpointMapper mapper = new TestEndpointMapper("localhost", dummyport, useCache);
         EndpointKey key = new EndpointKey("localhost", dummyport);
 
         ConnectionsManagerStats stats;
@@ -227,7 +235,7 @@ public class UnreachableBackendTest {
                         + "    </body>        \n"
                         + "</html>\n", resp.getBodyString());
             }
-            assertFalse(server.getBackendHealthManager().isAvailable(key.getHostPort()));
+            assertTrue(server.getBackendHealthManager().isAvailable(key.getHostPort()));
             TestUtils.waitForCondition(TestUtils.ALL_CONNECTIONS_CLOSED(stats), 100);
 
         }
@@ -236,7 +244,7 @@ public class UnreachableBackendTest {
     @Test
     public void testStuckRequest() throws Exception {
 
-        final boolean backendsUnreachableOnStuckRequests = variant;
+        final boolean backendsUnreachableOnStuckRequests = testCaseTrue;
 
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
@@ -296,7 +304,7 @@ public class UnreachableBackendTest {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /good-index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                if (variant) {
+                if (testCaseTrue) {
                     assertEquals("HTTP/1.1 500 Internal Server Error\r\n", resp.getStatusLine());
                     assertEquals("<html>\n"
                             + "    <body>\n"


### PR DESCRIPTION
Added a way to avoid the disabling of backends reachability for stacked requests:
> new property connectionsmanager.backendsunreachableonstuckrequests=true|false (default false)

 Raised the timeout for connectFuture

Avoid check+recreation of connections when returned to the pool