### PR TITLE
Fix connections release leaks

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/client/EndpointConnection.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/EndpointConnection.java
@@ -57,7 +57,8 @@ public interface EndpointConnection {
      * Connection is no more useful for the RequestHandler.
      * @param forceClose
      * @param handler
+     * @param onReleasePerformed
      */
-    public void release(boolean forceClose, RequestHandler handler);
+    public void release(boolean forceClose, RequestHandler handler, Runnable onReleasePerformed);
 
 }


### PR DESCRIPTION
Some fix in order to properly release connections:

- during EndpointConnectionImpl#sendRequest from clients, in case of errorSendingRequest (before starting writing to the server) we need to release the connection immediately or none will do
- when RequestHandler#releaseConnectionToEndpoint is called either by server and client, whether the first one cannot actually release the connection, the second one won't perform the release anymore because of the compareAndSet which set the connection to null even if the release is delayed.
- Added a test case to reproduce the case of a non released connection on errorSendingRequest 
