### PR TITLE
Netty eventloop deadlock on connections release

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -37,6 +37,6 @@ jobs:
           key: 'cache'
           restore-keys: 'cache'
       - name: 'Build with Maven'
-        run: mvn verify -Pproduction -Dmaven.test.redirectTestOutputToFile=true -Dsurefire.rerunFailingTestsCount=5
+        run: mvn verify -Pproduction -Dmaven.test.redirectTestOutputToFile=true -Dsurefire.rerunFailingTestsCount=3
       - name: 'Remove Snapshots Before Caching'
         run: find ~/.m2 -name '*SNAPSHOT' | xargs rm -Rf

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -37,6 +37,6 @@ jobs:
           key: 'cache'
           restore-keys: 'cache'
       - name: 'Build with Maven'
-        run: mvn verify -Pproduction -Dmaven.test.redirectTestOutputToFile=true -Dsurefire.rerunFailingTestsCount=3
+        run: mvn verify -Pproduction -Dmaven.test.redirectTestOutputToFile=true -Dsurefire.rerunFailingTestsCount=5
       - name: 'Remove Snapshots Before Caching'
         run: find ~/.m2 -name '*SNAPSHOT' | xargs rm -Rf

--- a/carapace-server/src/main/java/org/carapaceproxy/client/impl/ConnectionsManagerImpl.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/impl/ConnectionsManagerImpl.java
@@ -312,6 +312,13 @@ public class ConnectionsManagerImpl implements ConnectionsManager, AutoCloseable
         connections.close();
         group.shutdownGracefully();
         eventLoopForOutboundConnections.shutdownGracefully();
+
+        try {
+            returnConnectionThreadPool.shutdown();
+            returnConnectionThreadPool.awaitTermination(10, TimeUnit.SECONDS);
+        } catch (InterruptedException ex) {
+            LOG.severe("Error wating for returnConnectionThreadPool termination: " + ex);
+        }
     }
 
     final ConnectionsManagerStats stats = new ConnectionsManagerStats() {

--- a/carapace-server/src/main/java/org/carapaceproxy/client/impl/ConnectionsManagerImpl.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/impl/ConnectionsManagerImpl.java
@@ -318,6 +318,7 @@ public class ConnectionsManagerImpl implements ConnectionsManager, AutoCloseable
             returnConnectionThreadPool.awaitTermination(10, TimeUnit.SECONDS);
         } catch (InterruptedException ex) {
             LOG.severe("Error wating for returnConnectionThreadPool termination: " + ex);
+            Thread.currentThread().interrupt();
         }
     }
 


### PR DESCRIPTION
Now connections releasing and recreation for the pool is done throw a dedicated thread pool instead of netty eventloop.

Sistem-property for threadpool size: _**carapace.connectionsmanager.returnconnectionthreadpool.size**_ (default **10**; 0 for rollback)