### PR TITLE
Requests header debug

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
@@ -63,6 +63,8 @@ import org.carapaceproxy.utils.PrometheusUtils;
 
 public class EndpointConnectionImpl implements EndpointConnection {
 
+    public static final String DEBUG_HEADER_NAME = "X-Carapace-Debug";
+
     private static final Logger LOG = Logger.getLogger(EndpointConnectionImpl.class.getName());
 
     private static final AtomicLong IDGENERATOR = new AtomicLong();
@@ -101,6 +103,7 @@ public class EndpointConnectionImpl implements EndpointConnection {
 
     private boolean forceErrorOnRequest = false;
     final AtomicBoolean returningToPool = new AtomicBoolean();
+    private boolean requestsHeaderDebugEnabled = false;
 
     private static enum ConnectionState {
         IDLE,
@@ -241,6 +244,11 @@ public class EndpointConnectionImpl implements EndpointConnection {
         // may have already been received !
         clientSidePeerHandler.messageSentToBackend(EndpointConnectionImpl.this);
         activityDone();
+
+        if (requestsHeaderDebugEnabled) {
+            request.headers().add(DEBUG_HEADER_NAME, "cid-" + id);
+        }
+
         channelToEndpoint
                 .writeAndFlush(request)
                 .addListener((Future<? super Void> future) -> {
@@ -518,6 +526,10 @@ public class EndpointConnectionImpl implements EndpointConnection {
     @VisibleForTesting
     public void forceErrorOnRequest(boolean force) {
         forceErrorOnRequest = force;
+    }
+
+    public void setRequestsHeaderDebugEnabled(boolean requestsHeaderDebugEnabled) {
+        this.requestsHeaderDebugEnabled = requestsHeaderDebugEnabled;
     }
 
     private void logConnectionInfo(String s) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
@@ -80,6 +80,7 @@ public class RuntimeServerConfiguration {
     private int keyPairsSize = DEFAULT_KEYPAIRS_SIZE;
     private List<String> supportedSSLProtocols = null;
     private int ocspStaplingManagerPeriod = 0;
+    private boolean requestsHeaderDebugEnabled = false;
 
     public String getAccessLogPath() {
         return accessLogPath;
@@ -235,6 +236,15 @@ public class RuntimeServerConfiguration {
         return ocspStaplingManagerPeriod;
     }
 
+    public boolean isRequestsHeaderDebugEnabled() {
+        return requestsHeaderDebugEnabled;
+    }
+
+    @VisibleForTesting
+    public void setRequestsHeaderDebugEnabled(boolean requestsHeaderDebugEnabled) {
+        this.requestsHeaderDebugEnabled = requestsHeaderDebugEnabled;
+    }
+
     public void configure(ConfigurationStore properties) throws ConfigurationNotValidException {
         LOG.log(Level.INFO, "configuring from {0}", properties);
         this.maxConnectionsPerEndpoint = properties.getInt("connectionsmanager.maxconnectionsperendpoint", maxConnectionsPerEndpoint);
@@ -302,6 +312,8 @@ public class RuntimeServerConfiguration {
         boolean loggingDebugEnabled = properties.getBoolean("logging.debug.enabled", false);
         CarapaceLogger.setLoggingDebugEnabled(loggingDebugEnabled);
         LOG.info("logging.debug.enabled=" + loggingDebugEnabled);
+        requestsHeaderDebugEnabled = properties.getBoolean("requests.header.debug.enabled", requestsHeaderDebugEnabled);
+        LOG.info("requests.header.debug.enabled=" + requestsHeaderDebugEnabled);
     }
 
     private void tryConfigureCertificates(ConfigurationStore properties) throws ConfigurationNotValidException {


### PR DESCRIPTION
Debug header added to keep track of connections id from carapace to endpoints