### PR TITLE
Filter requests based on server ip

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
@@ -74,7 +74,7 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
     private final boolean secure; // connection bind to https
     private String sslProtocol;
     private String cipherSuite;
-    final String serverAddress;
+    final SocketAddress serverAddress;
 
     public ClientConnectionHandler(
             EndpointMapper mapper,
@@ -82,7 +82,7 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
             List<RequestFilter> filters,
             ContentsCache cache,
             SocketAddress clientAddress,
-            String serverAddress,
+            SocketAddress serverAddress,
             StaticContentsManager staticContentsManager,
             Runnable onClientDisconnected,
             BackendHealthManager backendHealthManager,
@@ -112,7 +112,7 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
         return clientAddress;
     }
     
-    public String getServerAddress(){
+    public SocketAddress getServerAddress(){
         return serverAddress;
     }
 

--- a/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
@@ -74,6 +74,7 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
     private final boolean secure; // connection bind to https
     private String sslProtocol;
     private String cipherSuite;
+    final String serverAddress;
 
     public ClientConnectionHandler(
             EndpointMapper mapper,
@@ -81,6 +82,7 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
             List<RequestFilter> filters,
             ContentsCache cache,
             SocketAddress clientAddress,
+            String serverAddress,
             StaticContentsManager staticContentsManager,
             Runnable onClientDisconnected,
             BackendHealthManager backendHealthManager,
@@ -94,6 +96,7 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
         this.connectionsManager = connectionsManager;
         this.filters = filters;
         this.clientAddress = clientAddress;
+        this.serverAddress = serverAddress;
         this.connectionStartsTs = System.nanoTime();
         this.onClientDisconnected = onClientDisconnected;
         this.backendHealthManager = backendHealthManager;
@@ -107,6 +110,10 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
 
     public SocketAddress getClientAddress() {
         return clientAddress;
+    }
+    
+    public String getServerAddress(){
+        return serverAddress;
     }
 
     @Override

--- a/carapace-server/src/main/java/org/carapaceproxy/server/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/Listeners.java
@@ -236,7 +236,7 @@ public class Listeners {
                         ClientConnectionHandler connHandler = new ClientConnectionHandler(parent.getMapper(),
                                 parent.getConnectionsManager(),
                                 parent.getFilters(), parent.getCache(),
-                                channel.remoteAddress(), parent.getStaticContentsManager(),
+                                channel.remoteAddress(),channel.localAddress().getAddress().getHostAddress(), parent.getStaticContentsManager(),
                                 () -> CURRENT_CONNECTED_CLIENTS_GAUGE.dec(),
                                 parent.getBackendHealthManager(),
                                 parent.getRequestsLogger(),

--- a/carapace-server/src/main/java/org/carapaceproxy/server/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/Listeners.java
@@ -236,7 +236,7 @@ public class Listeners {
                         ClientConnectionHandler connHandler = new ClientConnectionHandler(parent.getMapper(),
                                 parent.getConnectionsManager(),
                                 parent.getFilters(), parent.getCache(),
-                                channel.remoteAddress(),channel.localAddress().getAddress().getHostAddress(), parent.getStaticContentsManager(),
+                                channel.remoteAddress(),channel.localAddress(), parent.getStaticContentsManager(),
                                 () -> CURRENT_CONNECTED_CLIENTS_GAUGE.dec(),
                                 parent.getBackendHealthManager(),
                                 parent.getRequestsLogger(),

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
@@ -157,7 +157,7 @@ public class RequestHandler implements MatchingContext {
     InetSocketAddress getLocalAddress() {
         return (InetSocketAddress) channelToClient.channel().localAddress();
     }
-
+    
     private void fireRequestFinished() {
         Runnable handler = onRequestFinished.getAndSet(null);
         if (handler != null) {
@@ -570,7 +570,7 @@ public class RequestHandler implements MatchingContext {
         connectionToClient.lastHttpContentSent(this);
         requestsLogger.logRequest(this);
     }
-
+    
     @Override
     public int hashCode() {
         int hash = 7;
@@ -822,6 +822,7 @@ public class RequestHandler implements MatchingContext {
     public static final String PROPERTY_HEADERS = "request.headers.";
     private static final int HEADERS_SUBSTRING_INDEX = PROPERTY_HEADERS.length();
     public static final String PROPERTY_LISTENER_ADDRESS = "listener.address";
+    public static final String PROPERTY_SERVER_IP = "request.serverip";
 
     @Override
     public String getProperty(String name) {
@@ -836,6 +837,8 @@ public class RequestHandler implements MatchingContext {
                     return request.method().name();
                 case PROPERTY_CONTENT_TYPE:
                     return request.headers().get(javax.ws.rs.core.HttpHeaders.CONTENT_TYPE, "");
+                case PROPERTY_SERVER_IP:
+                    return connectionToClient.getServerAddress();                    
                 case PROPERTY_LISTENER_ADDRESS: {
                     return connectionToClient.getListenerHost() + ":" + connectionToClient.getListenerPort();
                 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
@@ -821,8 +821,8 @@ public class RequestHandler implements MatchingContext {
     public static final String PROPERTY_CONTENT_TYPE = "request.content-type";
     public static final String PROPERTY_HEADERS = "request.headers.";
     private static final int HEADERS_SUBSTRING_INDEX = PROPERTY_HEADERS.length();
-    public static final String PROPERTY_LISTENER_HOST_PORT = "listener.address";
-    public static final String PROPERTY_LISTENER_IPADDRESS = "request.serverip";
+    public static final String PROPERTY_LISTENER_HOST_PORT = "listener.hostport";
+    public static final String PROPERTY_LISTENER_IPADDRESS = "listener.ipaddress";
 
     @Override
     public String getProperty(String name) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
@@ -838,7 +838,8 @@ public class RequestHandler implements MatchingContext {
                 case PROPERTY_CONTENT_TYPE:
                     return request.headers().get(javax.ws.rs.core.HttpHeaders.CONTENT_TYPE, "");
                 case PROPERTY_SERVER_IP:
-                    return connectionToClient.getServerAddress();                    
+                    InetSocketAddress address = (InetSocketAddress) connectionToClient.getServerAddress();
+                    return address.getAddress().getHostAddress();
                 case PROPERTY_LISTENER_ADDRESS: {
                     return connectionToClient.getListenerHost() + ":" + connectionToClient.getListenerPort();
                 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
@@ -821,8 +821,8 @@ public class RequestHandler implements MatchingContext {
     public static final String PROPERTY_CONTENT_TYPE = "request.content-type";
     public static final String PROPERTY_HEADERS = "request.headers.";
     private static final int HEADERS_SUBSTRING_INDEX = PROPERTY_HEADERS.length();
-    public static final String PROPERTY_LISTENER_ADDRESS = "listener.address";
-    public static final String PROPERTY_SERVER_IP = "request.serverip";
+    public static final String PROPERTY_LISTENER_HOST_PORT = "listener.address";
+    public static final String PROPERTY_LISTENER_IPADDRESS = "request.serverip";
 
     @Override
     public String getProperty(String name) {
@@ -837,10 +837,10 @@ public class RequestHandler implements MatchingContext {
                     return request.method().name();
                 case PROPERTY_CONTENT_TYPE:
                     return request.headers().get(javax.ws.rs.core.HttpHeaders.CONTENT_TYPE, "");
-                case PROPERTY_SERVER_IP:
+                case PROPERTY_LISTENER_IPADDRESS:
                     InetSocketAddress address = (InetSocketAddress) connectionToClient.getServerAddress();
                     return address.getAddress().getHostAddress();
-                case PROPERTY_LISTENER_ADDRESS: {
+                case PROPERTY_LISTENER_HOST_PORT: {
                     return connectionToClient.getListenerHost() + ":" + connectionToClient.getListenerPort();
                 }
                 default: {

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/requestmatcher/RequestMatcherTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/requestmatcher/RequestMatcherTest.java
@@ -23,6 +23,8 @@ import herddb.utils.TestUtils;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import javax.ws.rs.core.HttpHeaders;
 import org.carapaceproxy.server.ClientConnectionHandler;
 import org.carapaceproxy.server.RequestHandler;
@@ -224,12 +226,13 @@ public class RequestMatcherTest {
         request.headers().add(HttpHeaders.COOKIE, "test-cookie");
         request.headers().add(HttpHeaders.CONTENT_DISPOSITION, "inline");
         request.headers().add(HttpHeaders.CONTENT_TYPE, "text/html");
-
+        SocketAddress socketAddress = new InetSocketAddress("127.0.0.1", 0);
+        
         ClientConnectionHandler cch = mock(ClientConnectionHandler.class);
         when(cch.isSecure()).thenReturn(false);
         when(cch.getListenerHost()).thenReturn("localhost");
         when(cch.getListenerPort()).thenReturn(8080);
-        when(cch.getServerAddress()).thenReturn("127.0.0.1");
+        when(cch.getServerAddress()).thenReturn(socketAddress);
 
         RequestHandler handler = new RequestHandler(0, request, null, cch, null, null, null, null);
 
@@ -297,6 +300,10 @@ public class RequestMatcherTest {
         {
             RequestMatcher matcher = new RequestMatchParser("request.serverip = \"127.0.0.1\"").parse();
             assertTrue(matcher.matches(handler));
+        }
+        {
+            RequestMatcher matcher = new RequestMatchParser("request.serverip = \"127.0.1.1\"").parse();
+            assertFalse(matcher.matches(handler));
         }
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/requestmatcher/RequestMatcherTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/requestmatcher/RequestMatcherTest.java
@@ -280,29 +280,30 @@ public class RequestMatcherTest {
             matcher = new RequestMatchParser("not request.method = \"POST\" and request.method = \"GET\"").parse();
             assertTrue(matcher.matches(handler));
         }
-        // Test listener.address
+        // Test listener.hostport
         {
-            RequestMatcher matcher = new RequestMatchParser("listener.address = \"localhost:8080\"").parse();
+            RequestMatcher matcher = new RequestMatchParser("listener.hostport = \"localhost:8080\"").parse();
             assertTrue(matcher.matches(handler));
 
-            matcher = new RequestMatchParser("listener.address ~ \"localhost:.*\"").parse();
+            matcher = new RequestMatchParser("listener.hostport ~ \"localhost:.*\"").parse();
             assertTrue(matcher.matches(handler));
 
-            matcher = new RequestMatchParser("listener.address ~ \".*:8080\"").parse();
+            matcher = new RequestMatchParser("listener.hostport ~ \".*:8080\"").parse();
             assertTrue(matcher.matches(handler));
 
-            matcher = new RequestMatchParser("listener.address ~ \"loc.*:80.*\"").parse();
+            matcher = new RequestMatchParser("listener.hostport ~ \"loc.*:80.*\"").parse();
             assertTrue(matcher.matches(handler));
 
-            matcher = new RequestMatchParser("listener.address ~ \"some.*:8050\"").parse();
+            matcher = new RequestMatchParser("listener.hostport ~ \"some.*:8050\"").parse();
             assertFalse(matcher.matches(handler));
         }
+        // Test listener.ipaddress
         {
-            RequestMatcher matcher = new RequestMatchParser("request.serverip = \"127.0.0.1\"").parse();
+            RequestMatcher matcher = new RequestMatchParser("listener.ipaddress = \"127.0.0.1\"").parse();
             assertTrue(matcher.matches(handler));
         }
         {
-            RequestMatcher matcher = new RequestMatchParser("request.serverip = \"127.0.1.1\"").parse();
+            RequestMatcher matcher = new RequestMatchParser("listener.ipaddress = \"127.0.1.1\"").parse();
             assertFalse(matcher.matches(handler));
         }
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/requestmatcher/RequestMatcherTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/requestmatcher/RequestMatcherTest.java
@@ -229,6 +229,7 @@ public class RequestMatcherTest {
         when(cch.isSecure()).thenReturn(false);
         when(cch.getListenerHost()).thenReturn("localhost");
         when(cch.getListenerPort()).thenReturn(8080);
+        when(cch.getServerAddress()).thenReturn("127.0.0.1");
 
         RequestHandler handler = new RequestHandler(0, request, null, cch, null, null, null, null);
 
@@ -292,6 +293,10 @@ public class RequestMatcherTest {
 
             matcher = new RequestMatchParser("listener.address ~ \"some.*:8050\"").parse();
             assertFalse(matcher.matches(handler));
+        }
+        {
+            RequestMatcher matcher = new RequestMatchParser("request.serverip = \"127.0.0.1\"").parse();
+            assertTrue(matcher.matches(handler));
         }
     }
 }


### PR DESCRIPTION
In Route configuration,  it might be useful to separate the traffic based on the ip used to forward the request.
This is because there can be dedicated ip's  for a particular customer.