### PR TITLE
Bump HerdDB to 0.22.0 and Netty to 4.1.59.Final #225

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -272,6 +272,12 @@
             <artifactId>route53</artifactId>
             <version>2.13.13</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.bookkeeper.stats</groupId>
+            <artifactId>prometheus-metrics-provider</artifactId>
+            <version>4.12.0</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/HttpProxyServer.java
@@ -39,7 +39,6 @@ import java.util.logging.Logger;
 import javax.naming.ConfigurationException;
 import javax.servlet.DispatcherType;
 import org.apache.bookkeeper.stats.*;
-import org.apache.bookkeeper.stats.prometheus.*;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.carapaceproxy.EndpointMapper;
 import org.carapaceproxy.api.ApplicationConfig;
@@ -83,6 +82,7 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.glassfish.jersey.servlet.ServletContainer;
 import static org.glassfish.jersey.servlet.ServletProperties.JAXRS_APPLICATION_CLASS;
+import org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider;
 import org.carapaceproxy.server.certificates.ocsp.OcspStaplingManager;
 
 public class HttpProxyServer implements AutoCloseable {

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,11 @@
             <organization>Diennea</organization>
         </developer>
         <developer>
+            <id>nicolo.boschi</id>
+            <name>Nicolo Boschi</name>
+            <organization>Diennea</organization>
+        </developer>
+        <developer>
             <id>paolo.venturi</id>
             <name>Paolo Venturi</name>
             <organization>Diennea</organization>
@@ -94,8 +99,8 @@
         <curator.version>4.2.0</curator.version>
         <zookkeeper.version>3.5.6</zookkeeper.version>
         <commons.lang3>3.8.1</commons.lang3>
-        <netty.version>4.1.50.Final</netty.version>
-        <netty.ssl.version>2.0.30.Final</netty.ssl.version>
+        <netty.version>4.1.59.Final</netty.version>
+        <netty.ssl.version>2.0.36.Final</netty.ssl.version>
         <jetty.version>9.4.8.v20171121</jetty.version>
         <jersey.version>2.27</jersey.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -113,7 +118,7 @@
         <libs.javaxactivation.api>1.2.0</libs.javaxactivation.api>
         <libs.slf4j>1.7.29</libs.slf4j>
         <libs.stringtemplate>4.0.8</libs.stringtemplate>
-        <libs.herddb>0.15.2</libs.herddb>
+        <libs.herddb>0.22.0</libs.herddb>
         <libs.prometheus>0.6.0</libs.prometheus>
         <javacc-maven-plugin.version>2.4</javacc-maven-plugin.version>
     </properties>


### PR DESCRIPTION
PR for #225

Changelog:
- HerdDB > 0.22.0
- Netty > 4.1.59.Final
- Netty ssl > 2.0.36