### PR TITLE
Improve client-endpoints connection management

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/client/impl/ConnectionsManagerImpl.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/impl/ConnectionsManagerImpl.java
@@ -189,7 +189,8 @@ public class ConnectionsManagerImpl implements ConnectionsManager, AutoCloseable
                     if (connectionToEndpoint != null && backendsUnreachableOnStuckRequests) {
                         backendHealthManager.reportBackendUnreachable(
                                 connectionToEndpoint.getKey().getHostPort(), now,
-                                "a request to " + requestHandler.getUri() + " for user " + requestHandler.getUserId() + " appears stuck");
+                                "a request to " + requestHandler.getUri() + " for user " + requestHandler.getUserId() + " appears stuck"
+                        );
                     }
                     STUCK_REQUESTS_COUNTER.inc();
                     toRemove.add(entry.getValue());
@@ -199,7 +200,6 @@ public class ConnectionsManagerImpl implements ConnectionsManager, AutoCloseable
                 unregisterPendingRequest(r);
             });
         }
-
     }
 
     @Override
@@ -222,10 +222,18 @@ public class ConnectionsManagerImpl implements ConnectionsManager, AutoCloseable
         if (this.stuckRequestsReaperFuture != null && (oldIdleTimeout != idleTimeout)) {
             this.stuckRequestsReaperFuture.cancel(false);
             LOG.log(Level.INFO, "Re-scheduling stuckRequestsReaper with period (idleTimeout/4):{0} ms", idleTimeout / 4);
-            this.stuckRequestsReaperFuture =
-                    this.scheduler.scheduleWithFixedDelay(new RequestHandlerChecker(), idleTimeout / 4, idleTimeout / 4,
-                            TimeUnit.MILLISECONDS);
+            this.stuckRequestsReaperFuture = this.scheduler.scheduleWithFixedDelay(
+                    new RequestHandlerChecker(),
+                    idleTimeout / 4,
+                    idleTimeout / 4,
+                    TimeUnit.MILLISECONDS
+            );
         }
+
+        // reset clients endpoint-connection reuse for next request
+        pendingRequests.values().forEach(request -> {
+            request.getClientConnectionHandler().resetConnectionToEndpoint();
+        });
 
     }
 

--- a/carapace-server/src/main/java/org/carapaceproxy/client/impl/ConnectionsManagerImpl.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/impl/ConnectionsManagerImpl.java
@@ -243,6 +243,7 @@ public class ConnectionsManagerImpl implements ConnectionsManager, AutoCloseable
         config.setTestWhileIdle(true);
         config.setBlockWhenExhausted(true);
         config.setJmxEnabled(false);
+        config.setLifo(false); // connections borrowed as FIFO
         group = Epoll.isAvailable() ? new EpollEventLoopGroup() : new NioEventLoopGroup();
         eventLoopForOutboundConnections = Epoll.isAvailable() ? new EpollEventLoopGroup() : new NioEventLoopGroup();
         connections = new GenericKeyedObjectPool<>(new ConnectionsFactory(), config);

