### PR TITLE
Avoid using chunked transfer encoding while replying to HTTP/1.0 requests

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
@@ -104,6 +104,7 @@ public class RuntimeServerConfiguration {
     private boolean ocspEnabled = false;
     private int maxHeaderSize = 8_192; //bytes; default 8kb
     private boolean maintenanceModeEnabled = false;
+    private boolean http10BackwardCompatibilityEnabled = false;
 
     public RuntimeServerConfiguration() {
         defaultConnectionPool = new ConnectionPoolConfiguration(
@@ -234,6 +235,9 @@ public class RuntimeServerConfiguration {
 
         maintenanceModeEnabled = properties.getBoolean("carapace.maintenancemode.enabled", maintenanceModeEnabled);
         LOG.log(Level.INFO, "carapace.maintenancemode.enabled={0}", maintenanceModeEnabled);
+
+        http10BackwardCompatibilityEnabled = properties.getBoolean("carapace.http10backwardcompatibility.enabled", http10BackwardCompatibilityEnabled);
+        LOG.log(Level.INFO, "carapace.http10backwardcompatibility.enabled={0}", http10BackwardCompatibilityEnabled);
     }
 
     private void configureCertificates(ConfigurationStore properties) throws ConfigurationNotValidException {


### PR DESCRIPTION
Since HTTP 1.0 clients aren't required to support chunked transfer encoding, it shouldn't be used upon responding to HTTP/1.0 requests. Otherwise, a non-supporting client would just ignore the encoding and deliver a messed up response body to the application layer.

Implementation:
provide a dynamic configuration to enable or disabile this fix:

**carapace.http10backwardcompatibility.enabled=true/false** (default false)

More info:
[Writing data reactor netty](https://projectreactor.io/docs/netty/release/reference/index.html#_writing_data_4)
[Reactor netty set content lenght automatically](https://stackoverflow.com/questions/57802358/netty-set-content-length-automatically)