### PR TITLE
Fix direct memory leaks

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/server/cache/ContentsCache.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/cache/ContentsCache.java
@@ -300,7 +300,7 @@ public class ContentsCache {
         int hits;
 
         private void addChunk(ByteBuf chunk) {
-            chunks.add(chunk.copy().retain());
+            chunks.add(chunk.retainedDuplicate());
             if (chunk.isDirect()) {
                 directSize += chunk.capacity();
             } else {


### PR DESCRIPTION
Changelod:

- fix to direct memory leak in cache actions

Problem:
Calling copy.retain() increases the object's refCnt to 2. This disables the cleaner.
Calling release() only decrements the refCnt to 1. But the object is deallocated only if the refCnt is at 0.

With retainedDuplicated() the refCnt at the release point is at 1, so calling release() the object is deallocated.