### PR TITLE
Dump request/resposte header and body in a file #262

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
@@ -40,6 +40,7 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
@@ -85,7 +86,7 @@ public class EndpointConnectionImpl implements EndpointConnection {
 
     private AtomicReference<ConnectionState> state = new AtomicReference<>(ConnectionState.IDLE);
     private volatile boolean forcedInvalid = false;
-    private volatile RequestHandler clientSidePeerHandler;
+    private volatile AtomicReference<RequestHandler> clientSidePeerHandler = new AtomicReference<>();
 
     // stats
     private static final Summary CONNECTION_STATS_SUMMARY = PrometheusUtils.createSummary("backends", "connection_time_ns",
@@ -104,6 +105,7 @@ public class EndpointConnectionImpl implements EndpointConnection {
     private boolean forceErrorOnRequest = false;
     final AtomicBoolean returningToPool = new AtomicBoolean();
     private boolean requestsHeaderDebugEnabled = false;
+    private volatile boolean requestFinished = false;
 
     private static enum ConnectionState {
         IDLE,
@@ -151,6 +153,7 @@ public class EndpointConnectionImpl implements EndpointConnection {
                         ch.pipeline().addLast("writeTimeoutHandler", new WriteTimeoutHandler(parent.getIdleTimeout() / 2));
                         ch.pipeline().addLast("client-codec", new HttpClientCodec());
                         ch.pipeline().addLast(new ReadEndpointResponseHandler());
+                        parent.getFullHttpMessageLogger().attachHandler(ch, clientSidePeerHandler);
                     }
                 });
         final ChannelFuture connectFuture = b.connect(key.getHost(), key.getPort());
@@ -223,7 +226,8 @@ public class EndpointConnectionImpl implements EndpointConnection {
         }
 
         // these have to be set before calling clientSidePeerHandler.errorSendingRequest which will perform a release
-        this.clientSidePeerHandler = clientSidePeerHandler;
+        this.clientSidePeerHandler.set(clientSidePeerHandler);
+        requestFinished = false;
         endpointstats.getActiveConnections().incrementAndGet();
         activeConnectionsStats.inc();
         endpointstats.getTotalRequests().incrementAndGet();
@@ -434,8 +438,10 @@ public class EndpointConnectionImpl implements EndpointConnection {
         if (active.compareAndSet(true, false)) {
             endpointstats.getActiveConnections().decrementAndGet();
             activeConnectionsStats.dec();
-            parent.unregisterPendingRequest(clientSidePeerHandler);
-            clientSidePeerHandler = null;
+            if (!requestFinished) {
+                parent.unregisterPendingRequest(clientSidePeerHandler.get());
+                requestFinished = true;
+            }
         } else {
             LOG.log(Level.SEVERE, "connectionDeactivated on a non active connection! {0}", this);
         }
@@ -446,8 +452,8 @@ public class EndpointConnectionImpl implements EndpointConnection {
 
         @Override
         public void channelRead0(ChannelHandlerContext ctx, HttpObject msg) {
-            RequestHandler _clientSidePeerHandler = clientSidePeerHandler;
-            if (_clientSidePeerHandler == null) {
+            RequestHandler _clientSidePeerHandler = clientSidePeerHandler.get();
+            if (_clientSidePeerHandler == null || requestFinished) {
                 LOG.log(Level.INFO, "swallow content {0}: {1}, disconnected client. connection: {2}", new Object[]{msg.getClass(), msg, EndpointConnectionImpl.this});
                 return;
             }
@@ -464,12 +470,13 @@ public class EndpointConnectionImpl implements EndpointConnection {
                 LOG.log(Level.SEVERE, "unknown message type {0}: {1}. connection: {2}", new Object[]{msg.getClass(), msg, EndpointConnectionImpl.this});
             }
 
+            ctx.fireChannelRead(ReferenceCountUtil.retain(msg));
         }
 
         @Override
         public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-            RequestHandler _clientSidePeerHandler = clientSidePeerHandler;
-            if (_clientSidePeerHandler != null) {
+            RequestHandler _clientSidePeerHandler = clientSidePeerHandler.get();
+            if (_clientSidePeerHandler != null && !requestFinished) {
                 logConnectionInfo("channelReadComplete, open: " + ctx.channel().isOpen());
                 _clientSidePeerHandler.readCompletedFromRemote();
                 // server said no more data will be sent to this channel, we must close it before netty does
@@ -481,9 +488,9 @@ public class EndpointConnectionImpl implements EndpointConnection {
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             LOG.log(Level.SEVERE, "I/O error on endpoint " + key, cause);
             parent.backendHealthManager.reportBackendUnreachable(key.getHostPort(), System.currentTimeMillis(), "I/O error: " + cause);
-            RequestHandler _clientSidePeerHandler = clientSidePeerHandler;
+            RequestHandler _clientSidePeerHandler = clientSidePeerHandler.get();
 
-            if (_clientSidePeerHandler != null) {
+            if (_clientSidePeerHandler != null && !requestFinished) {
                 _clientSidePeerHandler.badErrorOnRemote(cause);
             }
             invalidate();
@@ -499,7 +506,7 @@ public class EndpointConnectionImpl implements EndpointConnection {
     }
 
     private void checkHandler(RequestHandler handler) throws IllegalStateException {
-        if (this.clientSidePeerHandler != handler) {
+        if (this.clientSidePeerHandler.get() != handler || requestFinished) {
             throw new IllegalStateException("connection is bound to " + this.clientSidePeerHandler + " cannot be managed by " + handler);
         }
     }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
@@ -29,12 +29,13 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.util.ReferenceCountUtil;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import java.net.SocketAddress;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.carapaceproxy.EndpointMapper;
@@ -70,7 +71,8 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
     final long connectionStartsTs;
     volatile boolean keepAlive = true;
     volatile boolean refuseOtherRequests;
-    private final List<RequestHandler> pendingRequests = new CopyOnWriteArrayList<>();
+    private final AtomicReference<RequestHandler> pendingRequest = new AtomicReference<>();
+    private volatile boolean requestFinished = false;
     final Runnable onClientDisconnected;
     private final String listenerHost;
     private final int listenerPort;
@@ -172,30 +174,31 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
             totalRequests.inc();
             RequestHandler currentRequest = new RequestHandler(requestIdGenerator.incrementAndGet(),
                     request, filters, this, ctx, () -> RUNNING_REQUESTS_GAUGE.dec(), backendHealthManager, requestsLogger);
-            addPendingRequest(currentRequest);
+            pendingRequest.set(currentRequest);
+            requestFinished = false;
             currentRequest.start();
         } else if (msg instanceof LastHttpContent) {
-            LastHttpContent trailer = (LastHttpContent) msg;
-            try {
-                RequestHandler currentRequest = pendingRequests.get(0);
-                currentRequest.clientRequestFinished(trailer);
-            } catch (java.lang.ArrayIndexOutOfBoundsException noMorePendingRequests) {
+            if (requestFinished) {
                 LOG.log(Level.INFO, "{0} swallow {1}, no more pending requests", new Object[]{this, msg});
                 refuseOtherRequests = true;
                 ctx.close();
+            } else {
+                LastHttpContent trailer = (LastHttpContent) msg;
+                pendingRequest.get().clientRequestFinished(trailer);
             }
         } else if (msg instanceof HttpContent) {
-            // for example chunks from client
-            HttpContent httpContent = (HttpContent) msg;
-            try {
-                RequestHandler currentRequest = pendingRequests.get(0);
-                currentRequest.continueClientRequest(httpContent);
-            } catch (java.lang.ArrayIndexOutOfBoundsException noMorePendingRequests) {
+            if (requestFinished) {
                 LOG.log(Level.INFO, "{0} swallow {1}, no more pending requests", new Object[]{this, msg});
                 refuseOtherRequests = true;
                 ctx.close();
+            } else {
+                // for example chunks from client
+                HttpContent httpContent = (HttpContent) msg;
+                pendingRequest.get().continueClientRequest(httpContent);
             }
         }
+
+        ctx.fireChannelRead(ReferenceCountUtil.retain(msg));
     }
 
     private void detectSSLProperties(ChannelHandlerContext ctx) {
@@ -247,13 +250,13 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
     }
 
     public void errorSendingRequest(RequestHandler request, EndpointConnectionImpl endpointConnection, ChannelHandlerContext peerChannel, Throwable error) {
-        pendingRequests.remove(request);
+        requestFinished = true;
         mapper.endpointFailed(endpointConnection.getKey(), error);
         LOG.log(Level.INFO, error, () -> this + " errorSendingRequest " + endpointConnection);
     }
 
     public void lastHttpContentSent(RequestHandler requestHandler) {
-        pendingRequests.remove(requestHandler);
+        requestFinished = true;
     }
 
     @Override
@@ -261,7 +264,7 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
         return "ClientConnectionHandler{chid=" + id + ",ka=" + keepAlive + '}';
     }
 
-    void addPendingRequest(RequestHandler request) {
-        pendingRequests.add(request);
+    public AtomicReference<RequestHandler> getPendingRequest() {
+        return pendingRequest;
     }
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/FullHttpMessageLogger.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/FullHttpMessageLogger.java
@@ -1,0 +1,381 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.carapaceproxy.server;
+
+import static org.stringtemplate.v4.STGroup.verbose;
+import com.google.common.annotations.VisibleForTesting;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.FullHttpMessage;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import java.io.BufferedWriter;
+import java.io.Closeable;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ *
+ * Logger for both http requests and reponses.
+ *
+ * @author paolo.venturi
+ */
+public class FullHttpMessageLogger implements Runnable, Closeable {
+
+    private static final Logger LOG = Logger.getLogger(FullHttpMessageLogger.class.getName());
+    private static final String FULL_ACCESS_LOG_PATH_SUFFIX = "full";
+
+    private final BlockingQueue<FullHttpMessageLogEntry> queue;
+
+    private volatile RuntimeServerConfiguration currentConfiguration;
+    private volatile RuntimeServerConfiguration newConfiguration = null;
+    private volatile boolean closeRequested = false;
+    private volatile boolean closed = false;
+
+    private boolean started = false;
+    private final Thread thread;
+
+    private OutputStream os = null;
+    private OutputStreamWriter osw = null;
+    private BufferedWriter bw = null;
+    private PrintWriter pw = null;
+
+    public long lastFlush = 0;
+
+    public FullHttpMessageLogger(RuntimeServerConfiguration currentConfiguration) {
+        this.currentConfiguration = currentConfiguration;
+        this.queue = new ArrayBlockingQueue<>(this.currentConfiguration.getAccessLogMaxQueueCapacity());
+        this.thread = new Thread(this);
+    }
+
+    private void ensureAccessLogFileOpened() throws IOException {
+        if (os != null) {
+            return;
+        }
+
+        LOG.log(Level.INFO, "Opening file: {0}", getFullAccessLogPath());
+        os = new FileOutputStream(getFullAccessLogPath(), true);
+        osw = new OutputStreamWriter(os, StandardCharsets.UTF_8);
+        bw = new BufferedWriter(osw);
+        pw = new PrintWriter(bw);
+    }
+
+    private String getFullAccessLogPath() {
+        return currentConfiguration.getAccessLogPath() + "." + FULL_ACCESS_LOG_PATH_SUFFIX;
+    }
+
+    private void closeAccessLogFile() throws IOException {
+        LOG.log(Level.INFO, "Closing file");
+        if (pw != null) {
+            pw = null;
+        }
+        if (bw != null) {
+            bw.close();
+            bw = null;
+        }
+        if (osw != null) {
+            osw.close();
+            osw = null;
+        }
+        if (os != null) {
+            os.close();
+            os = null;
+        }
+    }
+
+    public void reloadConfiguration(RuntimeServerConfiguration newConfiguration) {
+        this.newConfiguration = newConfiguration;
+    }
+
+    private void _reloadConfiguration() throws IOException {
+        if (newConfiguration == null) {
+            return;
+        }
+
+        LOG.log(Level.INFO, "Reloading conf");
+        String oldAccessLogPath = this.currentConfiguration.getAccessLogPath();
+        if (newConfiguration.getAccessLogMaxQueueCapacity() != currentConfiguration.getAccessLogMaxQueueCapacity()) {
+            LOG.log(Level.SEVERE, "accesslog.queue.maxcapacity hot reload is not currently supported");
+        }
+        this.currentConfiguration = newConfiguration;
+        if (!oldAccessLogPath.equals(newConfiguration.getAccessLogPath())) {
+            closeAccessLogFile();
+            // File opening will be retried at next cycle start
+        }
+        newConfiguration = null;
+    }
+
+    @Override
+    public void close() {
+        closeRequested = true;
+    }
+
+    public void start() {
+        if (started) {
+            throw new IllegalStateException("Already started");
+        }
+        thread.start();
+        started = true;
+    }
+
+    public void stop() {
+        close();
+        try {
+            thread.join(60_000);
+        } catch (InterruptedException ex) {
+            LOG.log(Level.SEVERE, "Interrupted while stopping");
+        }
+    }
+
+    @VisibleForTesting
+    void flushAccessLogFile() throws IOException {
+        if (verbose) {
+            LOG.log(Level.INFO, "Flushed");
+        }
+        if (bw != null) {
+            bw.flush();
+        }
+        if (osw != null) {
+            osw.flush();
+        }
+        if (os != null) {
+            os.flush();
+        }
+        lastFlush = System.currentTimeMillis();
+    }
+
+    @Override
+    public void run() {
+        if (lastFlush == 0) {
+            lastFlush = System.currentTimeMillis();
+        }
+
+        FullHttpMessageLogEntry currentEntry = null;
+        while (!closed) {
+            try {
+                _reloadConfiguration();
+
+                try {
+                    ensureAccessLogFileOpened();
+                } catch (IOException ex) {
+                    LOG.log(Level.SEVERE, "Exception while trying to open access log file");
+                    LOG.log(Level.SEVERE, null, ex);
+                    Thread.sleep(currentConfiguration.getAccessLogWaitBetweenFailures());
+                    lastFlush = System.currentTimeMillis();
+                    continue;
+                }
+
+                long waitTime = !closeRequested
+                        ? currentConfiguration.getAccessLogFlushInterval() - (System.currentTimeMillis() - lastFlush)
+                        : 0L;
+                waitTime = Math.max(waitTime, 0L);
+
+                if (currentEntry == null) {
+                    currentEntry = queue.poll(waitTime, TimeUnit.MILLISECONDS);
+                }
+
+                if (currentEntry != null) {
+                    if (verbose) {
+                        LOG.log(Level.INFO, "writing entry: {0}", currentEntry);
+                    }
+                    currentEntry.write();
+                    currentEntry = null;
+                } else {
+                    if (closeRequested) {
+                        closeAccessLogFile();
+                        closed = true;
+                    }
+                }
+
+                if (System.currentTimeMillis() - lastFlush >= currentConfiguration.getAccessLogFlushInterval()) {
+                    flushAccessLogFile();
+                }
+            } catch (InterruptedException ex) {
+                LOG.log(Level.SEVERE, "Interrupt received");
+                try {
+                    closeAccessLogFile();
+                } catch (IOException ex1) {
+                    LOG.log(Level.SEVERE, null, ex1);
+                }
+                closed = true;
+
+            } catch (IOException ex) {
+                LOG.log(Level.SEVERE, "Exception while writing on access log file");
+                LOG.log(Level.SEVERE, null, ex);
+                try {
+                    closeAccessLogFile();
+                } catch (IOException ex1) {
+                    LOG.log(Level.SEVERE, "Exception while trying to close access log file");
+                    LOG.log(Level.SEVERE, null, ex1);
+                }
+                // File opening will be retried at next cycle start
+
+                try {
+                    Thread.sleep(currentConfiguration.getAccessLogFlushInterval());
+                    lastFlush = System.currentTimeMillis();
+                } catch (InterruptedException ex1) {
+                    closed = true;
+                }
+            }
+        }
+    }
+
+    public void attachHandler(SocketChannel channel, AtomicReference<RequestHandler> reqHandler) {
+        channel.pipeline().addLast(new HttpObjectAggregator(Integer.MAX_VALUE));
+        channel.pipeline().addLast(new FullHttpMessageLoggerHandler(reqHandler));
+    }
+
+    public class FullHttpMessageLoggerHandler extends SimpleChannelInboundHandler<FullHttpMessage> {
+
+        private final AtomicReference<RequestHandler> reqHandler;
+
+        public FullHttpMessageLoggerHandler(AtomicReference<RequestHandler> reqHandler) {
+            this.reqHandler = reqHandler;
+        }
+
+        @Override
+        public void channelRead0(ChannelHandlerContext ctx, FullHttpMessage msg) throws Exception {
+            // Check for invalid http data
+            if (msg.decoderResult() != DecoderResult.SUCCESS) {
+                LOG.log(Level.SEVERE, "Message {0} cannot be logged due to failed decoding.", msg);
+                return;
+            }
+
+            RequestHandler request = reqHandler.get();
+            if (request != null) {
+                FullHttpMessageLogEntry entry = new FullHttpMessageLogEntry(
+                        request.getId(), msg, currentConfiguration.getAccessLogTimestampFormat()
+                );
+
+                logMessageEntry(entry);
+            }
+        }
+    }
+
+    public void logMessageEntry(FullHttpMessageLogEntry entry) {
+        if (closeRequested) {
+            LOG.log(Level.SEVERE, "Request {0} not logged to access log because RequestsLogger is closed", entry);
+            return;
+        }
+
+        // If configuration reloads already created entries will keep a possibile old format, but it doesn't really matter
+        boolean ret = queue.offer(entry);
+
+        if (!ret) {
+            LOG.log(Level.SEVERE, "Request {0} not logged to access log because queue is full", entry);
+        }
+    }
+
+    private class FullHttpMessageLogEntry {
+
+        private final long requestId;
+        private final String time;
+        private boolean request;
+        private String method;
+        private String uri;
+        private final String protocolVersion;
+        private final String headers;
+        private final String trailingHeaders;
+        private final String data;
+
+        FullHttpMessageLogEntry(long requestId, FullHttpMessage msg, String timestampFormat) {
+
+            this.requestId = requestId;
+            this.time = new SimpleDateFormat(timestampFormat).format(new Date());
+            if (msg instanceof FullHttpRequest) {
+                this.request = true;
+                FullHttpRequest request = (FullHttpRequest) msg;
+                method = request.method().toString();
+                uri = request.uri();
+            }
+
+            protocolVersion = msg.protocolVersion().toString();
+            headers = formatHeaders(msg.headers());
+            trailingHeaders = formatHeaders(msg.trailingHeaders());
+            ByteBuf data = msg.content();
+            this.data = data.toString(StandardCharsets.UTF_8);
+        }
+
+        void write() throws IOException {
+            String opening = ">>>>>>>>>>>>>>>>>>>>[ SERVER RESPONSE (requestId: " + requestId + ") ]>>>>>>>>>>>>>>>>>>>>";
+            String closing = ">>>>>>>>>>>>>>>>>>>>[ SERVER RESPONSE END (requestId: " + requestId + ") ]>>>>>>>>>>>>>>>>>>>>";
+            if (request) {
+                opening = "<<<<<<<<<<<<<<<<<<<<[ CLIENT REQUEST (requestId: " + requestId + ") ]<<<<<<<<<<<<<<<<<<<<";
+                closing = "<<<<<<<<<<<<<<<<<<<<[ CLIENT REQUEST END (requestId: " + requestId + ") ]<<<<<<<<<<<<<<<<<<<<";
+            }
+            pw.println(opening);
+            pw.println("Time: " + time);
+            pw.println("HTTP Version: " + protocolVersion);
+            if (request) {
+                pw.println("HTTP Method: " + method);
+                pw.println("URI: " + uri);
+            }
+            pw.println("--------------------[ HEADERS ]--------------------");
+            pw.println(headers);
+            if (!trailingHeaders.isEmpty()) {
+                pw.println(trailingHeaders);
+            }
+            if (data != null && !data.isEmpty()) {
+                pw.println("--------------------[ DATA ]--------------------");
+                pw.println(data);
+            }
+            pw.println(closing);
+            pw.println("\n");
+            pw.flush();
+        }
+
+        private String formatHeaders(HttpHeaders headers) {
+            if (headers.isEmpty()) {
+                return "";
+            }
+
+            StringBuilder sBuilder = new StringBuilder();
+            headers.forEach(h -> {
+                sBuilder.append(h.getKey());
+                sBuilder.append(": ");
+                sBuilder.append(h.getValue());
+                sBuilder.append("\n");
+            });
+            String res = sBuilder.toString();
+            return res.substring(0, res.length() - 1);
+        }
+
+        @Override
+        public String toString() {
+            return "FullHttpMessageLogEntry{" + "requestId=" + requestId + ", time=" + time + ", request=" + request + ", method=" + method + ", uri=" + uri + '}';
+        }
+    }
+}

--- a/carapace-server/src/main/java/org/carapaceproxy/server/FullHttpMessageLogger.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/FullHttpMessageLogger.java
@@ -103,17 +103,6 @@ public class FullHttpMessageLogger implements Runnable, Closeable {
 
     private void closeAccessLogFile() throws IOException {
         LOG.log(Level.INFO, "Closing file");
-        if (pw != null) {
-            pw = null;
-        }
-        if (bw != null) {
-            bw.close();
-            bw = null;
-        }
-        if (osw != null) {
-            osw.close();
-            osw = null;
-        }
         if (os != null) {
             os.close();
             os = null;
@@ -164,6 +153,7 @@ public class FullHttpMessageLogger implements Runnable, Closeable {
             thread.join(60_000);
         } catch (InterruptedException ex) {
             LOG.log(Level.SEVERE, "Interrupted while stopping");
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -237,7 +227,7 @@ public class FullHttpMessageLogger implements Runnable, Closeable {
                     LOG.log(Level.SEVERE, null, ex1);
                 }
                 closed = true;
-
+                Thread.currentThread().interrupt();
             } catch (IOException ex) {
                 LOG.log(Level.SEVERE, "Exception while writing on access log file");
                 LOG.log(Level.SEVERE, null, ex);
@@ -254,6 +244,7 @@ public class FullHttpMessageLogger implements Runnable, Closeable {
                     lastFlush = System.currentTimeMillis();
                 } catch (InterruptedException ex1) {
                     closed = true;
+                    Thread.currentThread().interrupt();
                 }
             }
         }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/Listeners.java
@@ -236,6 +236,7 @@ public class Listeners {
                                 listener.isSsl()
                         );
                         channel.pipeline().addLast(connHandler);
+                        parent.getFullHttpMessageLogger().attachHandler(channel, connHandler.getPendingRequest());
 
                         listenersHandlers.put(key, connHandler);
                     }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RuntimeServerConfiguration.java
@@ -77,6 +77,8 @@ public class RuntimeServerConfiguration {
     private int accessLogFlushInterval = 5000;
     private int accessLogWaitBetweenFailures = 10000;
     private long accessLogMaxSize = 524288000;
+    private boolean accessLogAdvancedEnabled = false;
+    private int accessLogAdvancedBodySize = 1_000; // bytes
     private String userRealmClassname;
     private int healthProbePeriod = 0;
     private int dynamicCertificatesManagerPeriod = 0;
@@ -141,6 +143,22 @@ public class RuntimeServerConfiguration {
 
     public void setAccessLogMaxSize(long accessLogMaxSize) {
         this.accessLogMaxSize = accessLogMaxSize;
+    }
+
+    public boolean isAccessLogAdvancedEnabled() {
+        return accessLogAdvancedEnabled;
+    }
+
+    public void setAccessLogAdvancedEnabled(boolean accessLogAdvancedEnabled) {
+        this.accessLogAdvancedEnabled = accessLogAdvancedEnabled;
+    }
+
+    public int getAccessLogAdvancedBodySize() {
+        return accessLogAdvancedBodySize;
+    }
+
+    public void setAccessLogAdvancedBodySize(int accessLogAdvancedBodySize) {
+        this.accessLogAdvancedBodySize = accessLogAdvancedBodySize;
     }
 
     public String getMapperClassname() {
@@ -328,6 +346,11 @@ public class RuntimeServerConfiguration {
         LOG.info("accesslog.flush.interval=" + accessLogFlushInterval);
         LOG.info("accesslog.failure.wait=" + accessLogWaitBetweenFailures);
         LOG.info("accesslog.maxsize=" + accessLogMaxSize);
+
+        accessLogAdvancedEnabled = properties.getBoolean("accesslog.advanced.enabled", accessLogAdvancedEnabled);
+        accessLogAdvancedBodySize = properties.getInt("accesslog.advanced.body.size", accessLogAdvancedBodySize);
+        LOG.info("accesslog.advanced.enabled=" + accessLogAdvancedEnabled);
+        LOG.info("accesslog.advanced.body.size=" + accessLogAdvancedBodySize);
 
         tryConfigureCertificates(properties);
         tryConfigureListeners(properties);

--- a/carapace-server/src/test/java/org/carapaceproxy/server/FullHttpMessageLoggerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/FullHttpMessageLoggerTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.carapaceproxy.server;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.carapaceproxy.client.EndpointKey;
+import org.carapaceproxy.utils.RawHttpClient;
+import org.carapaceproxy.utils.TestEndpointMapper;
+import static org.junit.Assert.assertTrue;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import java.nio.file.Files;
+import org.carapaceproxy.utils.CarapaceLogger;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ *
+ * @author paolo.venturi
+ */
+public class FullHttpMessageLoggerTest {
+
+    private static final boolean DEBUG = true;
+
+    private String accessLogFilePath;
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(0);
+
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
+
+    @Before
+    public void before() {
+        accessLogFilePath = tmpDir.getRoot().getAbsolutePath() + "/access.log";
+    }
+
+    @Test
+    public void testGetMessageLog() throws Exception {
+        stubFor(get(urlEqualTo("/index.html"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/html")
+                        .withHeader("Content-Length", "it <b>works</b> !!".length() + "")
+                        .withBody("it <b>works</b> !!")));
+
+        TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.port(), true);
+        EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
+
+        CarapaceLogger.setLoggingDebugEnabled(true);
+
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
+            server.getCurrentConfiguration().setAccessLogPath(tmpDir.getRoot().getAbsolutePath() + "/access.log");
+            Path path = Paths.get(server.getCurrentConfiguration().getAccessLogPath() + ".full");
+            server.start();
+            int port = server.getLocalPort();
+            try (RawHttpClient client = new RawHttpClient("localhost", port)) {
+                RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+                String s = resp.toString();
+                assertTrue(s.endsWith("it <b>works</b> !!"));
+            }
+            try (RawHttpClient client = new RawHttpClient("localhost", port)) {
+                {
+                    RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
+                    String s = resp.toString();
+                    assertTrue(s.endsWith("it <b>works</b> !!"));
+                }
+                {
+                    RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
+                    String s = resp.toString();
+                    assertTrue(s.endsWith("it <b>works</b> !!"));
+                }
+            }
+            Thread.sleep(3000);
+            File[] f = new File(tmpDir.getRoot().getAbsolutePath()).listFiles((dir, name) -> name.startsWith("access") && name.endsWith(".full"));
+            assertTrue(f.length == 1);
+            Files.readAllLines(f[0].toPath()).forEach(l -> System.out.println(l));
+        }
+    }
+
+    @Test
+    public void testPostMessageLog() throws Exception {
+        String responseJson = "{\"property\" : \"value\"}";
+        stubFor(post(urlEqualTo("/index.html"))
+                .willReturn(WireMock.okJson(responseJson)));
+
+        TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.port(), true);
+        EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
+
+        CarapaceLogger.setLoggingDebugEnabled(true);
+
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
+            server.getCurrentConfiguration().setAccessLogPath(tmpDir.getRoot().getAbsolutePath() + "/access.log");
+            Path path = Paths.get(server.getCurrentConfiguration().getAccessLogPath() + ".full");
+            server.start();
+            int port = server.getLocalPort();
+            try (RawHttpClient client = new RawHttpClient("localhost", port)) {
+                String body = "{\"values\" : {\"p\" : \"v\"}, \"options\" : {\"o\" : 1}}";
+                RawHttpClient.HttpResponse res =
+                        client.executeRequest("POST /index.html HTTP/1.1"
+                                + "\r\nHost: localhost"
+                                + "\r\nConnection: keep-alive"
+                                + "\r\nContent-Type: application/json"
+                                + "\r\nContent-Length: " + body.length()
+                                + "\r\n\r\n"
+                                + body
+                        );
+                String resp = res.getBodyString();
+            }
+        }
+        Thread.sleep(3000);
+        File[] f = new File(tmpDir.getRoot().getAbsolutePath()).listFiles((dir, name) -> name.startsWith("access") && name.endsWith(".full"));
+        assertTrue(f.length == 1);
+        Files.readAllLines(f[0].toPath()).forEach(l -> System.out.println(l));
+    }
+}

--- a/carapace-server/src/test/java/org/carapaceproxy/server/FullHttpMessageLoggerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/FullHttpMessageLoggerTest.java
@@ -26,8 +26,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.File;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.carapaceproxy.client.EndpointKey;
 import org.carapaceproxy.utils.RawHttpClient;
 import org.carapaceproxy.utils.TestEndpointMapper;
@@ -35,7 +33,6 @@ import static org.junit.Assert.assertTrue;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import java.nio.file.Files;
 import org.carapaceproxy.utils.CarapaceLogger;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -46,20 +43,11 @@ import org.junit.rules.TemporaryFolder;
  */
 public class FullHttpMessageLoggerTest {
 
-    private static final boolean DEBUG = true;
-
-    private String accessLogFilePath;
-
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(0);
 
     @Rule
     public TemporaryFolder tmpDir = new TemporaryFolder();
-
-    @Before
-    public void before() {
-        accessLogFilePath = tmpDir.getRoot().getAbsolutePath() + "/access.log";
-    }
 
     @Test
     public void testGetMessageLog() throws Exception {
@@ -77,7 +65,9 @@ public class FullHttpMessageLoggerTest {
 
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.getCurrentConfiguration().setAccessLogPath(tmpDir.getRoot().getAbsolutePath() + "/access.log");
-            Path path = Paths.get(server.getCurrentConfiguration().getAccessLogPath() + ".full");
+            server.getCurrentConfiguration().setAccessLogAdvancedEnabled(true);
+            server.getCurrentConfiguration().setAccessLogTimestampFormat("dd-MM-yyyy HH:mm:ss.SSS");
+            server.getFullHttpMessageLogger().reloadConfiguration(server.getCurrentConfiguration());
             server.start();
             int port = server.getLocalPort();
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
@@ -117,7 +107,9 @@ public class FullHttpMessageLoggerTest {
 
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.getCurrentConfiguration().setAccessLogPath(tmpDir.getRoot().getAbsolutePath() + "/access.log");
-            Path path = Paths.get(server.getCurrentConfiguration().getAccessLogPath() + ".full");
+            server.getCurrentConfiguration().setAccessLogAdvancedEnabled(true);
+            server.getCurrentConfiguration().setAccessLogAdvancedBodySize(5);
+            server.getFullHttpMessageLogger().reloadConfiguration(server.getCurrentConfiguration());
             server.start();
             int port = server.getLocalPort();
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {

--- a/carapace-server/src/test/java/org/carapaceproxy/server/RequestsLoggerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/RequestsLoggerTest.java
@@ -1,21 +1,21 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
 package org.carapaceproxy.server;
 
@@ -37,9 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.List;
-import static junit.framework.Assert.assertEquals;
 import org.carapaceproxy.EndpointStats;
 import org.carapaceproxy.MapResult;
 import org.carapaceproxy.client.ConnectionsManagerStats;
@@ -480,19 +478,19 @@ public class RequestsLoggerTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
-        try ( HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.getCurrentConfiguration().setAccessLogPath(tmpDir.getRoot().getAbsolutePath() + "/access.log");
             server.start();
             int port = server.getLocalPort();
 
-            try ( RawHttpClient client = new RawHttpClient("localhost", port)) {
+            try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 assertTrue(s.endsWith("it <b>works</b> !!"));
                 assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
             }
 
-            try ( RawHttpClient client = new RawHttpClient("localhost", port)) {
+            try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     String s = resp.toString();
@@ -537,7 +535,7 @@ public class RequestsLoggerTest {
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.port(), true);
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
-        try ( HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.getCurrentConfiguration().setAccessLogPath(tmpDir.getRoot().getAbsolutePath() + "/access.log");
             server.getCurrentConfiguration().setAccessLogMaxSize(1024);
             Path currentAccessLogPath = Paths.get(server.getCurrentConfiguration().getAccessLogPath());
@@ -547,13 +545,13 @@ public class RequestsLoggerTest {
             FileChannel logFileChannel = FileChannel.open(currentAccessLogPath);
 
             while (logFileChannel.size() < 1024) {
-                try ( RawHttpClient client = new RawHttpClient("localhost", port)) {
+                try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                     String s = resp.toString();
                     assertTrue(s.endsWith("it <b>works</b> !!"));
                 }
 
-                try ( RawHttpClient client = new RawHttpClient("localhost", port)) {
+                try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                     {
                         RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                         String s = resp.toString();
@@ -571,7 +569,7 @@ public class RequestsLoggerTest {
             //check if gzip file exist
             File[] f = new File(tmpDir.getRoot().getAbsolutePath()).listFiles((dir, name) -> name.startsWith("access") && name.endsWith(".gzip"));
             assertTrue(f.length == 1);
-            try ( RawHttpClient client = new RawHttpClient("localhost", port)) {
+            try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 assertTrue(s.endsWith("it <b>works</b> !!"));
@@ -579,4 +577,5 @@ public class RequestsLoggerTest {
             assertTrue(logFileChannel.size() > 0);
         }
     }
+
 }


### PR DESCRIPTION
Added an inbound handler to keep track of all clients requests and server responses and print them into dedicated logging file.

- New property _**accesslog.advanced.enabled=true**_ to enable advanged logging (default **false**)
- New property **_accesslog.advanced.body.size_** to limit the size of requests/responses body (default **1_000** bytes; 0 to disable)

All main configuration property values (like _file path_ and _timestamp format_) are inherited by **_accesslog._** ones.

Example of output:
```
<<<<<<<<<<<<<<<<<<<<[ CLIENT REQUEST (rid: 1) ]<<<<<<<<<<<<<<<<<<<<
Timestamp: 15-03-2021 10:11:01.140
HTTP Version: HTTP/1.1
HTTP Method: GET
URI: /index.html
--------------------[ HEADERS ]--------------------
Host: localhost
content-length: 0
<<<<<<<<<<<<<<<<<<<<[ CLIENT REQUEST END (rid: 1) ]<<<<<<<<<<<<<<<<<<<<


>>>>>>>>>>>>>>>>>>>>[ SERVER RESPONSE (rid: 1) ]>>>>>>>>>>>>>>>>>>>>
Timestamp: 15-03-2021 10:11:01.245
HTTP Version: HTTP/1.1
Status code: 200
--------------------[ HEADERS ]--------------------
Content-Type: text/html
Matched-Stub-Id: 9b3149a6-5d73-4d9d-a76c-ef7724b2b564
Vary: Accept-Encoding, User-Agent
Content-Length: 18
Server: Jetty(9.4.8.v20171121)
Expires: Mon, 15 Mar 2021 10:11:01 GMT
--------------------[ BODY ]--------------------
it <b>works</b> !!
>>>>>>>>>>>>>>>>>>>>[ SERVER RESPONSE END (rid: 1) ]>>>>>>>>>>>>>>>>>>>>
```
