### PR TITLE
Fix connection pool reload and metrics

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
@@ -631,6 +631,7 @@ public class HttpProxyServer implements AutoCloseable {
      *
      * @param newConfigurationStore
      * @throws InterruptedException
+     * @throws org.carapaceproxy.server.config.ConfigurationChangeInProgressException
      * @see #buildValidConfiguration(org.carapaceproxy.configstore.ConfigurationStore)
      */
     public void applyDynamicConfigurationFromAPI(ConfigurationStore newConfigurationStore) throws InterruptedException, ConfigurationChangeInProgressException {
@@ -671,7 +672,7 @@ public class HttpProxyServer implements AutoCloseable {
             Map<String, BackendConfiguration> newBackends = newMapper.getBackends();
             this.mapper = newMapper;
 
-            if (atBoot || !newBackends.equals(currentBackends) || isConnectionsConfigurationChanged(newConfiguration)) {
+            if (!newBackends.equals(currentBackends) || isConnectionsConfigurationChanged(newConfiguration)) {
                 proxyRequestsManager.reloadConfiguration(newConfiguration, newBackends.values());
             }
 
@@ -750,7 +751,7 @@ public class HttpProxyServer implements AutoCloseable {
             try {
                 dynamicConfigurationStore.reload();
                 applyDynamicConfiguration(null, true);
-            } catch (Throwable err) {
+            } catch (InterruptedException | ConfigurationChangeInProgressException err) {
                 LOG.log(Level.SEVERE, "Cannot apply new configuration", err);
             }
         }
@@ -760,7 +761,7 @@ public class HttpProxyServer implements AutoCloseable {
             LOG.log(Level.INFO, "Configuration listener - reloading configuration after ZK reconnection");
             try {
                 applyDynamicConfiguration(null, true);
-            } catch (Throwable err) {
+            } catch (InterruptedException | ConfigurationChangeInProgressException err) {
                 LOG.log(Level.SEVERE, "Cannot apply new configuration", err);
             }
         }

--- a/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
@@ -751,7 +751,7 @@ public class HttpProxyServer implements AutoCloseable {
             try {
                 dynamicConfigurationStore.reload();
                 applyDynamicConfiguration(null, true);
-            } catch (InterruptedException | ConfigurationChangeInProgressException err) {
+            } catch (Throwable err) {
                 LOG.log(Level.SEVERE, "Cannot apply new configuration", err);
             }
         }
@@ -761,7 +761,7 @@ public class HttpProxyServer implements AutoCloseable {
             LOG.log(Level.INFO, "Configuration listener - reloading configuration after ZK reconnection");
             try {
                 applyDynamicConfiguration(null, true);
-            } catch (InterruptedException | ConfigurationChangeInProgressException err) {
+            } catch (Throwable err) {
                 LOG.log(Level.SEVERE, "Cannot apply new configuration", err);
             }
         }

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -21,7 +21,9 @@ package org.carapaceproxy.core;
 
 import static org.carapaceproxy.server.mapper.MapResult.REDIRECT_PROTO_HTTP;
 import static org.carapaceproxy.server.mapper.MapResult.REDIRECT_PROTO_HTTPS;
+import static reactor.netty.Metrics.CONNECTION_PROVIDER_PREFIX;
 import com.google.common.annotations.VisibleForTesting;
+import io.micrometer.core.instrument.Metrics;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
@@ -316,7 +318,7 @@ public class ProxyRequestsManager {
         private final ProxyRequest request;
         private ContentsCache.ContentReceiver cacheReceiver;
         private final EndpointStats endpointStats;
-        private HttpClient client;
+        private final HttpClient client;
         private volatile boolean requestRunning;
 
         private RequestForwarder(ProxyRequest request, ContentsCache.ContentReceiver cacheReceiver) {
@@ -351,13 +353,12 @@ public class ProxyRequestsManager {
                     .responseTimeout(Duration.ofMillis(connectionConfig.getStuckRequestTimeout()))
                     .option(ChannelOption.SO_KEEPALIVE, true) // Enables TCP keepalive: TCP starts sending keepalive probes when a connection is idle for some time.
                     .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectionConfig.getConnectTimeout())
-                    .headers(h -> h.add(request.getRequestHeaders().copy()))
                     .doOnRequest((req, conn) -> {
-                        if(CarapaceLogger.isLoggingDebugEnabled()) {
+                        if (CarapaceLogger.isLoggingDebugEnabled()) {
                             CarapaceLogger.debug("Start sending request for " + request.getRemoteAddress()
-                            + " Uri " +  request.getUri()
-                            + " Timestamp " + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss.SSS"))
-                            + " Backend " + endpointHost + ":" + endpointPort);
+                                    + " Uri " + request.getUri()
+                                    + " Timestamp " + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss.SSS"))
+                                    + " Backend " + endpointHost + ":" + endpointPort);
                         }
 
                         PENDING_REQUESTS_GAUGE.inc();
@@ -367,14 +368,13 @@ public class ProxyRequestsManager {
                         endpointStats.getTotalRequests().incrementAndGet();
                         endpointStats.getLastActivity().set(System.currentTimeMillis());
                     }).doAfterRequest((req, conn) -> {
-                        if(CarapaceLogger.isLoggingDebugEnabled()) {
+                        if (CarapaceLogger.isLoggingDebugEnabled()) {
                             CarapaceLogger.debug("Finished sending request for " + request.getRemoteAddress()
-                                    + " Uri " +  request.getUri()
+                                    + " Uri " + request.getUri()
                                     + " Timestamp " + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss.SSS"))
                                     + " Backend " + endpointHost + ":" + endpointPort);
                         }
-                    })
-                    .doAfterResponseSuccess((resp, conn) -> {
+                    }).doAfterResponseSuccess((resp, conn) -> {
                         if (requestRunning) {
                             requestRunning = false;
                             PENDING_REQUESTS_GAUGE.dec();
@@ -386,11 +386,14 @@ public class ProxyRequestsManager {
         public Publisher<Void> forward() {
             return client.request(request.getMethod())
                     .uri(request.getUri())
-                    .send(request.getRequestData()) // client request body
+                    .send((req, out) -> {
+                        req.headers(request.getRequestHeaders().copy()); // client request headers
+                        return out.send(request.getRequestData()); // client request body
+                    })
                     .response((resp, flux) -> { // endpoint response
                         request.setResponseStatus(resp.status());
                         request.setResponseHeaders(resp.responseHeaders().copy()); // headers from endpoint to client
-                        if(CarapaceLogger.isLoggingDebugEnabled()) {
+                        if (CarapaceLogger.isLoggingDebugEnabled()) {
                             CarapaceLogger.debug("Receive response from backend for "
                                     + request.getRemoteAddress()
                                     + " uri" + request.getUri()
@@ -411,7 +414,7 @@ public class ProxyRequestsManager {
                             }
                         }).doOnComplete(() -> {
                             parent.getCache().cacheContent(cacheReceiver);
-                            if(CarapaceLogger.isLoggingDebugEnabled()) {
+                            if (CarapaceLogger.isLoggingDebugEnabled()) {
                                 CarapaceLogger.debug("Send all response to client "
                                         + request.getRemoteAddress()
                                         + " for uri " + request.getUri()
@@ -539,9 +542,9 @@ public class ProxyRequestsManager {
                         spec.pendingAcquireTimeout(Duration.ofMillis(connectionPool.getBorrowTimeout()));
                         spec.maxIdleTime(Duration.ofMillis(connectionPool.getIdleTimeout()));
                         spec.evictInBackground(Duration.ofMillis(connectionPool.getIdleTimeout() * 2));
-                        spec.lifo();
                         spec.metrics(true);
-                    }).metrics(true);
+                        spec.lifo();
+                    });
                 });
 
                 if (connectionPool.getId().equals("*")) {
@@ -554,14 +557,19 @@ public class ProxyRequestsManager {
 
         @Override
         public void close() {
-            connectionPools.values().forEach(connectionProvider -> {
-                connectionProvider.dispose(); // graceful shutdown according to disposeTimeout
-            });
+            connectionPools.values().forEach(ConnectionProvider::dispose); // graceful shutdown according to disposeTimeout
             connectionPools.clear();
 
             if (defaultConnectionPool != null) {
                 defaultConnectionPool.getValue().dispose(); // graceful shutdown according to disposeTimeout
             }
+
+            // reset connections provider metrics
+            Metrics.globalRegistry.forEachMeter(m -> {
+                if (m.getId().getName().startsWith(CONNECTION_PROVIDER_PREFIX)) {
+                    Metrics.globalRegistry.remove(m);
+                }
+            });
         }
 
         @Override


### PR DESCRIPTION
Fix to connections pool reload even without connection/backends configuration changes
Fix connections pools metrics not updated after configuration reload