### PR TITLE
Carapace > Provide maintenance mode

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/SimpleHTTPResponse.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/SimpleHTTPResponse.java
@@ -60,6 +60,10 @@ public class SimpleHTTPResponse {
         return new SimpleHTTPResponse(500, res, null);
     }
 
+    public static final SimpleHTTPResponse MAINTENANCE_MODE(String res) {
+        return new SimpleHTTPResponse(500, res, null);
+    }
+
     @Override
     public String toString() {
         return "SimpleHTTPResponse{" + "errorcode=" + errorcode + ", resource=" + resource + ", customHeaders=" + customHeaders + '}';

--- a/carapace-server/src/main/java/org/carapaceproxy/api/ConfigResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/ConfigResource.java
@@ -23,20 +23,16 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.util.Properties;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.ServletContext;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
+
 import org.carapaceproxy.configstore.ConfigurationStore;
 import org.carapaceproxy.configstore.PropertiesConfigurationStore;
 import org.carapaceproxy.core.HttpProxyServer;
+import org.carapaceproxy.core.RuntimeServerConfiguration;
 import org.carapaceproxy.server.config.ConfigurationChangeInProgressException;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 
@@ -127,6 +123,24 @@ public class ConfigResource {
         }
     }
 
+    @Path("/maintenance")
+    @Consumes(value = "text/plain")
+    @POST
+    public ConfigurationChangeResult setupMaintenanceMode(@QueryParam("enable") boolean value) {
+        HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
+        RuntimeServerConfiguration newCurrentConfiguration = server.getCurrentConfiguration();
+        newCurrentConfiguration.setMaintenanceModeEnabled(value);
+        server.getProxyRequestsManager().reloadConfiguration(newCurrentConfiguration);
+        return ConfigurationChangeResult.response(newCurrentConfiguration.isMaintenanceModeEnabled(), "");
+    }
+
+    @Path("/maintenance")
+    @GET
+    public ConfigurationChangeResult getMaintenanceStatus() {
+        HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
+        return ConfigurationChangeResult.response(server.getCurrentConfiguration().isMaintenanceModeEnabled(), "");
+    }
+
     private void dumpAndValidateInputConfiguration(PropertiesConfigurationStore simpleStore) throws ConfigurationNotValidException {
         int[] count = new int[]{0};
         simpleStore.forEach((k, v) -> {
@@ -178,6 +192,10 @@ public class ConfigResource {
             StringWriter w = new StringWriter();
             error.printStackTrace(new PrintWriter(w));
             return new ConfigurationChangeResult(false, w.toString());
+        }
+
+        public static ConfigurationChangeResult response(boolean status, String error) {
+            return new ConfigurationChangeResult(status, error);
         }
 
         private ConfigurationChangeResult(boolean ok, String error) {

--- a/carapace-server/src/main/java/org/carapaceproxy/api/ConfigResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/ConfigResource.java
@@ -126,10 +126,17 @@ public class ConfigResource {
     @Path("/maintenance")
     @Consumes(value = "text/plain")
     @POST
-    public ConfigurationChangeResult setupMaintenanceMode(@QueryParam("enable") boolean value) throws ConfigurationNotValidException, ConfigurationChangeInProgressException, InterruptedException {
+    public ConfigurationChangeResult setupMaintenanceMode(@QueryParam("enable") boolean value) {
         HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
-        server.UpdateMaintenanceMode(value);
-        return ConfigurationChangeResult.response(server.getCurrentConfiguration().isMaintenanceModeEnabled(), "");
+        try {
+            server.UpdateMaintenanceMode(value);
+            return ConfigurationChangeResult.response(server.getCurrentConfiguration().isMaintenanceModeEnabled(), "");
+        } catch (ConfigurationChangeInProgressException err) {
+            return ConfigurationChangeResult.error(err);
+        } catch (InterruptedException err) {
+            Thread.currentThread().interrupt();
+            return ConfigurationChangeResult.error(err);
+        }
     }
 
     @Path("/maintenance")

--- a/carapace-server/src/main/java/org/carapaceproxy/api/ConfigResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/ConfigResource.java
@@ -126,12 +126,10 @@ public class ConfigResource {
     @Path("/maintenance")
     @Consumes(value = "text/plain")
     @POST
-    public ConfigurationChangeResult setupMaintenanceMode(@QueryParam("enable") boolean value) {
+    public ConfigurationChangeResult setupMaintenanceMode(@QueryParam("enable") boolean value) throws ConfigurationNotValidException, ConfigurationChangeInProgressException, InterruptedException {
         HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
-        RuntimeServerConfiguration newCurrentConfiguration = server.getCurrentConfiguration();
-        newCurrentConfiguration.setMaintenanceModeEnabled(value);
-        server.getProxyRequestsManager().reloadConfiguration(newCurrentConfiguration);
-        return ConfigurationChangeResult.response(newCurrentConfiguration.isMaintenanceModeEnabled(), "");
+        server.UpdateMaintenanceMode(value);
+        return ConfigurationChangeResult.response(server.getCurrentConfiguration().isMaintenanceModeEnabled(), "");
     }
 
     @Path("/maintenance")

--- a/carapace-server/src/main/java/org/carapaceproxy/api/RoutesResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/RoutesResource.java
@@ -46,13 +46,15 @@ public class RoutesResource {
         private final String errorAction;
         private final boolean enabled;
         private final String matcher;
+        private final String maintenanceAction;
 
-        public RouteBean(String id, String action, String errorAction, boolean enabled, String matcher) {
+        public RouteBean(String id, String action, String errorAction, boolean enabled, String matcher, String maintenanceAction) {
             this.id = id;
             this.action = action;
             this.errorAction = errorAction;
             this.enabled = enabled;
             this.matcher = matcher;
+            this.maintenanceAction = maintenanceAction;
         }
 
         public String getId() {
@@ -74,6 +76,8 @@ public class RoutesResource {
         public String getMatcher() {
             return matcher;
         }
+
+        public String getMaintenanceAction() { return maintenanceAction; }
     }
 
     @GET
@@ -88,7 +92,8 @@ public class RoutesResource {
                             route.getAction(),
                             route.getErrorAction(),
                             route.isEnabled(),
-                            route.getMatcher().getDescription()));
+                            route.getMatcher().getDescription(),
+                            route.getMaintenanceModeAction()));
                 });
 
         return routes;

--- a/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
@@ -634,13 +634,13 @@ public class HttpProxyServer implements AutoCloseable {
         Properties props = dynamicConfigurationStore.asProperties(null);
         boolean newCertificate = !dynamicConfigurationStore.anyPropertyMatches((k, v) -> {
             if (k.matches("certificate\\.[0-9]+\\.hostname") && v.equals(cert.getDomain())) {
-                performUpdate(props, k, cert); // updating existing certificate
+                performCertificateUpdate(props, k, cert); // updating existing certificate
                 return true;
             }
             return false;
         });
         if (newCertificate) {
-            performCreate(props, cert);
+            performCertificateCreate(props, cert);
         }
 
         // Configuration reloading
@@ -653,7 +653,7 @@ public class HttpProxyServer implements AutoCloseable {
         applyDynamicConfigurationFromAPI(new PropertiesConfigurationStore(props));
     }
 
-    private void performUpdate(Properties props, String key, CertificateData cert) {
+    private void performCertificateUpdate(Properties props, String key, CertificateData cert) {
         props.setProperty(key.replace("hostname", "mode"), cert.isManual() ? "manual" : "acme");
         if (cert.isManual()) {
             props.remove(key.replace("hostname", "daysbeforerenewal")); // type changed from acme to manual
@@ -662,7 +662,7 @@ public class HttpProxyServer implements AutoCloseable {
         }
     }
 
-    private void performCreate(Properties props, CertificateData cert) {
+    private void performCertificateCreate(Properties props, CertificateData cert) {
         int index = dynamicConfigurationStore.findMaxIndexForPrefix("certificate") + 1;
         String prefix = "certificate." + index + ".";
         props.setProperty(prefix + "hostname", cert.getDomain());
@@ -721,10 +721,6 @@ public class HttpProxyServer implements AutoCloseable {
 
             if (!newBackends.equals(currentBackends) || isConnectionsConfigurationChanged(newConfiguration)) {
                 proxyRequestsManager.reloadConfiguration(newConfiguration, newBackends.values());
-            }
-
-            if(currentConfiguration.isMaintenanceModeEnabled() != newConfiguration.isMaintenanceModeEnabled()) {
-                proxyRequestsManager.reloadConfiguration(newConfiguration);
             }
 
             if (!atBoot) {

--- a/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
@@ -713,7 +713,8 @@ public class HttpProxyServer implements AutoCloseable {
             Map<String, BackendConfiguration> newBackends = newMapper.getBackends();
             this.mapper = newMapper;
 
-            if (!newBackends.equals(currentBackends) || isConnectionsConfigurationChanged(newConfiguration)) {
+            if (!newBackends.equals(currentBackends) || isConnectionsConfigurationChanged(newConfiguration)
+                || currentConfiguration.isMaintenanceModeEnabled() != newConfiguration.isMaintenanceModeEnabled()) {
                 proxyRequestsManager.reloadConfiguration(newConfiguration, newBackends.values());
             }
 

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -109,10 +109,6 @@ public class ProxyRequestsManager {
         connectionsManager.reloadConfiguration(newConfiguration, newEndpoints);
     }
 
-    public void reloadConfiguration(RuntimeServerConfiguration newConfiguration) {
-        this.currentConfiguration = newConfiguration;
-    }
-
     public void close() {
         connectionsManager.close();
     }
@@ -238,7 +234,7 @@ public class ProxyRequestsManager {
             customHeaders = res.getCustomHeaders();
         }
         if (resource == null) {
-            resource = StaticContentsManager.DEFAULT_MAINTENANCE_MODE_PAGE;
+            resource = StaticContentsManager.DEFAULT_MAINTENANCE_MODE_ERROR;
         }
         if (code <= 0) {
             code = 500;

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -106,7 +106,6 @@ public class ProxyRequestsManager {
     }
 
     public void reloadConfiguration(RuntimeServerConfiguration newConfiguration, Collection<BackendConfiguration> newEndpoints) {
-        this.currentConfiguration = newConfiguration;
         connectionsManager.reloadConfiguration(newConfiguration, newEndpoints);
     }
 
@@ -128,11 +127,6 @@ public class ProxyRequestsManager {
         if (action == null) {
             LOGGER.log(Level.INFO, "Mapper returned NULL action for {0}", this);
             action = MapResult.internalError(MapResult.NO_ROUTE);
-        }
-
-        if(currentConfiguration.isMaintenanceModeEnabled()) {
-            String routeId = action.routeId;
-            action = MapResult.maintenanceMode(routeId);
         }
 
         request.setAction(action);

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -110,6 +110,10 @@ public class ProxyRequestsManager {
         connectionsManager.reloadConfiguration(newConfiguration, newEndpoints);
     }
 
+    public void reloadConfiguration(RuntimeServerConfiguration newConfiguration) {
+        this.currentConfiguration = newConfiguration;
+    }
+
     public void close() {
         connectionsManager.close();
     }

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -19,8 +19,7 @@
  */
 package org.carapaceproxy.core;
 
-import static org.carapaceproxy.server.mapper.MapResult.REDIRECT_PROTO_HTTP;
-import static org.carapaceproxy.server.mapper.MapResult.REDIRECT_PROTO_HTTPS;
+import static org.carapaceproxy.server.mapper.MapResult.*;
 import static reactor.netty.Metrics.CONNECTION_PROVIDER_PREFIX;
 import com.google.common.annotations.VisibleForTesting;
 import io.micrometer.core.instrument.Metrics;
@@ -107,6 +106,7 @@ public class ProxyRequestsManager {
     }
 
     public void reloadConfiguration(RuntimeServerConfiguration newConfiguration, Collection<BackendConfiguration> newEndpoints) {
+        this.currentConfiguration = newConfiguration;
         connectionsManager.reloadConfiguration(newConfiguration, newEndpoints);
     }
 
@@ -125,6 +125,12 @@ public class ProxyRequestsManager {
             LOGGER.log(Level.INFO, "Mapper returned NULL action for {0}", this);
             action = MapResult.internalError(MapResult.NO_ROUTE);
         }
+
+        if(currentConfiguration.isMaintenanceModeEnabled()) {
+            String routeId = action.routeId;
+            action = MapResult.maintenanceMode(routeId);
+        }
+
         request.setAction(action);
 
         if (LOGGER.isLoggable(Level.FINER)) {
@@ -138,6 +144,8 @@ public class ProxyRequestsManager {
 
                 case INTERNAL_ERROR:
                     return serveInternalErrorMessage(request);
+                case MAINTENANCE_MODE:
+                    return  serverMaintenanceMessage(request);
 
                 case STATIC:
                 case ACME_CHALLENGE:
@@ -208,6 +216,31 @@ public class ProxyRequestsManager {
         }
         if (resource == null) {
             resource = StaticContentsManager.DEFAULT_INTERNAL_SERVER_ERROR;
+        }
+        if (code <= 0) {
+            code = 500;
+        }
+        FullHttpResponse response = parent.getStaticContentsManager().buildResponse(code, resource);
+
+        return writeSimpleResponse(request, response, customHeaders);
+    }
+
+    private Publisher<Void> serverMaintenanceMessage(ProxyRequest request) {
+        if (request.getResponse().hasSentHeaders()) {
+            return Mono.empty();
+        }
+
+        SimpleHTTPResponse res = parent.getMapper().mapMaintenanceMode(request.getAction().routeId);
+        int code = 0;
+        String resource = null;
+        List<CustomHeader> customHeaders = null;
+        if (res != null) {
+            code = res.getErrorcode();
+            resource = res.getResource();
+            customHeaders = res.getCustomHeaders();
+        }
+        if (resource == null) {
+            resource = StaticContentsManager.DEFAULT_MAINTENANCE_MODE_PAGE;
         }
         if (code <= 0) {
             code = 500;

--- a/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
@@ -103,6 +103,7 @@ public class RuntimeServerConfiguration {
     private String sslTrustStorePassword;
     private boolean ocspEnabled = false;
     private int maxHeaderSize = 8_192; //bytes; default 8kb
+    private boolean maintenanceModeEnabled = false;
 
     public RuntimeServerConfiguration() {
         defaultConnectionPool = new ConnectionPoolConfiguration(
@@ -230,6 +231,9 @@ public class RuntimeServerConfiguration {
             throw new ConfigurationNotValidException("Invalid value '" + this.maxHeaderSize + "' for carapace.maxheadersize");
         }
         LOG.log(Level.INFO, "carapace.maxheadersize={0}", maxHeaderSize);
+
+        maintenanceModeEnabled = properties.getBoolean("carapace.maintenancemode.enabled", maintenanceModeEnabled);
+        LOG.log(Level.INFO, "carapace.maintenancemode.enabled={0}", maintenanceModeEnabled);
     }
 
     private void configureCertificates(ConfigurationStore properties) throws ConfigurationNotValidException {

--- a/carapace-server/src/main/java/org/carapaceproxy/core/StaticContentsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/StaticContentsManager.java
@@ -47,6 +47,7 @@ public class StaticContentsManager {
 
     public static final String DEFAULT_NOT_FOUND = CLASSPATH_RESOURCE + "/default-error-pages/404_notfound.html";
     public static final String DEFAULT_INTERNAL_SERVER_ERROR = CLASSPATH_RESOURCE + "/default-error-pages/500_internalservererror.html";
+    public static final String DEFAULT_MAINTENANCE_MODE_PAGE =  CLASSPATH_RESOURCE + "/default-error-pages/500_maintenance.html";
 
     private static final Logger LOG = Logger.getLogger(StaticContentsManager.class.getName());
 

--- a/carapace-server/src/main/java/org/carapaceproxy/core/StaticContentsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/StaticContentsManager.java
@@ -47,7 +47,7 @@ public class StaticContentsManager {
 
     public static final String DEFAULT_NOT_FOUND = CLASSPATH_RESOURCE + "/default-error-pages/404_notfound.html";
     public static final String DEFAULT_INTERNAL_SERVER_ERROR = CLASSPATH_RESOURCE + "/default-error-pages/500_internalservererror.html";
-    public static final String DEFAULT_MAINTENANCE_MODE_PAGE =  CLASSPATH_RESOURCE + "/default-error-pages/500_maintenance.html";
+    public static final String DEFAULT_MAINTENANCE_MODE_ERROR =  CLASSPATH_RESOURCE + "/default-error-pages/500_maintenance.html";
 
     private static final Logger LOG = Logger.getLogger(StaticContentsManager.class.getName());
 

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/RouteConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/RouteConfiguration.java
@@ -32,6 +32,7 @@ public class RouteConfiguration {
     private final RequestMatcher matcher;
     private final String action;
     private String errorAction;
+    private String maintenanceModeAction;
 
     public RouteConfiguration(String id, String action, boolean enabled, RequestMatcher matcher) {
         this.id = id;
@@ -52,8 +53,16 @@ public class RouteConfiguration {
         return errorAction;
     }
 
+    public String getMaintenanceModeAction() {
+        return maintenanceModeAction;
+    }
+
     public void setErrorAction(String errorAction) {
         this.errorAction = errorAction;
+    }
+
+    public void setMaintenanceModeAction(String maintenanceModeAction) {
+        this.maintenanceModeAction = maintenanceModeAction;
     }
 
     public boolean isEnabled() {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/EndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/EndpointMapper.java
@@ -66,7 +66,7 @@ public abstract class EndpointMapper {
     }
 
     public SimpleHTTPResponse mapMaintenanceMode(String routeId) {
-        return SimpleHTTPResponse.MAINTENANCE_MODE(StaticContentsManager.DEFAULT_MAINTENANCE_MODE_PAGE);
+        return SimpleHTTPResponse.MAINTENANCE_MODE(StaticContentsManager.DEFAULT_MAINTENANCE_MODE_ERROR);
     }
 
     public abstract void configure(ConfigurationStore properties) throws ConfigurationNotValidException;

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/EndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/EndpointMapper.java
@@ -57,12 +57,16 @@ public abstract class EndpointMapper {
 
     public abstract MapResult map(ProxyRequest request);
 
-    public SimpleHTTPResponse mapPageNotFound(String routeid) {
+    public SimpleHTTPResponse mapPageNotFound(String routeId) {
         return SimpleHTTPResponse.NOT_FOUND(StaticContentsManager.DEFAULT_NOT_FOUND);
     }
 
-    public SimpleHTTPResponse mapInternalError(String routeid) {
+    public SimpleHTTPResponse mapInternalError(String routeId) {
         return SimpleHTTPResponse.INTERNAL_ERROR(StaticContentsManager.DEFAULT_INTERNAL_SERVER_ERROR);
+    }
+
+    public SimpleHTTPResponse mapMaintenanceMode(String routeId) {
+        return SimpleHTTPResponse.MAINTENANCE_MODE(StaticContentsManager.DEFAULT_MAINTENANCE_MODE_PAGE);
     }
 
     public abstract void configure(ConfigurationStore properties) throws ConfigurationNotValidException;

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/MapResult.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/MapResult.java
@@ -45,6 +45,10 @@ public class MapResult {
          */
         INTERNAL_ERROR,
         /**
+         * Maintenance mode
+         */
+        MAINTENANCE_MODE,
+        /**
          * Custom static message
          */
         STATIC,
@@ -87,6 +91,13 @@ public class MapResult {
     public static MapResult internalError(String routeId) {
         return MapResult.builder()
                 .action(Action.INTERNAL_ERROR)
+                .routeId(routeId)
+                .build();
+    }
+
+    public static MapResult maintenanceMode(String routeId) {
+        return MapResult.builder()
+                .action(Action.MAINTENANCE_MODE)
                 .routeId(routeId)
                 .build();
     }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -116,6 +116,14 @@ public class StandardEndpointMapper extends EndpointMapper {
             if (!route.isEnabled()) {
                 continue;
             }
+
+            if(parent.getCurrentConfiguration().isMaintenanceModeEnabled()) {
+                if(LOG.isLoggable(Level.FINER)) {
+                    LOG.log(Level.FINER, "Maintenance mode is enable: request uri: {0}",request.getUri());
+                }
+                return MapResult.maintenanceMode(route.getId());
+            }
+
             boolean matchResult = route.matches(request);
             if (LOG.isLoggable(Level.FINER)) {
                 LOG.log(Level.FINER, "route {0}, map {1} -> {2}", new Object[]{route.getId(), request.getUri(), matchResult});

--- a/carapace-server/src/main/resources/default-error-pages/500_maintenance.html
+++ b/carapace-server/src/main/resources/default-error-pages/500_maintenance.html
@@ -1,0 +1,5 @@
+<html>
+    <body>
+        Maintenance in progress
+    </body>
+</html>

--- a/carapace-server/src/test/java/org/carapaceproxy/MaintenanceModeTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/MaintenanceModeTest.java
@@ -10,6 +10,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.Base64;
 import java.util.Properties;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -89,6 +90,105 @@ public class MaintenanceModeTest extends UseAdminServer {
         HttpResponse<String> response2 = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         assertEquals(500, response2.statusCode());
         assertTrue(response2.body().contains("Maintenance in progress"));
+
+        //disable maintenance mode
+        config.put("carapace.maintenancemode.enabled", "false");
+        changeDynamicConfiguration(config);
+        HttpResponse<String> response3 = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals("it <b>works</b> !!", response3.body());
+
+    }
+
+
+    @Test
+    public void maintenanceModeApiTest() throws Exception {
+
+        stubFor(get(urlEqualTo("/index.html"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/html")
+                        .withHeader("Content-Length", "it <b>works</b> !!".length() + "")
+                        .withBody("it <b>works</b> !!")));
+
+        config = new Properties(HTTP_ADMIN_SERVER_CONFIG);
+        startServer(config);
+
+        // Default certificate
+        String defaultCertificate = TestUtils.deployResource("ia.p12", tmpDir.getRoot());
+        config.put("certificate.1.hostname", "*");
+        config.put("certificate.1.file", defaultCertificate);
+        config.put("certificate.1.password", "changeit");
+
+        // Listeners
+        config.put("listener.1.host", "localhost");
+        config.put("listener.1.port", "8086");
+        config.put("listener.1.enabled", "true");
+        config.put("listener.1.defaultcertificate", "*");
+
+        // Backends
+        config.put("backend.1.id", "localhost");
+        config.put("backend.1.enabled", "true");
+        config.put("backend.1.host", "localhost");
+        config.put("backend.1.port", wireMockRule.port() + "");
+
+        config.put("backend.2.id", "localhost2");
+        config.put("backend.2.enabled", "true");
+        config.put("backend.2.host", "localhost2");
+        config.put("backend.2.port", wireMockRule.port() + "");
+
+        // Default director
+        config.put("director.1.id", "*");
+        config.put("director.1.backends", "localhost");
+        config.put("director.1.enabled", "true");
+
+        // Default route
+        config.put("route.100.id", "default");
+        config.put("route.100.enabled", "true");
+        config.put("route.100.match", "all");
+        config.put("route.100.action", "proxy-all");
+
+        changeDynamicConfiguration(config);
+        HttpClient httpClient = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .build();
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .GET()
+                .uri(URI.create("http://localhost:" + 8086 + "/index.html"))
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals("it <b>works</b> !!", response.body());
+
+        //ENABLE MAINTENANCE MODE VIA API
+        HttpRequest enableMaintenanceRequest = HttpRequest.newBuilder()
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .uri(URI.create("http://localhost:" + DEFAULT_ADMIN_PORT + "/api/config/maintenance?enable=true"))
+                .header("Authorization", "Basic " +
+                        Base64.getEncoder().encodeToString((DEFAULT_USERNAME + ":" + DEFAULT_PASSWORD).getBytes()))
+                .build();
+
+        HttpResponse<String> enableMaintenanceModeResponse = httpClient.send(enableMaintenanceRequest, HttpResponse.BodyHandlers.ofString());
+        assertEquals("{\"ok\":true,\"error\":\"\"}", enableMaintenanceModeResponse.body());
+
+        HttpResponse<String> response2 = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(500, response2.statusCode());
+        assertTrue(response2.body().contains("Maintenance in progress"));
+
+        //DISABLE MAINTENANCE MODE VIA API
+        HttpRequest disableMaintenanceModeRequest = HttpRequest.newBuilder()
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .uri(URI.create("http://localhost:" + DEFAULT_ADMIN_PORT + "/api/config/maintenance?enable=false"))
+                .header("Authorization", "Basic " +
+                        Base64.getEncoder().encodeToString((DEFAULT_USERNAME + ":" + DEFAULT_PASSWORD).getBytes()))
+                .build();
+
+        HttpResponse<String> disableMaintenanceModeResponse = httpClient.send(disableMaintenanceModeRequest, HttpResponse.BodyHandlers.ofString());
+        assertEquals("{\"ok\":false,\"error\":\"\"}", disableMaintenanceModeResponse.body());
+
+        HttpResponse<String> response3 = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals("it <b>works</b> !!", response3.body());
 
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/MaintenanceModeTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/MaintenanceModeTest.java
@@ -1,0 +1,95 @@
+package org.carapaceproxy;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.carapaceproxy.api.UseAdminServer;
+import org.carapaceproxy.utils.TestUtils;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Properties;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MaintenanceModeTest extends UseAdminServer {
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(0);
+
+    private Properties config;
+
+    @Test
+    public void test() throws Exception {
+
+        stubFor(get(urlEqualTo("/index.html"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/html")
+                        .withHeader("Content-Length", "it <b>works</b> !!".length() + "")
+                        .withBody("it <b>works</b> !!")));
+
+        config = new Properties(HTTP_ADMIN_SERVER_CONFIG);
+        startServer(config);
+
+        // Default certificate
+        String defaultCertificate = TestUtils.deployResource("ia.p12", tmpDir.getRoot());
+        config.put("certificate.1.hostname", "*");
+        config.put("certificate.1.file", defaultCertificate);
+        config.put("certificate.1.password", "changeit");
+
+        // Listeners
+        config.put("listener.1.host", "localhost");
+        config.put("listener.1.port", "8086");
+        config.put("listener.1.enabled", "true");
+        config.put("listener.1.defaultcertificate", "*");
+
+        // Backends
+        config.put("backend.1.id", "localhost");
+        config.put("backend.1.enabled", "true");
+        config.put("backend.1.host", "localhost");
+        config.put("backend.1.port", wireMockRule.port() + "");
+
+        config.put("backend.2.id", "localhost2");
+        config.put("backend.2.enabled", "true");
+        config.put("backend.2.host", "localhost2");
+        config.put("backend.2.port", wireMockRule.port() + "");
+
+        // Default director
+        config.put("director.1.id", "*");
+        config.put("director.1.backends", "localhost");
+        config.put("director.1.enabled", "true");
+
+        // Default route
+        config.put("route.100.id", "default");
+        config.put("route.100.enabled", "true");
+        config.put("route.100.match", "all");
+        config.put("route.100.action", "proxy-all");
+
+        changeDynamicConfiguration(config);
+        HttpClient httpClient = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .build();
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .GET()
+                .uri(URI.create("http://localhost:" + 8086 + "/index.html"))
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals("it <b>works</b> !!", response.body());
+
+        //enable maintenance mode
+        config.put("carapace.maintenancemode.enabled", "true");
+        changeDynamicConfiguration(config);
+        HttpResponse<String> response2 = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(500, response2.statusCode());
+        assertTrue(response2.body().contains("Maintenance in progress"));
+
+    }
+
+}

--- a/carapace-ui/src/main/webapp/src/components/Configuration.vue
+++ b/carapace-ui/src/main/webapp/src/components/Configuration.vue
@@ -38,6 +38,8 @@
             <b-modal 
             id="maintenance" 
             title="Maintenance"
+            cancel-title="Close"
+            no-close-on-backdrop
             @ok="setupMaintenanceMode"
             @hidden="reset"
             >
@@ -122,21 +124,25 @@ export default {
                 }
             );
         },
-       setupMaintenanceMode() {
+       setupMaintenanceMode(bvModalEvent) {
+           bvModalEvent.preventDefault()
            doPost("/api/config/maintenance?enable=" + this.checked,
                this.checked,
                data => {
                    this.checked = data.ok;
                    this.opSuccess = true;
                    this.opMessage = data.ok
-                        ? "Maintenance mode has been enabled."
-                        : "Maintenance mode has been disabled";
+                        ? "Maintenance mode has been enabled.\n Refresh page to see the change."
+                        : "Maintenance mode has been disabled.\n Refresh page to see the change.";
                },
                error => {
                    this.opSuccess = false;
                    this.opMessage = "Something went wrong (" + error + ")";
                }
            );
+           this.$nextTick(() => {
+             this.$bvModal.hide('maintenance')
+           })
        },
        getMaintenanceStatus() {
             doGet("/api/config/maintenance", data => {
@@ -145,7 +151,6 @@ export default {
        },
        reset() {
            this.getMaintenanceStatus();
-           this.fetch();
        },
     }
 };

--- a/carapace-ui/src/main/webapp/src/components/Configuration.vue
+++ b/carapace-ui/src/main/webapp/src/components/Configuration.vue
@@ -145,6 +145,7 @@ export default {
        },
        reset() {
            this.getMaintenanceStatus();
+           this.fetch();
        },
     }
 };

--- a/carapace-ui/src/main/webapp/src/components/Navbar.vue
+++ b/carapace-ui/src/main/webapp/src/components/Navbar.vue
@@ -1,9 +1,10 @@
 <template>
-    <nav class="navbar">
+    <nav :class="classes">
         <a class="navbar-brand" href="#">
             <img id="logo" :src="logo" height="45px" width="45px" />
             <span id="label">{{label}}</span>
         </a>
+        <b v-if="maintenanceStatus">MAINTENANCE MODE IS ENABLE</b>
         <router-link to="/peers">
             <b>Node:</b> {{nodeId}}
         </router-link>
@@ -11,6 +12,8 @@
 </template>
 
 <script>
+import { doGet } from "./../mockserver";
+
 export default {
     name: "Navbar",
     props: {
@@ -19,9 +22,24 @@ export default {
         nodeId: String
     },
     data() {
-        return {};
+        return {
+            maintenanceStatus: false
+        };
     },
-    methods: {}
+    created() {
+        doGet("/api/config/maintenance", data => {
+            this.maintenanceStatus = data.ok;
+        });
+    },
+    methods: {},
+    computed: {
+        classes () {
+            if (this.maintenanceStatus) {
+                return 'navbar maintenance';
+            }
+            return 'navbar';
+        }
+    }
 };
 </script>
 
@@ -38,6 +56,14 @@ export default {
 
     * {
         color: $navbar-elements;
+    }
+
+    &.maintenance {
+       background-color: $navbar-maintenance;
+
+           * {
+               color: $primary-dark;
+           }
     }
 
     a,

--- a/carapace-ui/src/main/webapp/src/components/Routes.vue
+++ b/carapace-ui/src/main/webapp/src/components/Routes.vue
@@ -37,6 +37,7 @@ export default {
                 { key: "matcher", label: "Request Matcher", sortable: true },
                 { key: "action", label: "Action", sortable: true },
                 { key: "errorAction", label: "Error Action", sortable: true },
+                { key: "maintenanceAction", label: "Maintenance Action", sortable: true },
                 {
                     key: "enabled",
                     label: "Enabled",

--- a/carapace-ui/src/main/webapp/src/variables.scss
+++ b/carapace-ui/src/main/webapp/src/variables.scss
@@ -16,6 +16,7 @@ $shadow: rgba(65, 91, 117, 0.6);
 
 // Components colors
 $navbar-background: $primary;
+$navbar-maintenance: $warning;
 $navbar-logo: $primary-dark;
 $navbar-elements: $primary-bright;
 $sidebar-background: $primary-dark;
@@ -25,3 +26,4 @@ $sidebar-elements: $primary-bright;
 $navbar-height: 65px;
 $sidebar-width: 240px;
 $sidebar-collapsed-width: 65px;
+


### PR DESCRIPTION
- provide dynamic config - **carapace.maintenancemode.enabled=true/false**
- added possibility of configuring a maintenance page per route (ex. **route.1.maintenanceaction=maintenance-static-action**)