### PR TITLE
In-memory certificates data improvement

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
@@ -184,7 +184,7 @@ public class CertificatesResource {
                 state = certificate.isAcme()
                         ? cert.getState()
                         : CertificatesUtils.isCertificateExpired(cert.getExpiringDate(), 0) ? DynamicCertificateState.EXPIRED : DynamicCertificateState.AVAILABLE;
-                bean.setExpiringDate(cert.getExpiringDate().toString());
+                bean.setExpiringDate(cert.getExpiringDate() != null ? cert.getExpiringDate().toString() : "");
                 bean.setSerialNumber(cert.getSerialNumber());
             } else {
                 KeyStore keystore = loadKeyStoreFromFile(certificate.getFile(), certificate.getPassword(), server.getBasePath());

--- a/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/CertificatesResource.java
@@ -175,28 +175,30 @@ public class CertificatesResource {
 
     private static void fillCertificateBean(CertificateBean bean, SSLCertificateConfiguration certificate, DynamicCertificatesManager dCManager, HttpProxyServer server) {
         try {
-            Certificate[] chain;
             DynamicCertificateState state = null;
             if (certificate.isDynamic()) {
                 CertificateData cert = dCManager.getCertificateDataForDomain(certificate.getId());
                 if (cert == null) {
                     return;
                 }
-                chain = base64DecodeCertificateChain(cert.getChain());
-                state = cert.getState();
+                state = certificate.isAcme()
+                        ? cert.getState()
+                        : CertificatesUtils.isCertificateExpired(cert.getExpiringDate(), 0) ? DynamicCertificateState.EXPIRED : DynamicCertificateState.AVAILABLE;
+                bean.setExpiringDate(cert.getExpiringDate().toString());
+                bean.setSerialNumber(cert.getSerialNumber());
             } else {
                 KeyStore keystore = loadKeyStoreFromFile(certificate.getFile(), certificate.getPassword(), server.getBasePath());
                 if (keystore == null) {
                     return;
                 }
-                chain = CertificatesUtils.readChainFromKeystore(keystore);
-            }
-            if (chain != null && chain.length > 0) {
-                X509Certificate _cert = ((X509Certificate) chain[0]);
-                bean.setExpiringDate(_cert.getNotAfter().toString());
-                bean.setSerialNumber(_cert.getSerialNumber().toString(16).toUpperCase()); // HEX
-                if (!certificate.isAcme()) {
-                    state = CertificatesUtils.isCertificateExpired(chain, 0) ? DynamicCertificateState.EXPIRED : DynamicCertificateState.AVAILABLE;
+                Certificate[] chain = CertificatesUtils.readChainFromKeystore(keystore);
+                if (chain != null && chain.length > 0) {
+                    X509Certificate _cert = ((X509Certificate) chain[0]);
+                    bean.setExpiringDate(_cert.getNotAfter().toString());
+                    bean.setSerialNumber(_cert.getSerialNumber().toString(16).toUpperCase()); // HEX
+                    if (!certificate.isAcme()) {
+                        state = CertificatesUtils.isCertificateExpired(_cert.getNotAfter(), 0) ? DynamicCertificateState.EXPIRED : DynamicCertificateState.AVAILABLE;
+                    }
                 }
             }
             if (certificate.isAcme()) {

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
@@ -20,6 +20,7 @@
 package org.carapaceproxy.configstore;
 
 import java.net.URL;
+import java.util.Date;
 import java.util.Objects;
 import org.carapaceproxy.server.certificates.DynamicCertificateState;
 import org.shredzone.acme4j.toolbox.JSON;
@@ -35,7 +36,7 @@ public class CertificateData {
     private String domain;
     private String privateKey; // base64 encoded string.
     private String chain; // base64 encoded string of the KeyStore.
-    private DynamicCertificateState state;
+    private volatile DynamicCertificateState state;
     private String pendingOrderLocation;
     private String pendingChallengeData;
 
@@ -43,6 +44,9 @@ public class CertificateData {
     private boolean wildcard;
     private boolean manual;
     private int daysBeforeRenewal;
+    private Date expiringDate;
+    private String serialNumber; // hex
+    private byte[] keystoreData; // decoded chain
 
     public CertificateData(String domain, String privateKey, String chain, DynamicCertificateState state,
                            String orderLocation, String challengeData) {
@@ -132,6 +136,30 @@ public class CertificateData {
 
     public void setDaysBeforeRenewal(int daysBeforeRenewal) {
         this.daysBeforeRenewal = daysBeforeRenewal;
+    }
+
+    public Date getExpiringDate() {
+        return expiringDate;
+    }
+
+    public void setExpiringDate(Date expiringDate) {
+        this.expiringDate = expiringDate;
+    }
+
+    public String getSerialNumber() {
+        return serialNumber;
+    }
+
+    public void setSerialNumber(String serialNumber) {
+        this.serialNumber = serialNumber;
+    }
+
+    public byte[] getKeystoreData() {
+        return keystoreData;
+    }
+
+    public void setKeystoreData(byte[] keystoreData) {
+        this.keystoreData = keystoreData;
     }
 
     @Override

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
@@ -19,7 +19,6 @@
  */
 package org.carapaceproxy.server.certificates;
 
-import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64DecodeCertificateChain;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64EncodeCertificateChain;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.AVAILABLE;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.DNS_CHALLENGE_WAIT;
@@ -63,7 +62,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
 import org.carapaceproxy.server.HttpProxyServer;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
-import org.carapaceproxy.utils.CertificatesUtils;
 import org.glassfish.jersey.internal.guava.ThreadFactoryBuilder;
 import org.shredzone.acme4j.Order;
 import org.shredzone.acme4j.Status;

--- a/carapace-server/src/main/java/org/carapaceproxy/utils/CertificatesUtils.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/utils/CertificatesUtils.java
@@ -32,11 +32,7 @@ import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
-import java.security.cert.CertificateExpiredException;
-import java.security.cert.CertificateNotYetValidException;
-import java.security.cert.X509Certificate;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
 
@@ -50,6 +46,8 @@ public final class CertificatesUtils {
     private static final String KEYSTORE_FORMAT = "PKCS12";
     private static final String KEYSTORE_CERT_ALIAS = "cert-chain";
     public static final char[] KEYSTORE_PW = new char[0];
+
+    private static final long DAY_TO_MILLIS = 24 * 60 * 60 * 1_000;
 
     /**
      *
@@ -150,10 +148,8 @@ public final class CertificatesUtils {
         if (expiringDate == null) {
             return false;
         }
-        Calendar cal = Calendar.getInstance();
-        cal.setTime(new Date());
-        cal.add(Calendar.DATE, daysBeforeRenewal);
-        return cal.getTime().after(expiringDate);
+
+        return System.currentTimeMillis() + (daysBeforeRenewal * DAY_TO_MILLIS) >= expiringDate.getTime();
     }
 
     /**

--- a/carapace-server/src/main/java/org/carapaceproxy/utils/CertificatesUtils.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/utils/CertificatesUtils.java
@@ -146,19 +146,14 @@ public final class CertificatesUtils {
         return ks;
     }
 
-    public static boolean isCertificateExpired(Certificate[] chain, int daysBeforeRenewal) throws GeneralSecurityException {
-        if (chain == null || chain.length == 0) {
+    public static boolean isCertificateExpired(Date expiringDate, int daysBeforeRenewal) throws GeneralSecurityException {
+        if (expiringDate == null) {
             return false;
         }
-        try {
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(new Date());
-            cal.add(Calendar.DATE, daysBeforeRenewal);
-            ((X509Certificate) chain[0]).checkValidity(cal.getTime());
-        } catch (CertificateNotYetValidException | CertificateExpiredException ex) {
-            return true;
-        }
-        return false;
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(new Date());
+        cal.add(Calendar.DATE, daysBeforeRenewal);
+        return cal.getTime().after(expiringDate);
     }
 
     /**

--- a/carapace-server/src/test/java/org/carapaceproxy/api/StartAPIServerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/StartAPIServerTest.java
@@ -405,11 +405,12 @@ public class StartAPIServerTest extends UseAdminServer {
 
             // Downloading
             CertificateData cert = store.loadCertificateForDomain(dynDomain);
-            cert.setChain(Base64.getEncoder().encodeToString("CHAIN".getBytes()));
+            byte[] newKeystore = createKeystore(generateSampleChain(endUserKeyPair, false), KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE).getPrivate());
+            cert.setChain(Base64.getEncoder().encodeToString(newKeystore));
             store.saveCertificate(cert);
             man.setStateOfCertificate(dynDomain, DynamicCertificateState.AVAILABLE);
             response = client.get("/api/certificates/" + dynDomain + "/download", credentials);
-            assertEquals("CHAIN", response.getBodyString());
+            assertTrue(Arrays.equals(newKeystore, response.getBody()));
         }
 
         // Manual certificate

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesTest.java
@@ -494,12 +494,12 @@ public class CertificatesTest extends UseAdminServer {
 
         ConfigurationStore store = dcMan.getConfigurationStore();
         store.saveKeyPairForDomain(keyPair, "localhost", false);
-        CertificateData cert = store.loadCertificateForDomain("localhost");
+        CertificateData cert = dcMan.getCertificateDataForDomain("localhost");
         cert.setState(DynamicCertificateState.ORDERING);
         cert.setPendingOrderLocation("https://localhost/orderlocation");
-        store.saveCertificate(cert);
-        assertEquals(DynamicCertificateState.ORDERING, dcMan.getStateOfCertificate("localhost"));
-        assertNotNull(dcMan.getCertificateForDomain("localhost"));
+        cert = dcMan.getCertificateDataForDomain("localhost");
+        assertNotNull(cert);
+        assertEquals(DynamicCertificateState.ORDERING, cert.getState());
 
         // ACME mocking
         ACMEClient ac = mock(ACMEClient.class);

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesUtilsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesUtilsTest.java
@@ -33,6 +33,8 @@ import java.util.Arrays;
 import org.junit.Test;
 import org.shredzone.acme4j.util.KeyPairUtils;
 import static org.carapaceproxy.utils.CertificatesUtils.compareChains;
+import java.security.cert.X509Certificate;
+import java.util.Date;
 import org.carapaceproxy.utils.CertificatesUtils;
 
 /**
@@ -70,16 +72,16 @@ public class CertificatesUtilsTest {
         {
             KeyPair endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
             Certificate[] chain = generateSampleChain(endUserKeyPair, false); // not before == not after == today
-            assertFalse(CertificatesUtils.isCertificateExpired(chain, 0));
-            assertTrue(CertificatesUtils.isCertificateExpired(chain, -30)); // not before
-            assertTrue(CertificatesUtils.isCertificateExpired(chain, 30)); // not after
+            Date expiringDate = ((X509Certificate) chain[0]).getNotAfter();
+            assertFalse(CertificatesUtils.isCertificateExpired(expiringDate, 0));
+            assertTrue(CertificatesUtils.isCertificateExpired(expiringDate, 30)); // not after
         }
         {
             KeyPair endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
             Certificate[] chain = generateSampleChain(endUserKeyPair, true); // not before == not after == today
-            assertTrue(CertificatesUtils.isCertificateExpired(chain, 0));
-            assertTrue(CertificatesUtils.isCertificateExpired(chain, -30)); // not before
-            assertTrue(CertificatesUtils.isCertificateExpired(chain, 30)); // not after
+            Date expiringDate = ((X509Certificate) chain[0]).getNotAfter();
+            assertTrue(CertificatesUtils.isCertificateExpired(expiringDate, 0));
+            assertTrue(CertificatesUtils.isCertificateExpired(expiringDate, 30)); // not after
         }
     }
 }


### PR DESCRIPTION
Improved certificates data management on memory:

- serial number, expiring date and keystore data are now keep in memory and not more retrived from decoded chain
