### PR TITLE
Bug/100 continue management

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
@@ -457,7 +457,8 @@ public class EndpointConnectionImpl implements EndpointConnection {
         public void channelRead0(ChannelHandlerContext ctx, HttpObject msg) {
             RequestHandler _clientSidePeerHandler = clientSidePeerHandler.get();
             if (_clientSidePeerHandler == null || !requestRunning) {
-                LOG.log(Level.INFO, "swallow content {0}: {1}, disconnected client. connection: {2}", new Object[]{msg.getClass(), msg, EndpointConnectionImpl.this});
+                final String cause = _clientSidePeerHandler == null ? "no more client connected" : "request stopped";
+                LOG.log(Level.INFO, id + ": swallow content {0}: {1}, disconnected client due to {2}. connection: {3}", new Object[]{msg.getClass(), msg, cause, EndpointConnectionImpl.this});
                 return;
             }
             if (msg instanceof HttpContent) {
@@ -479,7 +480,7 @@ public class EndpointConnectionImpl implements EndpointConnection {
         public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
             RequestHandler _clientSidePeerHandler = clientSidePeerHandler.get();
             if (_clientSidePeerHandler != null && requestRunning) {
-                logConnectionInfo("channelReadComplete, open: " + ctx.channel().isOpen(), "");
+                logConnectionInfo("channelReadComplete, open: " + ctx.channel().isOpen());
                 _clientSidePeerHandler.readCompletedFromRemote();
             }
         }

--- a/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
@@ -45,6 +45,7 @@ import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Summary;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -210,7 +211,7 @@ public class EndpointConnectionImpl implements EndpointConnection {
 
     @Override
     public void sendRequest(HttpRequest request, RequestHandler clientSidePeerHandler) {
-        logConnectionInfo("sendRequest");
+        logConnectionInfo("sendRequest", request);
 
         if (assertNotInEndpointEventLoop(clientSidePeerHandler)) {
             return;
@@ -280,7 +281,7 @@ public class EndpointConnectionImpl implements EndpointConnection {
 
     @Override
     public void sendChunk(HttpContent msg, RequestHandler clientSidePeerHandler) {
-        logConnectionInfo("sendChunk");
+        logConnectionInfo("sendChunk", msg);
         if (assertNotInEndpointEventLoop(clientSidePeerHandler)) {
             return;
         }
@@ -315,7 +316,7 @@ public class EndpointConnectionImpl implements EndpointConnection {
 
     @Override
     public void sendLastHttpContent(LastHttpContent msg, RequestHandler clientSidePeerHandler) {
-        logConnectionInfo("sendLastHttpContent");
+        logConnectionInfo("sendLastHttpContent", msg);
         if (assertNotInEndpointEventLoop(clientSidePeerHandler)) {
             return;
         }
@@ -460,11 +461,11 @@ public class EndpointConnectionImpl implements EndpointConnection {
                 return;
             }
             if (msg instanceof HttpContent) {
-                logConnectionInfo("receivedFromRemote HttpContent");
+                logConnectionInfo("receivedFromRemote HttpContent", msg);
                 HttpContent f = (HttpContent) msg;
                 _clientSidePeerHandler.receivedFromRemote(f.copy(), EndpointConnectionImpl.this);
             } else if (msg instanceof DefaultHttpResponse) {
-                logConnectionInfo("receivedFromRemote DefaultHttpResponse");
+                logConnectionInfo("receivedFromRemote DefaultHttpResponse", msg);
                 DefaultHttpResponse f = (DefaultHttpResponse) msg;
                 // DefaultHttpResponse has no "copy" method
                 _clientSidePeerHandler.receivedFromRemote(new DefaultHttpResponse(f.protocolVersion(), f.status(), f.headers()), EndpointConnectionImpl.this);
@@ -478,10 +479,8 @@ public class EndpointConnectionImpl implements EndpointConnection {
         public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
             RequestHandler _clientSidePeerHandler = clientSidePeerHandler.get();
             if (_clientSidePeerHandler != null && requestRunning) {
-                logConnectionInfo("channelReadComplete, open: " + ctx.channel().isOpen());
+                logConnectionInfo("channelReadComplete, open: " + ctx.channel().isOpen(), "");
                 _clientSidePeerHandler.readCompletedFromRemote();
-                // server said no more data will be sent to this channel, we must close it before netty does
-//                release(true, clientSidePeerHandler, null);
             }
         }
 
@@ -534,8 +533,16 @@ public class EndpointConnectionImpl implements EndpointConnection {
         this.requestsHeaderDebugEnabled = requestsHeaderDebugEnabled;
     }
 
-    private void logConnectionInfo(String s) {
-        CarapaceLogger.debug("{0}: {1}", s, EndpointConnectionImpl.this);
+    private void logConnectionInfo(String desc) {
+        logConnectionInfo(desc, "");
+    }
+
+    private void logConnectionInfo(String desc, Object info) {
+        if (info != null && info instanceof HttpContent) {
+            HttpContent content = (HttpContent) info;
+            info = content.content().asReadOnly().readCharSequence(content.content().readableBytes(), Charset.forName("utf-8")).toString();
+        }
+        CarapaceLogger.debug("{0}: {1} \nEndpointConnectionImpl={2}", desc, info, EndpointConnectionImpl.this);
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
@@ -539,7 +539,7 @@ public class EndpointConnectionImpl implements EndpointConnection {
     }
 
     private void logConnectionInfo(String desc, Object info) {
-        if (info != null && info instanceof HttpContent) {
+        if (CarapaceLogger.isLoggingDebugEnabled() && info != null && info instanceof HttpContent) {
             HttpContent content = (HttpContent) info;
             info = content.content().asReadOnly().readCharSequence(content.content().readableBytes(), Charset.forName("utf-8")).toString();
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/RawClientTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/RawClientTest.java
@@ -844,10 +844,15 @@ public class RawClientTest {
                             oo.flush();
 
                             String resp = consumeHttpResponseInput(socket.getInputStream()).getBodyString();
-                            System.out.println("RESP trigger: " + resp);
+                            System.out.println("RESP client1: " + resp);
                             if (!resp.contains("HTTP/1.1 100 Continue")) {
                                 failed.set(true);
                             }
+//                            resp = consumeHttpResponseInput(socket.getInputStream()).getBodyString();
+//                            System.out.println("RESP2 client1: " + resp);
+//                            if (!resp.contains("HTTP/1.1 100 Continue")) {
+//                                failed.set(true);
+//                            }
                         } catch (Exception e) {
                             System.out.println("EXCEPTION: " + e);
                             failed.set(true);
@@ -860,8 +865,8 @@ public class RawClientTest {
                                 responseEnabled.set(true);
                                 RawHttpClient.HttpResponse res = client2.get("/index.html");
                                 String resp = res.getBodyString();
-                                System.out.println("RESP NOtrigger: " + resp);
-                                if (!resp.contains("resp=continue")) { // this resp should been received by client1 not client2
+                                System.out.println("RESP client2: " + resp);
+                                if (!resp.contains("resp=client2")) {
                                     failed.set(true);
                                 }
                             }
@@ -948,7 +953,7 @@ public class RawClientTest {
                                         boolean keepAlive = HttpUtil.isKeepAlive(request);
                                         DefaultFullHttpResponse response = new DefaultFullHttpResponse(
                                                 HTTP_1_1, HttpResponseStatus.OK,
-                                                Unpooled.copiedBuffer("resp=" + request.headers().get("trigger"), Charset.forName("utf-8"))
+                                                Unpooled.copiedBuffer("resp=" + (request.headers().contains("trigger") ? "client1" : "client2"), Charset.forName("utf-8"))
                                         );
                                         response.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=UTF-8");
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/FullHttpMessageLoggerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/FullHttpMessageLoggerTest.java
@@ -67,6 +67,7 @@ public class FullHttpMessageLoggerTest {
             server.getCurrentConfiguration().setAccessLogPath(tmpDir.getRoot().getAbsolutePath() + "/access.log");
             server.getCurrentConfiguration().setAccessLogAdvancedEnabled(true);
             server.getCurrentConfiguration().setAccessLogTimestampFormat("dd-MM-yyyy HH:mm:ss.SSS");
+            server.getCurrentConfiguration().setMaxConnectionsPerEndpoint(1);
             server.getFullHttpMessageLogger().reloadConfiguration(server.getCurrentConfiguration());
             server.start();
             int port = server.getLocalPort();

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/RawHttpClient.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/RawHttpClient.java
@@ -45,7 +45,7 @@ import javax.net.ssl.SSLSocketFactory;
  */
 public final class RawHttpClient implements AutoCloseable {
 
-    private static boolean DEBUG = false;
+    private static boolean DEBUG = true;
 
     private final Socket socket;
     private final String host;

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/RawHttpClient.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/RawHttpClient.java
@@ -248,7 +248,7 @@ public final class RawHttpClient implements AutoCloseable {
         }
     }
 
-    private static HttpResponse consumeHttpResponseInput(final InputStream in) throws IOException {
+    public static HttpResponse consumeHttpResponseInput(final InputStream in) throws IOException {
 
         HttpResponse result = new HttpResponse();
 

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/RawHttpClient.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/RawHttpClient.java
@@ -45,7 +45,7 @@ import javax.net.ssl.SSLSocketFactory;
  */
 public final class RawHttpClient implements AutoCloseable {
 
-    private static boolean DEBUG = true;
+    private static boolean DEBUG = false;
 
     private final Socket socket;
     private final String host;


### PR DESCRIPTION
Whenever a client makes a request including header "Expect: 100-continue" the server sends back a 100 continue response together with a LastHttpContent. This breaks the "client-server release handshake" so that another client may use the same connection whenever the first client (c1) sends its LastHttpContent (performing delayed release recovery) and getting the response  of c1.