--- a/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/impl/EndpointConnectionImpl.java
@@ -193,6 +193,10 @@ public class EndpointConnectionImpl implements EndpointConnection {
         channelToEndpoint
                 .closeFuture()
                 .addListener((Future<? super Void> future) -> {
+                    RequestHandler pendingRequest = this.clientSidePeerHandler.get();
+                    if (pendingRequest != null) {
+                        pendingRequest.getClientConnectionHandler().resetConnectionToEndpoint();
+                    }
                     parent.returnConnection(EndpointConnectionImpl.this, "channel closed by server");
                     CarapaceLogger.debug("channel closed to {0}. connection: {1}", key, this);
                     endpointstats.getOpenConnections().decrementAndGet();
@@ -387,6 +391,7 @@ public class EndpointConnectionImpl implements EndpointConnection {
             endpointstats.getActiveConnections().decrementAndGet();
             activeConnectionsStats.dec();
             parent.unregisterPendingRequest(_clientSidePeerHandler);
+            _clientSidePeerHandler.getClientConnectionHandler().resetConnectionToEndpoint();
             clientSidePeerHandler.set(null);
         } else {
             LOG.log(Level.SEVERE, "connectionDeactivated on a non active connection! {0}", this);

--- a/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.carapaceproxy.EndpointMapper;
+import org.carapaceproxy.client.EndpointConnection;
 import org.carapaceproxy.client.impl.EndpointConnectionImpl;
 import org.carapaceproxy.server.backends.BackendHealthManager;
 import org.carapaceproxy.server.cache.ContentsCache;
@@ -80,6 +81,7 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
     private String sslProtocol;
     private String cipherSuite;
     final SocketAddress serverAddress;
+    private EndpointConnection connectionToEndpoint;
 
     public ClientConnectionHandler(
             EndpointMapper mapper,
@@ -113,6 +115,10 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
         this.secure = secure;
 
         this.totalRequests = TOTAL_REQUESTS_COUNTER_PER_LISTENER.labels(this.listenerHost + "_" + this.listenerPort);
+    }
+
+    public long getId() {
+        return id;
     }
 
     public SocketAddress getClientAddress() {
@@ -261,12 +267,21 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
         requestRunning = false;
     }
 
+    public AtomicReference<RequestHandler> getPendingRequest() {
+        return pendingRequest;
+    }
+
+    public EndpointConnection getConnectionToEndpoint() {
+        return connectionToEndpoint;
+    }
+
+    public void setConnectionToEndpoint(EndpointConnection connectionToEndpoint) {
+        this.connectionToEndpoint = connectionToEndpoint;
+    }
+
     @Override
     public String toString() {
         return "ClientConnectionHandler{chid=" + id + ",ka=" + keepAlive + '}';
     }
 
-    public AtomicReference<RequestHandler> getPendingRequest() {
-        return pendingRequest;
-    }
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/ClientConnectionHandler.java
@@ -81,7 +81,7 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
     private String sslProtocol;
     private String cipherSuite;
     final SocketAddress serverAddress;
-    private EndpointConnection connectionToEndpoint;
+    private final AtomicReference<EndpointConnection> connectionToEndpoint = new AtomicReference<>();
 
     public ClientConnectionHandler(
             EndpointMapper mapper,
@@ -150,7 +150,7 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
         if (evt instanceof IdleStateEvent) {
             IdleStateEvent e = (IdleStateEvent) evt;
             if (e.state() == IdleState.ALL_IDLE) {
-                CarapaceLogger.debug("Idle connection detected for client {0}. Channel closed.", clientAddress);
+                CarapaceLogger.debug("Idle connection detected for client {0} {1}. Closing channel.", id, clientAddress);
                 forceClose(ctx);
             }
         }
@@ -272,11 +272,15 @@ public class ClientConnectionHandler extends SimpleChannelInboundHandler<Object>
     }
 
     public EndpointConnection getConnectionToEndpoint() {
-        return connectionToEndpoint;
+        return connectionToEndpoint.get();
     }
 
     public void setConnectionToEndpoint(EndpointConnection connectionToEndpoint) {
-        this.connectionToEndpoint = connectionToEndpoint;
+        this.connectionToEndpoint.set(connectionToEndpoint);
+    }
+
+    public void resetConnectionToEndpoint() {
+        connectionToEndpoint.set(null);
     }
 
     @Override

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
@@ -870,4 +870,9 @@ public class RequestHandler implements MatchingContext {
     public boolean isSecure() {
         return connectionToClient.isSecure();
     }
+
+    public void setCloseAfterResponse(boolean closeAfterResponse) {
+        this.closeAfterResponse = closeAfterResponse;
+    }
+
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
@@ -204,7 +204,6 @@ public class RequestHandler implements MatchingContext {
             LOG.log(Level.INFO, "Mapper returned NULL action for {0}", this);
             action = MapResult.INTERNAL_ERROR(MapResult.NO_ROUTE);
         }
-        //LOG.info("map " + request.uri() + " to " + action.action);
         Counter.Child requestsPerUser;
         if (userId != null) {
             requestsPerUser = USER_REQUESTS_COUNTER.labels(userId);
@@ -226,7 +225,6 @@ public class RequestHandler implements MatchingContext {
             case PROXY: {
                 EndpointConnection connection;
                 try {
-//                    LOG.log(Level.SEVERE, "TIME"+TIME_TRACKER.incrementAndGet()+" start " + this + " thread " + Thread.currentThread().getName());
                     connection = connectionToClient.connectionsManager.getConnection(new EndpointKey(action.host, action.port));
                 } catch (EndpointNotAvailableException err) {
                     fireRequestFinished();
@@ -244,7 +242,6 @@ public class RequestHandler implements MatchingContext {
                 }
                 EndpointConnection connection;
                 try {
-//                    LOG.log(Level.SEVERE, "TIME"+TIME_TRACKER.incrementAndGet()+" startc " + this + " thread " + Thread.currentThread().getName());
                     connection = connectionToClient.connectionsManager.getConnection(new EndpointKey(
                             action.host, action.port));
                 } catch (EndpointNotAvailableException err) {
@@ -666,7 +663,6 @@ public class RequestHandler implements MatchingContext {
                     connectionToClient.keepAlive = false;
                 }
             }
-            // LOG.log(Level.INFO, this + " returnConnection:" + returnConnection + ", keepAlive1:" + keepAlive1 + " connecton " + connectionToEndpoint);
             if (msg instanceof LastHttpContent && (future.isSuccess() || closeAfterResponse)) {
                 connectionToClient.closeIfNotKeepAlive(channelToClient);
             }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/RequestHandler.java
@@ -223,16 +223,29 @@ public class RequestHandler implements MatchingContext {
             case REDIRECT:
                 return;
             case PROXY: {
-                EndpointConnection connection;
-                try {
-                    connection = connectionToClient.connectionsManager.getConnection(new EndpointKey(action.host, action.port));
-                } catch (EndpointNotAvailableException err) {
-                    fireRequestFinished();
-                    LOG.log(Level.INFO, "{0} error on endpoint {1}: {2}", new Object[]{this, action, err});
-                    return;
+                connectionToEndpoint.set(connectionToClient.getConnectionToEndpoint()); // existing client2endpoint connection
+                if (connectionToEndpoint.get() == null) {
+                    try {
+                        connectionToEndpoint.set(connectionToClient.connectionsManager.getConnection(new EndpointKey(action.host, action.port)));
+                        connectionToClient.setConnectionToEndpoint(connectionToEndpoint.get());
+                        channelToClient.channel().closeFuture().addListener((Future<? super Void> future) -> {
+                            CarapaceLogger.debug("Closing channel to client id={0}.", connectionToClient.getId());
+                            EndpointConnection endpointConn = connectionToEndpoint.get();
+                            if (endpointConn != null) {
+                                fireRequestFinished();
+                                // return the connection the pool (async)
+                                endpointConn.release(closeAfterResponse, this, () -> connectionToEndpoint.compareAndSet(endpointConn, null));
+                            } else {
+                                LOG.log(Level.SEVERE, "{0} CANNOT release connection {1}, closeAfterResponse {2}", new Object[]{this, connectionToEndpoint, closeAfterResponse});
+                            }
+                        });
+                    } catch (EndpointNotAvailableException err) {
+                        fireRequestFinished();
+                        LOG.log(Level.INFO, "{0} error on endpoint {1}: {2}", new Object[]{this, action, err});
+                        return;
+                    }
                 }
-                connectionToEndpoint.set(connection);
-                connection.sendRequest(request, this);
+                connectionToEndpoint.get().sendRequest(request, this);
                 return;
             }
             case CACHE: {
@@ -240,22 +253,34 @@ public class RequestHandler implements MatchingContext {
                 if (cacheSender != null) {
                     return;
                 }
-                EndpointConnection connection;
-                try {
-                    connection = connectionToClient.connectionsManager.getConnection(new EndpointKey(
-                            action.host, action.port));
-                } catch (EndpointNotAvailableException err) {
-                    fireRequestFinished();
-                    LOG.log(Level.INFO, "{0} error on endpoint {1}: {2}", new Object[]{this, action, err});
-                    return;
+                connectionToEndpoint.set(connectionToClient.getConnectionToEndpoint()); // existing client2endpoint connection
+                if (connectionToEndpoint.get() == null) {
+                    try {
+                        connectionToEndpoint.set(connectionToClient.connectionsManager.getConnection(new EndpointKey(action.host, action.port)));
+                        connectionToClient.setConnectionToEndpoint(connectionToEndpoint.get());
+                        channelToClient.channel().closeFuture().addListener((Future<? super Void> future) -> {
+                            CarapaceLogger.debug("Closing channel to client id={0}.", connectionToClient.getId());
+                            EndpointConnection endpointConn = connectionToEndpoint.get();
+                            if (endpointConn != null) {
+                                fireRequestFinished();
+                                // return the connection the pool (async)
+                                endpointConn.release(closeAfterResponse, this, () -> connectionToEndpoint.compareAndSet(endpointConn, null));
+                            } else {
+                                LOG.log(Level.SEVERE, "{0} CANNOT release connection {1}, closeAfterResponse {2}", new Object[]{this, connectionToEndpoint, closeAfterResponse});
+                            }
+                        });
+                    } catch (EndpointNotAvailableException err) {
+                        fireRequestFinished();
+                        LOG.log(Level.INFO, "{0} error on endpoint {1}: {2}", new Object[]{this, action, err});
+                        return;
+                    }
                 }
-                connectionToEndpoint.set(connection);
                 cacheReceiver = connectionToClient.cache.startCachingResponse(request, isSecure());
                 if (cacheReceiver != null) {
                     // https://tools.ietf.org/html/rfc7234#section-4.3.4
                     cleanRequestFromCacheValidators(request);
                 }
-                connection.sendRequest(request, this);
+                connectionToEndpoint.get().sendRequest(request, this);
                 return;
             }
 
@@ -376,7 +401,9 @@ public class RequestHandler implements MatchingContext {
 
     private void forceCloseChannelToClient() {
         // If keep-alive is off, close the connection once the content is fully written.
-        channelToClient.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
+        closeAfterResponse = true;
+        channelToClient.writeAndFlush(Unpooled.EMPTY_BUFFER)
+                .addListener(ChannelFutureListener.CLOSE);
     }
 
     private void serveInternalErrorMessage(boolean forceClose) {
@@ -550,20 +577,18 @@ public class RequestHandler implements MatchingContext {
     }
 
     private void sendServiceNotAvailable() {
-//        LOG.info(this + " sendServiceNotAvailable due to " + cause + " to " + ctx);
         FullHttpResponse response = connectionToClient.staticContentsManager.buildResponse(500, DEFAULT_INTERNAL_SERVER_ERROR);
         clientState = RequestHandlerState.WRITING;
         channelToClient.writeAndFlush(response).addListener(new GenericFutureListener<Future<? super Void>>() {
             @Override
             public void operationComplete(Future<? super Void> future) throws Exception {
                 clientState = RequestHandlerState.IDLE;
+                lastHttpContentSent();
                 LOG.log(Level.INFO, "{0} sendServiceNotAvailable result: {1}, cause {2}",
                         new Object[]{this, future.isSuccess(), future.cause()});
-                channelToClient.close();
-                lastHttpContentSent();
+                forceCloseChannelToClient();
             }
         });
-
     }
 
     public void lastHttpContentSent() {
@@ -603,13 +628,10 @@ public class RequestHandler implements MatchingContext {
 
     public boolean errorSendingRequest(EndpointConnectionImpl connection, Throwable cause) {
         LOG.log(Level.INFO, "errorSendingRequest to " + connection, cause);
-        boolean ok = releaseConnectionToEndpoint(true, connection);
-        if (ok) {
-            connectionToClient.errorSendingRequest(this, connection, channelToClient, cause);
-            sendServiceNotAvailable();
-        }
-        return ok;
+        connectionToClient.errorSendingRequest(this, connection, channelToClient, cause);
+        sendServiceNotAvailable();
 
+        return true;
     }
 
     public void receivedFromRemote(HttpObject msg, EndpointConnection connection) {
@@ -636,15 +658,6 @@ public class RequestHandler implements MatchingContext {
                     msg.getClass(), isKeepAlive, connectionToEndpoint.get());
         }
 
-        // endpoint finished his work, we can release the connection
-        if (msg instanceof LastHttpContent) {
-            if (continueRequest) {
-                continueRequest = false;
-            } else {
-                releaseConnectionToEndpoint(closeAfterResponse, connection);
-            }
-        }
-
         addCustomResponseHeaders(msg, action.customHeaders);
         clientState = RequestHandlerState.WRITING;
         channelToClient.writeAndFlush(msg).addListener((Future<? super Void> future) -> {
@@ -663,7 +676,7 @@ public class RequestHandler implements MatchingContext {
                     connectionToClient.keepAlive = false;
                 }
             }
-            if (msg instanceof LastHttpContent && (future.isSuccess() || closeAfterResponse)) {
+            if (msg instanceof LastHttpContent) {
                 connectionToClient.closeIfNotKeepAlive(channelToClient);
             }
         });
@@ -683,20 +696,6 @@ public class RequestHandler implements MatchingContext {
                     headers.add(customHeader.getName(), customHeader.getValue());
                 }
             });
-        }
-    }
-
-    private boolean releaseConnectionToEndpoint(boolean forceClose, EndpointConnection current) {
-        if (connectionToEndpoint.get() != null && connectionToEndpoint.get().equals(current)) {
-            fireRequestFinished();
-            if (current != null) {
-                // return the connection the pool (async)
-                current.release(forceClose, this, () -> connectionToEndpoint.compareAndSet(current, null));
-            }
-            return true;
-        } else {
-            LOG.log(Level.SEVERE, "{0} CANNOT release connection {1}, forceClose {2}, current {3}", new Object[]{this, connectionToEndpoint, forceClose, current});
-            return false;
         }
     }
 
@@ -815,7 +814,6 @@ public class RequestHandler implements MatchingContext {
         if (delta >= stuckRequestTimeout) {
             LOG.log(Level.INFO, "{0} connection appears stuck {1}, on request {2} for userId: {3}", new Object[]{this, connectionToEndpoint, uri, userId});
             onStuck.run();
-            releaseConnectionToEndpoint(true, connectionToEndpoint.get());
             serveInternalErrorMessage(true);
         }
     }
@@ -826,7 +824,6 @@ public class RequestHandler implements MatchingContext {
 
     public void badErrorOnRemote(Throwable cause) {
         LOG.log(Level.INFO, "{0} badErrorOnRemote {1}", new Object[]{this, cause});
-        releaseConnectionToEndpoint(true, connectionToEndpoint.get());
         serveInternalErrorMessage(true);
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/ConnectionPoolTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/ConnectionPoolTest.java
@@ -183,7 +183,7 @@ public class ConnectionPoolTest {
 
             // tewaking configuration
             server.getCurrentConfiguration().setMaxConnectionsPerEndpoint(1);
-            server.getCurrentConfiguration().setBorrowTimeout(1000);
+            server.getCurrentConfiguration().setBorrowTimeout(30_000);
             server.getConnectionsManager().applyNewConfiguration(server.getCurrentConfiguration());
             server.start();
             stats = server.getConnectionsManager().getStats();
@@ -194,16 +194,13 @@ public class ConnectionPoolTest {
             try {
                 List<Future<?>> all = new ArrayList<>();
                 for (int i = 0; i < 5; i++) {
-                    all.add(
-                            threadPool.submit(() -> {
-                                try {
-                                    assertEquals("ok", IOUtils.
-                                            toString(new URL("http://localhost:" + port + "/index.html").toURI(),
-                                                    "utf-8"));
-                                } catch (Exception err) {
-                                    throw new RuntimeException(err);
-                                }
-                            }));
+                    all.add(threadPool.submit(() -> {
+                        try {
+                            assertEquals("ok", IOUtils.toString(new URL("http://localhost:" + port + "/index.html").toURI(), "utf-8"));
+                        } catch (Exception err) {
+                            throw new RuntimeException(err);
+                        }
+                    }));
 
                 }
                 for (Future<?> handle : all) {

--- a/carapace-server/src/test/java/org/carapaceproxy/ConnectionPoolTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/ConnectionPoolTest.java
@@ -102,9 +102,9 @@ public class ConnectionPoolTest {
                 assertEquals("ok", IOUtils.toString(new URL("http://localhost:" + port + "/index.html").toURI(), "utf-8"));
                 TestUtils.waitForCondition(TestUtils.NO_ACTIVE_CONNECTION(stats), 100);
                 System.out.println("STATS: " + epstats);
-                assertTrue(epstats.getTotalConnections().intValue() <= 2);
+                assertEquals(epstats.getTotalConnections().intValue(), 1);
                 assertEquals(0, epstats.getActiveConnections().intValue());
-                assertTrue(epstats.getOpenConnections().intValue() <= 2);
+                assertEquals(epstats.getOpenConnections().intValue(), 1);
                 assertEquals(i + 3, epstats.getTotalRequests().intValue());
             }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/RawClientTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/RawClientTest.java
@@ -801,7 +801,7 @@ public class RawClientTest {
 
             ConnectionsManagerStats stats;
             try (HttpProxyServer proxy = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder())) {
-                proxy.getCurrentConfiguration().setMaxConnectionsPerEndpoint(1);
+                proxy.getCurrentConfiguration().setMaxConnectionsPerEndpoint(2);
                 proxy.getCurrentConfiguration().setRequestsHeaderDebugEnabled(true);
                 proxy.getConnectionsManager().applyNewConfiguration(proxy.getCurrentConfiguration());
                 proxy.start();

--- a/carapace-server/src/test/java/org/carapaceproxy/RawClientTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/RawClientTest.java
@@ -990,4 +990,108 @@ public class RawClientTest {
         }
     }
 
+    @Test
+    public void testMultiClientTimeout() throws Exception {
+        stubFor(post(urlEqualTo("/index.html"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/html")
+                        .withHeader("Content-Length", "it <b>works</b> !!".length() + "")
+                        .withBody("it <b>works</b> !!")));
+
+        stubFor(get(urlEqualTo("/index.html"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/html")
+                        .withHeader("Content-Length", "it <b>works</b> !!".length() + "")
+                        .withBody("it <b>works</b> !!")));
+
+        TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.port());
+        EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
+
+        ExecutorService ex = Executors.newFixedThreadPool(2);
+        List<Future> futures = new ArrayList<>();
+
+        CarapaceLogger.setLoggingDebugEnabled(true);
+
+        ConnectionsManagerStats stats;
+        try (HttpProxyServer proxy = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder())) {
+            proxy.getCurrentConfiguration().setMaxConnectionsPerEndpoint(1);
+            proxy.getCurrentConfiguration().setRequestsHeaderDebugEnabled(true);
+            proxy.getCurrentConfiguration().setClientsIdleTimeoutSeconds(10);
+            proxy.getConnectionsManager().applyNewConfiguration(proxy.getCurrentConfiguration());
+            proxy.start();
+            stats = proxy.getConnectionsManager().getStats();
+            int port = proxy.getLocalPort();
+            assertTrue(port > 0);
+
+            RuntimeServerConfiguration currentConfiguration = proxy.getCurrentConfiguration();
+            proxy.getConnectionsManager().applyNewConfiguration(currentConfiguration);
+
+            AtomicBoolean failed = new AtomicBoolean();
+            AtomicBoolean c2go = new AtomicBoolean();
+            try {
+                futures.add(ex.submit(() -> {
+                    try (RawHttpClient client1 = new RawHttpClient("localhost", port)) {
+                        String body = "filler-content";
+                        String request = "POST /index.html HTTP/1.1"
+                                + "\r\nHost: localhost"
+                                + "\r\nConnection: keep-alive"
+                                + "\r\nContent-Type: text/plain"
+                                + "\r\n" + HttpHeaderNames.EXPECT + ": " + HttpHeaderValues.CONTINUE
+                                + "\r\nContent-Length: " + body.length()
+                                + "\r\n\r\n";
+
+                        Socket socket = client1.getSocket();
+                        OutputStream oo = socket.getOutputStream();
+
+                        oo.write(request.getBytes(StandardCharsets.UTF_8));
+                        oo.flush();
+                        Thread.sleep(5_000);
+                        c2go.set(true);
+                        Thread.sleep(10_000); // should trigger timeout
+
+                        String resp = consumeHttpResponseInput(socket.getInputStream()).getBodyString();
+                        System.out.println("### RESP client1: " + resp);
+                        if (!resp.isEmpty()) {
+                            failed.set(true);
+                        }
+                    } catch (Throwable e) {
+                        System.out.println("EXCEPTION: " + e);
+                    }
+                }));
+                futures.add(ex.submit(() -> {
+                    try {
+                        while (!c2go.get()) {
+                            Thread.sleep(1_000);
+                        }
+                        try (RawHttpClient client2 = new RawHttpClient("localhost", port)) {
+                            RawHttpClient.HttpResponse res = client2.get("/index.html");
+                            String resp = res.getBodyString();
+                            System.out.println("### RESP client2: " + resp);
+                            if (!resp.contains("it <b>works</b> !!")) {
+                                failed.set(true);
+                            }
+                        }
+                    } catch (Exception e) {
+                        System.out.println("EXCEPTION: " + e);
+                        failed.set(true);
+                    }
+                }));
+            } finally {
+                for (Future future : futures) {
+                    try {
+                        future.get();
+                    } catch (InterruptedException | ExecutionException e) {
+                        System.out.println("ERR" + e);
+                    }
+                }
+                ex.shutdown();
+                ex.awaitTermination(1, TimeUnit.MINUTES);
+            }
+            assertThat(failed.get(), is(false));
+        }
+        TestUtils.waitForCondition(TestUtils.ALL_CONNECTIONS_CLOSED(stats), 100);
+    }
+
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/ChunkedEncodingResponseTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/ChunkedEncodingResponseTest.java
@@ -33,6 +33,7 @@ import org.carapaceproxy.utils.RawHttpClient;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import org.carapaceproxy.utils.CarapaceLogger;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -52,58 +53,61 @@ public class ChunkedEncodingResponseTest {
     @Test
     public void testSimpleChunckedResponseNoCache() throws Exception {
         wireMockRule.stubFor(
-            get(urlEqualTo("/index.html")).
-                willReturn(aResponse()
-                    .withStatus(200)
-                    .withHeader("Content-Type", "text/html")
-                    .withBody("it <b>works</b> !!"))
+                get(urlEqualTo("/index.html")).
+                        willReturn(aResponse()
+                                .withStatus(200)
+                                .withHeader("Content-Type", "text/html")
+                                .withBody("it <b>works</b> !!"))
         );
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.port());
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         ConnectionsManagerStats stats;
+        CarapaceLogger.setLoggingDebugEnabled(true);
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
             int port = server.getLocalPort();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
-                RawHttpClient.HttpResponse resp = client
-                    .executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
+                RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
                 assertTrue(s.endsWith("12\r\n"
-                    + "it <b>works</b> !!\r\n"
-                    + "0\r\n\r\n"));
+                        + "it <b>works</b> !!\r\n"
+                        + "0\r\n\r\n"));
                 assertTrue(resp.getBodyString().equals("it <b>works</b> !!"));
 
-                resp = client
-                    .executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
+                resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 System.out.println("s:" + resp);
                 assertTrue(resp.toString().endsWith("12\r\n"
-                    + "it <b>works</b> !!\r\n"
-                    + "0\r\n\r\n"));
+                        + "it <b>works</b> !!\r\n"
+                        + "0\r\n\r\n"));
                 assertTrue(resp.getBodyString().equals("it <b>works</b> !!"));
             }
+            stats = server.getConnectionsManager().getStats();
+            TestUtils.waitForCondition(() -> {
+                EndpointStats epstats = stats.getEndpointStats(key);
+                return epstats.getTotalConnections().intValue() == 1
+                        && epstats.getActiveConnections().intValue() == 0
+                        && epstats.getOpenConnections().intValue() == 0;
+            }, 100);
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
-                String s = client
-                    .executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").toString();
+                String s = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").toString();
                 System.out.println("s:" + s);
                 assertTrue(s.endsWith("12\r\n"
-                    + "it <b>works</b> !!\r\n"
-                    + "0\r\n\r\n"));
+                        + "it <b>works</b> !!\r\n"
+                        + "0\r\n\r\n"));
             }
-            stats = server.getConnectionsManager().getStats();
             assertNotNull(stats.getEndpoints().get(key));
             assertEquals(0, server.getCache().getCacheSize());
+            TestUtils.waitForCondition(() -> {
+                EndpointStats epstats = stats.getEndpointStats(key);
+                return epstats.getTotalConnections().intValue() == 2
+                        && epstats.getActiveConnections().intValue() == 0
+                        && epstats.getOpenConnections().intValue() == 0;
+            }, 100);
         }
-
-        TestUtils.waitForCondition(() -> {
-            EndpointStats epstats = stats.getEndpointStats(key);
-            return epstats.getTotalConnections().intValue() == 1
-                && epstats.getActiveConnections().intValue() == 0
-                && epstats.getOpenConnections().intValue() == 0;
-        }, 100);
 
         TestUtils.waitForCondition(TestUtils.ALL_CONNECTIONS_CLOSED(stats), 100);
 
@@ -112,11 +116,11 @@ public class ChunkedEncodingResponseTest {
     @Test
     public void testSimpleChunckedResponseWithCache() throws Exception {
         wireMockRule.stubFor(
-            get(urlEqualTo("/index.html")).
-                willReturn(aResponse()
-                    .withStatus(200)
-                    .withHeader("Content-Type", "text/html")
-                    .withBody("it <b>works</b> !!"))
+                get(urlEqualTo("/index.html")).
+                        willReturn(aResponse()
+                                .withStatus(200)
+                                .withHeader("Content-Type", "text/html")
+                                .withBody("it <b>works</b> !!"))
         );
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.port(), true);
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
@@ -128,30 +132,30 @@ public class ChunkedEncodingResponseTest {
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client
-                    .executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
+                        .executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
                 assertTrue(s.endsWith("12\r\n"
-                    + "it <b>works</b> !!\r\n"
-                    + "0\r\n\r\n"));
+                        + "it <b>works</b> !!\r\n"
+                        + "0\r\n\r\n"));
                 assertTrue(resp.getBodyString().equals("it <b>works</b> !!"));
 
                 resp = client
-                    .executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
+                        .executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 System.out.println("s:" + resp);
                 assertTrue(resp.toString().endsWith("12\r\n"
-                    + "it <b>works</b> !!\r\n"
-                    + "0\r\n\r\n"));
+                        + "it <b>works</b> !!\r\n"
+                        + "0\r\n\r\n"));
                 assertTrue(resp.getBodyString().equals("it <b>works</b> !!"));
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client
-                    .executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").toString();
+                        .executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").toString();
                 System.out.println("s:" + s);
                 assertTrue(s.endsWith("12\r\n"
-                    + "it <b>works</b> !!\r\n"
-                    + "0\r\n\r\n"));
+                        + "it <b>works</b> !!\r\n"
+                        + "0\r\n\r\n"));
             }
             stats = server.getConnectionsManager().getStats();
             assertNotNull(stats.getEndpoints().get(key));
@@ -163,8 +167,8 @@ public class ChunkedEncodingResponseTest {
         TestUtils.waitForCondition(() -> {
             EndpointStats epstats = stats.getEndpointStats(key);
             return epstats.getTotalConnections().intValue() == 1
-                && epstats.getActiveConnections().intValue() == 0
-                && epstats.getOpenConnections().intValue() == 0;
+                    && epstats.getActiveConnections().intValue() == 0
+                    && epstats.getOpenConnections().intValue() == 0;
         }, 100);
 
         TestUtils.waitForCondition(TestUtils.ALL_CONNECTIONS_CLOSED(stats), 100);

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/RestartEndpointTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/RestartEndpointTest.java
@@ -24,8 +24,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -40,6 +38,7 @@ import org.carapaceproxy.utils.RawHttpClient;
 import org.carapaceproxy.utils.TestEndpointMapper;
 import org.carapaceproxy.utils.TestUtils;
 import static org.junit.Assert.assertEquals;
+import org.carapaceproxy.utils.CarapaceLogger;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -168,6 +167,8 @@ public class RestartEndpointTest {
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.port());
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
+        CarapaceLogger.setLoggingDebugEnabled(true);
+
         ConnectionsManagerStats stats;
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.start();
@@ -182,7 +183,7 @@ public class RestartEndpointTest {
                 System.out.println("*********************************************************");
                 // ensure that wiremock started again
                 IOUtils.toByteArray(new URL("http://localhost:" + wireMockRule.port() + "/index.html"));
-                assertThat(client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString(), containsString("An internal error occurred"));
+                assertEquals("it <b>works</b> !!", client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString());
             }
 
             stats = server.getConnectionsManager().getStats();

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/RestartEndpointTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/RestartEndpointTest.java
@@ -24,6 +24,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -180,7 +182,7 @@ public class RestartEndpointTest {
                 System.out.println("*********************************************************");
                 // ensure that wiremock started again
                 IOUtils.toByteArray(new URL("http://localhost:" + wireMockRule.port() + "/index.html"));
-                assertEquals("it <b>works</b> !!", client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString());
+                assertThat(client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString(), containsString("An internal error occurred"));
             }
 
             stats = server.getConnectionsManager().getStats();

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/requestmatcher/RequestMatcherTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/requestmatcher/RequestMatcherTest.java
@@ -38,6 +38,9 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
 
 /**
  *
@@ -48,12 +51,17 @@ public class RequestMatcherTest {
     @Test
     public void test() throws Exception {
 
+        Channel ch = mock(Channel.class);
+        when(ch.closeFuture()).thenReturn(mock(ChannelFuture.class));
+        ChannelHandlerContext chc = mock(ChannelHandlerContext.class);
+        when(chc.channel()).thenReturn(ch);
+
         ClientConnectionHandler cch = mock(ClientConnectionHandler.class);
         when(cch.isSecure()).thenReturn(true);
 
         DefaultHttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_0, HttpMethod.GET, "/test.html");
 
-        RequestHandler handler = new RequestHandler(0, request, null, cch, null, null, null, null);
+        RequestHandler handler = new RequestHandler(0, request, null, cch, chc, null, null, null);
 
         {
             RequestMatcher matcher = new RequestMatchParser("all").parse();
@@ -208,16 +216,16 @@ public class RequestMatcherTest {
             assertFalse(matcher.matches(handler));
             assertEquals("not secure request", matcher.getDescription());
         }
-        {            
+        {
             RequestMatcher matcher = new RequestMatchParser("not secure request.uri ~\".*test.*\"").parse();
             assertFalse(matcher.matches(handler));
             assertEquals("not secure request", matcher.getDescription());
         }
-        {            
+        {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" all").parse();
             assertTrue(matcher.matches(handler));
             assertEquals("request.uri ~ \".*test.*\"", matcher.getDescription());
-        }        
+        }
     }
 
     @Test
@@ -227,14 +235,19 @@ public class RequestMatcherTest {
         request.headers().add(HttpHeaders.CONTENT_DISPOSITION, "inline");
         request.headers().add(HttpHeaders.CONTENT_TYPE, "text/html");
         SocketAddress socketAddress = new InetSocketAddress("127.0.0.1", 0);
-        
+
+        Channel ch = mock(Channel.class);
+        when(ch.closeFuture()).thenReturn(mock(ChannelFuture.class));
+        ChannelHandlerContext chc = mock(ChannelHandlerContext.class);
+        when(chc.channel()).thenReturn(ch);
+
         ClientConnectionHandler cch = mock(ClientConnectionHandler.class);
         when(cch.isSecure()).thenReturn(false);
         when(cch.getListenerHost()).thenReturn("localhost");
         when(cch.getListenerPort()).thenReturn(8080);
         when(cch.getServerAddress()).thenReturn(socketAddress);
 
-        RequestHandler handler = new RequestHandler(0, request, null, cch, null, null, null, null);
+        RequestHandler handler = new RequestHandler(0, request, null, cch, chc, null, null, null);
 
         // Test headers
         {


### PR DESCRIPTION
- Improved connections exclusively reuse
- Endpoints connections released right after clients one is closed (client-endpoint release handshake dropped)
- Requests form same client (re)uses same endpoint connection
- Clients endpoint-connection reuse reset on config reload and endpoint down