### PR TITLE
UI Certiticates list and detail > status outdated during renewal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 *.pyc
 dependency-reduced-pom.xml
 **/nbproject/
-**/access.log
+**/access.log*
 **/pom.xml.releaseBackup
 release.properties
 **/*.p12


### PR DESCRIPTION
Regression from https://github.com/diennea/carapaceproxy/pull/257: certificates state is no more fetched from db but from cache, so during a certificate renewal this is outdated.

Changelog:
Now after every certificates batch update whether at least a certificate has been updated all cluster nodes reload cached data.
