### PR TITLE
Advanced logger: disable fireChannelRead when disabled

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
@@ -40,7 +40,6 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
-import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
@@ -471,8 +470,7 @@ public class EndpointConnectionImpl implements EndpointConnection {
             } else {
                 LOG.log(Level.SEVERE, "unknown message type {0}: {1}. connection: {2}", new Object[]{msg.getClass(), msg, EndpointConnectionImpl.this});
             }
-
-            ctx.fireChannelRead(ReferenceCountUtil.retain(msg));
+            parent.getFullHttpMessageLogger().fireChannelRead(ctx, msg);
         }
 
         @Override

--- a/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
@@ -29,7 +29,6 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
-import io.netty.util.ReferenceCountUtil;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import java.net.SocketAddress;
@@ -68,6 +67,7 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
     final ContentsCache cache;
     final StaticContentsManager staticContentsManager;
     final RequestsLogger requestsLogger;
+    final FullHttpMessageLogger fullHttpMessageLogger;
     final long connectionStartsTs;
     volatile boolean keepAlive = true;
     volatile boolean refuseOtherRequests;
@@ -92,6 +92,7 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
             Runnable onClientDisconnected,
             BackendHealthManager backendHealthManager,
             RequestsLogger requestsLogger,
+            FullHttpMessageLogger fullHttpMessageLogger,
             String listenerHost,
             int listenerPort,
             boolean secure) {
@@ -106,6 +107,7 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
         this.onClientDisconnected = onClientDisconnected;
         this.backendHealthManager = backendHealthManager;
         this.requestsLogger = requestsLogger;
+        this.fullHttpMessageLogger = fullHttpMessageLogger;
         this.listenerHost = listenerHost;
         this.listenerPort = listenerPort;
         this.secure = secure;
@@ -198,7 +200,7 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
             }
         }
 
-        ctx.fireChannelRead(ReferenceCountUtil.retain(msg));
+        fullHttpMessageLogger.fireChannelRead(ctx, msg);
     }
 
     private void detectSSLProperties(ChannelHandlerContext ctx) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/FullHttpMessageLogger.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/FullHttpMessageLogger.java
@@ -30,6 +30,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.util.ReferenceCountUtil;
 import java.io.BufferedWriter;
 import java.io.Closeable;
 import java.io.FileOutputStream;
@@ -254,6 +255,12 @@ public class FullHttpMessageLogger implements Runnable, Closeable {
         if (accessLogAdvancedEnabled) {
             channel.pipeline().addLast(new HttpObjectAggregator(Integer.MAX_VALUE));
             channel.pipeline().addLast(new FullHttpMessageLoggerHandler(reqHandler));
+        }
+    }
+
+    public void fireChannelRead(ChannelHandlerContext ctx, Object msg) {
+        if (accessLogAdvancedEnabled) {
+            ctx.fireChannelRead(ReferenceCountUtil.retain(msg));
         }
     }
 

--- a/carapace-server/src/main/java/org/carapaceproxy/server/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/Listeners.java
@@ -231,6 +231,7 @@ public class Listeners {
                                 () -> CURRENT_CONNECTED_CLIENTS_GAUGE.dec(),
                                 parent.getBackendHealthManager(),
                                 parent.getRequestsLogger(),
+                                parent.getFullHttpMessageLogger(),
                                 listener.getHost(),
                                 port,
                                 listener.isSsl()


### PR DESCRIPTION
Whether the advanced logger is disabled we has not to call ctx.fireChannelRead