### PR TITLE
Improved server-client connection release + ssl chain cache

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/server/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/Listeners.java
@@ -71,6 +71,7 @@ import org.carapaceproxy.utils.PrometheusUtils;
 import static org.carapaceproxy.utils.CertificatesUtils.readChainFromKeystore;
 import io.netty.handler.timeout.IdleStateHandler;
 import static org.carapaceproxy.utils.CertificatesUtils.loadKeyStoreFromFile;
+import io.netty.handler.ssl.OpenSslCachingX509KeyManagerFactory;
 
 /**
  *
@@ -138,7 +139,7 @@ public class Listeners {
                 );
                 keystore = loadKeyStoreFromFile(certificate.getFile(), certificate.getPassword(), basePath);
             }
-            KeyManagerFactory keyFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            KeyManagerFactory keyFactory = new OpenSslCachingX509KeyManagerFactory(KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm()));
             keyFactory.init(keystore, certificate.getPassword().toCharArray());
 
             LOG.log(Level.INFO, "loading trustore from {0}", listener.getSslTrustoreFile());

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
@@ -656,9 +656,12 @@ public class RequestHandler implements MatchingContext {
                         connectionToClient.keepAlive = false;
                     }
                 }
+                if (closeAfterResponse) {
+                    connectionToClient.keepAlive = false;
+                }
             }
             // LOG.log(Level.INFO, this + " returnConnection:" + returnConnection + ", keepAlive1:" + keepAlive1 + " connecton " + connectionToEndpoint);
-            if (msg instanceof LastHttpContent && future.isSuccess()) {
+            if (msg instanceof LastHttpContent && (future.isSuccess() || closeAfterResponse)) {
                 connectionToClient.closeIfNotKeepAlive(channelToClient);
             }
         });


### PR DESCRIPTION
Changelog:

- whether the server send connection close now we close the channel to the client
- release connection to endpoint with forceClose flag now skip client check for release
- KeyManagerFactory is now wrapped by OpenSslCachingX509KeyManagerFactory (this should improve performance during ssl connections establishment)