### PR TITLE
Manage cache mode in HTTPS requests #260

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
@@ -252,7 +252,7 @@ public class RequestHandler implements MatchingContext {
                     return;
                 }
                 connectionToEndpoint.set(connection);
-                cacheReceiver = connectionToClient.cache.startCachingResponse(request);
+                cacheReceiver = connectionToClient.cache.startCachingResponse(request, isSecure());
                 if (cacheReceiver != null) {
                     // https://tools.ietf.org/html/rfc7234#section-4.3.4
                     cleanRequestFromCacheValidators(request);

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
@@ -64,6 +64,7 @@ public class RuntimeServerConfiguration {
     private int borrowTimeout = 60000;
     private long cacheMaxSize = 0;
     private long cacheMaxFileSize = 0;
+    private boolean cacheDisabledForSecureRequestsWithoutPublic = false;
     private String mapperClassname;
     private String accessLogPath = "access.log";
     private String accessLogTimestampFormat = "yyyy-MM-dd HH:mm:ss.SSS";
@@ -131,7 +132,7 @@ public class RuntimeServerConfiguration {
     public void setAccessLogWaitBetweenFailures(int accessLogWaitBetweenFailures) {
         this.accessLogWaitBetweenFailures = accessLogWaitBetweenFailures;
     }
-    
+
     public long getAccessLogMaxSize() {
         return accessLogMaxSize;
     }
@@ -220,6 +221,14 @@ public class RuntimeServerConfiguration {
         this.cacheMaxFileSize = cacheMaxFileSize;
     }
 
+    public boolean isCacheDisabledForSecureRequestsWithoutPublic() {
+        return cacheDisabledForSecureRequestsWithoutPublic;
+    }
+
+    public void setCacheDisabledForSecureRequestsWithoutPublic(boolean cacheDisabledForSecureRequestsWithoutPublic) {
+        this.cacheDisabledForSecureRequestsWithoutPublic = cacheDisabledForSecureRequestsWithoutPublic;
+    }
+
     public int getHealthProbePeriod() {
         return healthProbePeriod;
     }
@@ -287,8 +296,10 @@ public class RuntimeServerConfiguration {
 
         this.cacheMaxSize = properties.getLong("cache.maxsize", cacheMaxSize);
         this.cacheMaxFileSize = properties.getLong("cache.maxfilesize", cacheMaxFileSize);
+        this.cacheDisabledForSecureRequestsWithoutPublic = properties.getBoolean("cache.requests.secure.disablewithoutpublic", cacheDisabledForSecureRequestsWithoutPublic);
         LOG.info("cache.maxsize=" + cacheMaxSize);
         LOG.info("cache.maxfilesize=" + cacheMaxFileSize);
+        LOG.info("cache.requests.secure.disablewithoutpublic=" + cacheDisabledForSecureRequestsWithoutPublic);
 
         this.accessLogPath = properties.getString("accesslog.path", accessLogPath);
         this.accessLogTimestampFormat = properties.getString("accesslog.format.timestamp", accessLogTimestampFormat);
@@ -296,7 +307,7 @@ public class RuntimeServerConfiguration {
         this.accessLogMaxQueueCapacity = properties.getInt("accesslog.queue.maxcapacity", accessLogMaxQueueCapacity);
         this.accessLogFlushInterval = properties.getInt("accesslog.flush.interval", accessLogFlushInterval);
         this.accessLogWaitBetweenFailures = properties.getInt("accesslog.failure.wait", accessLogWaitBetweenFailures);
-        this.accessLogMaxSize =  properties.getLong("accesslog.maxsize", accessLogMaxSize);
+        this.accessLogMaxSize = properties.getLong("accesslog.maxsize", accessLogMaxSize);
         String tsFormatExample;
         try {
             SimpleDateFormat formatter = new SimpleDateFormat(this.accessLogTimestampFormat);

--- a/carapace-server/src/main/java/org/carapaceproxy/server/cache/CacheRuntimeConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/cache/CacheRuntimeConfiguration.java
@@ -1,21 +1,21 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 package org.carapaceproxy.server.cache;
 
@@ -28,17 +28,20 @@ public class CacheRuntimeConfiguration {
 
     private final long cacheMaxSize;
     private final long cacheMaxFileSize;
+    private final boolean cacheDisabledForSecureRequestsWithoutPublic;
 
-    public CacheRuntimeConfiguration(long cacheMaxSize, long cacheMaxFileSize) {
+    public CacheRuntimeConfiguration(long cacheMaxSize, long cacheMaxFileSize, boolean cacheDisabledForSecureRequestsWithoutPublic) {
         this.cacheMaxSize = cacheMaxSize;
         this.cacheMaxFileSize = cacheMaxFileSize;
+        this.cacheDisabledForSecureRequestsWithoutPublic = cacheDisabledForSecureRequestsWithoutPublic;
     }
 
     @Override
     public int hashCode() {
         int hash = 3;
-        hash = 79 * hash + (int) (this.cacheMaxSize ^ (this.cacheMaxSize >>> 32));
-        hash = 79 * hash + (int) (this.cacheMaxFileSize ^ (this.cacheMaxFileSize >>> 32));
+        hash = 83 * hash + (int) (this.cacheMaxSize ^ (this.cacheMaxSize >>> 32));
+        hash = 83 * hash + (int) (this.cacheMaxFileSize ^ (this.cacheMaxFileSize >>> 32));
+        hash = 83 * hash + (this.cacheDisabledForSecureRequestsWithoutPublic ? 1 : 0);
         return hash;
     }
 
@@ -60,6 +63,9 @@ public class CacheRuntimeConfiguration {
         if (this.cacheMaxFileSize != other.cacheMaxFileSize) {
             return false;
         }
+        if (this.cacheDisabledForSecureRequestsWithoutPublic != other.cacheDisabledForSecureRequestsWithoutPublic) {
+            return false;
+        }
         return true;
     }
 
@@ -69,6 +75,10 @@ public class CacheRuntimeConfiguration {
 
     public long getCacheMaxFileSize() {
         return cacheMaxFileSize;
+    }
+
+    public boolean isCacheDisabledForSecureRequestsWithoutPublic() {
+        return cacheDisabledForSecureRequestsWithoutPublic;
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/cache/ContentsCache.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/cache/ContentsCache.java
@@ -164,9 +164,12 @@ public class ContentsCache {
             }
             return false;
         }
-        if ((secure && !cacheControl.contains(HttpHeaderValues.PUBLIC)
-                || headers.contains(HttpHeaderNames.PRAGMA, HttpHeaderValues.NO_CACHE, true))) {
-            LOG.log(Level.FINER, "not cachable {0}", request);
+        if (secure && !cacheControl.equals(HttpHeaderValues.PUBLIC + "")) {
+            return false;
+        }
+        if ((!cacheControl.isEmpty() && CACHE_CONTROL_CACHE_DISABLED_VALUES.stream().anyMatch(v -> cacheControl.contains(v)))
+                || headers.contains(HttpHeaderNames.PRAGMA, HttpHeaderValues.NO_CACHE, true)) {
+            // never cache Pragma: no-cache, Cache-Control: nostore/no-cache
             return false;
         }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheTest.java
@@ -256,15 +256,15 @@ public class CacheTest {
 
             try (RawHttpClient client = new RawHttpClient("localhost", port, true)) {
                 {
-                    RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
+                    RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: public\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
                     assertTrue(s.endsWith("it <b>works</b> !!"));
-                    assertTrue(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
                 }
 
                 {
-                    RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
+                    RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: public\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
                     assertTrue(s.endsWith("it <b>works</b> !!"));
@@ -275,7 +275,7 @@ public class CacheTest {
             stats = server.getConnectionsManager().getStats();
             assertNotNull(stats.getEndpoints().get(key));
             assertEquals(1, server.getCache().getCacheSize());
-            assertEquals(2, server.getCache().getStats().getHits());
+            assertEquals(1, server.getCache().getStats().getHits());
             assertEquals(1, server.getCache().getStats().getMisses());
         }
 


### PR DESCRIPTION
PR for #260

Changelog:
- Https requests won't be cached anymore whether header _Cache-Control_ != _public_
   - this is achieved only whether dynamic property **_cache.requests.secure.disablewithoutpublic = true_** is set
- Http/Https requests won't be cached anymore whether
  - header _Pragma: no-cache_ is present
  - header _Cache-Control_ has values: _private_, _no-cache_, _no-store_ or _max-age=0_
