### PR TITLE
Move pr validation to java17

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - name: 'Set up JDK 15'
+      - name: 'Set up JDK 17'
         uses: actions/setup-java@v1
         with:
-          java-version: '15'
+          java-version: '17'
       - name: 'Cache Maven packages'
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
There is a bug impacting from java15 to java18 (More detail here https://nakedsecurity.sophos.com/2022/04/20/critical-cryptographic-java-security-blunder-patched-update-now/ ).
We can move pr test to java17. The patch java 17.0.3 fix this bug.
