### PR TITLE
Bump libs: awssdk and prometheus-metrics

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -54,7 +54,6 @@
                     <groupId>org.apache.yetus</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
-
                 <exclusion>
                     <groupId>io.netty</groupId>
                     <artifactId>*</artifactId>
@@ -270,13 +269,25 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>route53</artifactId>
-            <version>2.13.13</version>
+            <version>${libs.awssdk}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.bookkeeper.stats</groupId>
             <artifactId>prometheus-metrics-provider</artifactId>
-            <version>4.12.0</version>
+            <version>${libs.prometheus.metrics}</version>
             <type>jar</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,8 @@
         <libs.stringtemplate>4.0.8</libs.stringtemplate>
         <libs.herddb>0.22.0</libs.herddb>
         <libs.prometheus>0.6.0</libs.prometheus>
+        <libs.prometheus.metrics>4.13.0</libs.prometheus.metrics>
+        <libs.awssdk>2.16.18</libs.awssdk>
         <javacc-maven-plugin.version>2.4</javacc-maven-plugin.version>
     </properties>
     <repositories>


### PR DESCRIPTION
AWS SDK updated from 2.13.13 to 2.16.18
Prometheus metrics updated from 4.12.0 to 4.13.0

Moreover, added Netty dependencies exclusion
