### PR TITLE
Perform dns check before create/renew certificate #239

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
@@ -41,6 +41,7 @@ import java.util.Arrays;
 import javax.net.ssl.SSLContext;
 import org.carapaceproxy.server.mapper.StandardEndpointMapper;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_DAYS_BEFORE_RENEWAL;
+import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DOMAINS_REACHABILITY_CHECKER_TIMEOUT;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
 import org.carapaceproxy.utils.CarapaceLogger;
 
@@ -79,6 +80,7 @@ public class RuntimeServerConfiguration {
     private int healthProbePeriod = 0;
     private int dynamicCertificatesManagerPeriod = 0;
     private int keyPairsSize = DEFAULT_KEYPAIRS_SIZE;
+    private int domainsReachabilityCheckerTimeout = DOMAINS_REACHABILITY_CHECKER_TIMEOUT; // millis
     private List<String> supportedSSLProtocols = null;
     private int ocspStaplingManagerPeriod = 0;
     private boolean requestsHeaderDebugEnabled = false;
@@ -131,7 +133,7 @@ public class RuntimeServerConfiguration {
     public void setAccessLogWaitBetweenFailures(int accessLogWaitBetweenFailures) {
         this.accessLogWaitBetweenFailures = accessLogWaitBetweenFailures;
     }
-    
+
     public long getAccessLogMaxSize() {
         return accessLogMaxSize;
     }
@@ -264,6 +266,10 @@ public class RuntimeServerConfiguration {
         this.clientsIdleTimeoutSeconds = clientIdleTimeoutSeconds;
     }
 
+    public int getDomainsReachabilityCheckerTimeout() {
+        return domainsReachabilityCheckerTimeout;
+    }
+
     public void configure(ConfigurationStore properties) throws ConfigurationNotValidException {
         LOG.log(Level.INFO, "configuring from {0}", properties);
         this.maxConnectionsPerEndpoint = properties.getInt("connectionsmanager.maxconnectionsperendpoint", maxConnectionsPerEndpoint);
@@ -296,7 +302,7 @@ public class RuntimeServerConfiguration {
         this.accessLogMaxQueueCapacity = properties.getInt("accesslog.queue.maxcapacity", accessLogMaxQueueCapacity);
         this.accessLogFlushInterval = properties.getInt("accesslog.flush.interval", accessLogFlushInterval);
         this.accessLogWaitBetweenFailures = properties.getInt("accesslog.failure.wait", accessLogWaitBetweenFailures);
-        this.accessLogMaxSize =  properties.getLong("accesslog.maxsize", accessLogMaxSize);
+        this.accessLogMaxSize = properties.getLong("accesslog.maxsize", accessLogMaxSize);
         String tsFormatExample;
         try {
             SimpleDateFormat formatter = new SimpleDateFormat(this.accessLogTimestampFormat);
@@ -326,6 +332,8 @@ public class RuntimeServerConfiguration {
         LOG.info("dynamiccertificatesmanager.period=" + dynamicCertificatesManagerPeriod);
         keyPairsSize = properties.getInt("dynamiccertificatesmanager.keypairssize", DEFAULT_KEYPAIRS_SIZE);
         LOG.info("dynamiccertificatesmanager.keypairssize=" + keyPairsSize);
+        domainsReachabilityCheckerTimeout = properties.getInt("dynamiccertificatesmanager.domainsreachabilitychecker.timeout", domainsReachabilityCheckerTimeout);
+        LOG.info("dynamiccertificatesmanager.domainsreachabilitychecker.timeout=" + domainsReachabilityCheckerTimeout);
 
         ocspStaplingManagerPeriod = properties.getInt("ocspstaplingmanager.period", 0);
         LOG.info("ocspstaplingmanager.period=" + ocspStaplingManagerPeriod);

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
@@ -41,8 +41,8 @@ import java.util.Arrays;
 import javax.net.ssl.SSLContext;
 import org.carapaceproxy.server.mapper.StandardEndpointMapper;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_DAYS_BEFORE_RENEWAL;
-import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DOMAINS_REACHABILITY_CHECKER_TIMEOUT;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
+import java.util.Set;
 import org.carapaceproxy.utils.CarapaceLogger;
 
 /**
@@ -80,7 +80,7 @@ public class RuntimeServerConfiguration {
     private int healthProbePeriod = 0;
     private int dynamicCertificatesManagerPeriod = 0;
     private int keyPairsSize = DEFAULT_KEYPAIRS_SIZE;
-    private int domainsReachabilityCheckerTimeout = DOMAINS_REACHABILITY_CHECKER_TIMEOUT; // millis
+    private Set<String> domainsReachabilityCheckerIPAddresses;
     private List<String> supportedSSLProtocols = null;
     private int ocspStaplingManagerPeriod = 0;
     private boolean requestsHeaderDebugEnabled = false;
@@ -266,8 +266,8 @@ public class RuntimeServerConfiguration {
         this.clientsIdleTimeoutSeconds = clientIdleTimeoutSeconds;
     }
 
-    public int getDomainsReachabilityCheckerTimeout() {
-        return domainsReachabilityCheckerTimeout;
+    public Set<String> getDomainsReachabilityCheckerIPAddresses() {
+        return domainsReachabilityCheckerIPAddresses;
     }
 
     public void configure(ConfigurationStore properties) throws ConfigurationNotValidException {
@@ -332,8 +332,9 @@ public class RuntimeServerConfiguration {
         LOG.info("dynamiccertificatesmanager.period=" + dynamicCertificatesManagerPeriod);
         keyPairsSize = properties.getInt("dynamiccertificatesmanager.keypairssize", DEFAULT_KEYPAIRS_SIZE);
         LOG.info("dynamiccertificatesmanager.keypairssize=" + keyPairsSize);
-        domainsReachabilityCheckerTimeout = properties.getInt("dynamiccertificatesmanager.domainsreachabilitychecker.timeout", domainsReachabilityCheckerTimeout);
-        LOG.info("dynamiccertificatesmanager.domainsreachabilitychecker.timeout=" + domainsReachabilityCheckerTimeout);
+
+        domainsReachabilityCheckerIPAddresses = Set.of(properties.getArray("dynamiccertificatesmanager.domainsreachabilitychecker.ipaddresses", new String[]{}));
+        LOG.info("dynamiccertificatesmanager.domainsreachabilitychecker.ipaddresses=" + domainsReachabilityCheckerIPAddresses);
 
         ocspStaplingManagerPeriod = properties.getInt("ocspstaplingmanager.period", 0);
         LOG.info("ocspstaplingmanager.period=" + ocspStaplingManagerPeriod);

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
@@ -80,7 +80,7 @@ public class RuntimeServerConfiguration {
     private int healthProbePeriod = 0;
     private int dynamicCertificatesManagerPeriod = 0;
     private int keyPairsSize = DEFAULT_KEYPAIRS_SIZE;
-    private Set<String> domainsReachabilityCheckerIPAddresses;
+    private Set<String> domainsCheckerIPAddresses;
     private List<String> supportedSSLProtocols = null;
     private int ocspStaplingManagerPeriod = 0;
     private boolean requestsHeaderDebugEnabled = false;
@@ -266,8 +266,8 @@ public class RuntimeServerConfiguration {
         this.clientsIdleTimeoutSeconds = clientIdleTimeoutSeconds;
     }
 
-    public Set<String> getDomainsReachabilityCheckerIPAddresses() {
-        return domainsReachabilityCheckerIPAddresses;
+    public Set<String> getDomainsCheckerIPAddresses() {
+        return domainsCheckerIPAddresses;
     }
 
     public void configure(ConfigurationStore properties) throws ConfigurationNotValidException {
@@ -333,8 +333,8 @@ public class RuntimeServerConfiguration {
         keyPairsSize = properties.getInt("dynamiccertificatesmanager.keypairssize", DEFAULT_KEYPAIRS_SIZE);
         LOG.info("dynamiccertificatesmanager.keypairssize=" + keyPairsSize);
 
-        domainsReachabilityCheckerIPAddresses = Set.of(properties.getArray("dynamiccertificatesmanager.domainsreachabilitychecker.ipaddresses", new String[]{}));
-        LOG.info("dynamiccertificatesmanager.domainsreachabilitychecker.ipaddresses=" + domainsReachabilityCheckerIPAddresses);
+        domainsCheckerIPAddresses = Set.of(properties.getArray("dynamiccertificatesmanager.domainschecker.ipaddresses", new String[]{}));
+        LOG.info("dynamiccertificatesmanager.domainschecker.ipaddresses=" + domainsCheckerIPAddresses);
 
         ocspStaplingManagerPeriod = properties.getInt("ocspstaplingmanager.period", 0);
         LOG.info("ocspstaplingmanager.period=" + ocspStaplingManagerPeriod);

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
@@ -297,7 +297,7 @@ public class DynamicCertificatesManager implements Runnable {
                 CertificateData cert = loadOrCreateDynamicCertificateForDomain(domain, data.isWildcard(), false, data.getDaysBeforeRenewal());
                 switch (cert.getState()) {
                     case WAITING: { // certificate waiting to be issues/renew
-                        LOG.log(Level.INFO, "Certificate ISSUING process for domain: {0} STARTED.", domain);
+                        LOG.log(Level.INFO, "WAITING certificate issuing process start for domain: {0}.", domain);
                         if (reachableDomains.remove(domain)) {
                             Order order = createOrderForCertificate(cert);
                             createChallengeForCertificateOrder(cert, order);

--- a/carapace-server/src/test/java/org/carapaceproxy/ConnectionPoolTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/ConnectionPoolTest.java
@@ -58,6 +58,8 @@ import org.junit.rules.TemporaryFolder;
 
 public class ConnectionPoolTest {
 
+    public static final long KEEP_ALIVE_TIMEOUT = 30_000;
+
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(0);
 
@@ -77,6 +79,7 @@ public class ConnectionPoolTest {
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.port());
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
+        long start = System.currentTimeMillis();
         ConnectionsManagerStats stats;
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
@@ -92,7 +95,8 @@ public class ConnectionPoolTest {
             EndpointStats epstats = stats.getEndpointStats(key);
             System.out.println("STATS: " + epstats);
             assertNotNull(epstats);
-            assertEquals(1, epstats.getTotalConnections().intValue());
+            long diff = System.currentTimeMillis() - start;
+            assertEquals(diff > KEEP_ALIVE_TIMEOUT ? 2 : 1, epstats.getTotalConnections().intValue());
             assertEquals(0, epstats.getActiveConnections().intValue());
             assertEquals(1, epstats.getOpenConnections().intValue());
             assertEquals(1, epstats.getTotalRequests().intValue());
@@ -102,7 +106,8 @@ public class ConnectionPoolTest {
             }
             TestUtils.waitForCondition(TestUtils.NO_ACTIVE_CONNECTION(stats), 100);
             System.out.println("STATS: " + epstats);
-            assertEquals(1, epstats.getTotalConnections().intValue());
+            diff = System.currentTimeMillis() - start;
+            assertEquals(diff > KEEP_ALIVE_TIMEOUT ? 2 : 1, epstats.getTotalConnections().intValue());
             assertEquals(0, epstats.getActiveConnections().intValue());
             assertEquals(1, epstats.getOpenConnections().intValue());
             assertEquals(2, epstats.getTotalRequests().intValue());
@@ -112,7 +117,8 @@ public class ConnectionPoolTest {
                         toString(new URL("http://localhost:" + port + "/index.html").toURI(), "utf-8"));
                 TestUtils.waitForCondition(TestUtils.NO_ACTIVE_CONNECTION(stats), 100);
                 System.out.println("STATS: " + epstats);
-                assertEquals(1, epstats.getTotalConnections().intValue());
+                diff = System.currentTimeMillis() - start;
+                assertEquals(diff > KEEP_ALIVE_TIMEOUT ? 2 : 1, epstats.getTotalConnections().intValue());
                 assertEquals(0, epstats.getActiveConnections().intValue());
                 assertEquals(1, epstats.getOpenConnections().intValue());
                 assertEquals(i + 3, epstats.getTotalRequests().intValue());

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
@@ -172,9 +172,7 @@ public class DynamicCertificatesManagerTest {
 
         // WAITING
         assertEquals(WAITING, man.getStateOfCertificate(d1));
-        man.run(); // checking domain reachability
-        verify(store, times(++saveCounter)).saveCertificate(any());
-        man.run(); // domain reachable
+        man.run();
         assertEquals(runCase.equals("challenge_null") ? VERIFIED : VERIFYING, man.getStateOfCertificate(d1));
         verify(store, times(++saveCounter)).saveCertificate(any());
 
@@ -296,9 +294,7 @@ public class DynamicCertificatesManagerTest {
 
         // WAITING
         assertEquals(WAITING, man.getStateOfCertificate(domain));
-        man.run(); // checking domain reachability
-        verify(store, times(++saveCounter)).saveCertificate(any());
-        man.run(); // domain reachable
+        man.run();
         verify(store, times(++saveCounter)).saveCertificate(any());
         if (runCase.equals("challenge_creation_failed")) {
             // WAITING
@@ -389,10 +385,10 @@ public class DynamicCertificatesManagerTest {
         props.setProperty("certificate.1.hostname", domain);
         props.setProperty("certificate.1.mode", "acme");
         if (domainCase.equals("localhost-ip-check-partial")) {
-            props.setProperty("dynamiccertificatesmanager.domainsreachabilitychecker.ipaddresses", "127.0.0.1");
+            props.setProperty("dynamiccertificatesmanager.domainschecker.ipaddresses", "127.0.0.1");
         }
         if (domainCase.equals("localhost-ip-check-full")) {
-            props.setProperty("dynamiccertificatesmanager.domainsreachabilitychecker.ipaddresses", "127.0.0.1, 0:0:0:0:0:0:0:1");
+            props.setProperty("dynamiccertificatesmanager.domainschecker.ipaddresses", "127.0.0.1, 0:0:0:0:0:0:0:1");
         }
         ConfigurationStore configStore = new PropertiesConfigurationStore(props);
         RuntimeServerConfiguration conf = new RuntimeServerConfiguration();
@@ -403,15 +399,10 @@ public class DynamicCertificatesManagerTest {
 
         // WAITING
         assertEquals(WAITING, man.getStateOfCertificate(domain));
-        man.run(); // checking domain reachability
-        verify(store, times(++saveCounter)).saveCertificate(any());
-        assertThat(man.getStateOfCertificate(domain), is(WAITING));
-        Thread.sleep(10_000);
-        man.run();
+        man.run(); // checking domain
         verify(store, times(++saveCounter)).saveCertificate(any());
         if (domainCase.equals("localhost-ip-check-partial")) {
             assertThat(man.getStateOfCertificate(domain), is(WAITING));
-            Thread.sleep(10_000);
             man.run();
             verify(store, times(++saveCounter)).saveCertificate(any());
             assertThat(man.getStateOfCertificate(domain), is(WAITING));


### PR DESCRIPTION
PR for #239 

Changelog:

- domain dns checking before acme certificates order creation
- _**dynamiccertificatesmanager.domainsreachabilitychecker.ipaddresses**_ to define carapace ips that acme certificate domains has to point to.
