### PR TITLE
Certificate > sync certificates locally #324

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/api/SimpleResponse.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/SimpleResponse.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.carapaceproxy.api;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import lombok.Data;
+
+/**
+ * Simple REST response
+ *
+ * @author paolo.venturi
+ */
+@Data
+public class SimpleResponse {
+
+    private final boolean ok;
+    private final String error;
+
+    private SimpleResponse(boolean ok, String error) {
+        this.ok = ok;
+        this.error = error;
+    }
+
+    public static final SimpleResponse success() {
+        return new SimpleResponse(true, "");
+    }
+
+    public static final SimpleResponse error(Throwable error) {
+        StringWriter w = new StringWriter();
+        error.printStackTrace(new PrintWriter(w));
+        return new SimpleResponse(false, w.toString());
+    }
+
+}

--- a/carapace-server/src/main/java/org/carapaceproxy/cluster/GroupMembershipHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/cluster/GroupMembershipHandler.java
@@ -53,10 +53,11 @@ public interface GroupMembershipHandler {
      * Notify an event on the group.
      *
      * @param eventId
+     * @param data
      */
-    void fireEvent(String eventId);
+    void fireEvent(String eventId, Map<String, Object> data);
 
-     /**
+    /**
      * To execute code in mutual exclusion to other peers.
      *
      * Whether the peer fails to acquire/release the mutex code passed will be skipped and no exceptions will be thrown.
@@ -87,15 +88,16 @@ public interface GroupMembershipHandler {
      */
     String describePeer(String peerId);
 
-
     /**
-     * To store some key-value info for the local peer.     
+     * To store some key-value info for the local peer.
+     *
      * @param info properties of the peer.
      */
     void storeLocalPeerInfo(Map<String, String> info);
 
     /**
      * To load info associated to the peer.
+     *
      * @param id
      * @return properties of the peer
      */
@@ -104,12 +106,13 @@ public interface GroupMembershipHandler {
     interface EventCallback {
 
         /**
-         * Called whenever an event is fired. This method should not access external resources and it must not be
-         * expensive. Inside this method you cannot call other methods of the same {@link GroupMembershipHandler}.
+         * Called whenever an event is fired. This method should not access external resources and it must not be expensive. Inside this method you cannot call other methods of the same
+         * {@link GroupMembershipHandler}.
          *
          * @param eventId
+         * @param data
          */
-        void eventFired(String eventId);
+        void eventFired(String eventId, Map<String, Object> data);
 
         /**
          * Called whenever ZK connection has been re-established.

--- a/carapace-server/src/main/java/org/carapaceproxy/cluster/impl/NullGroupMembershipHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/cluster/impl/NullGroupMembershipHandler.java
@@ -45,7 +45,7 @@ public class NullGroupMembershipHandler implements GroupMembershipHandler {
     }
 
     @Override
-    public void fireEvent(String eventId) {
+    public void fireEvent(String eventId, Map<String, Object> data) {
         // nothing to do, 'cause self events have to be ignored.
     }
 

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
@@ -34,7 +34,6 @@ import org.shredzone.acme4j.toolbox.JSON;
 public class CertificateData {
 
     private String domain;
-    private String privateKey; // base64 encoded string.
     private String chain; // base64 encoded string of the KeyStore.
     private volatile DynamicCertificateState state;
     private String pendingOrderLocation;
@@ -48,10 +47,9 @@ public class CertificateData {
     private String serialNumber; // hex
     private byte[] keystoreData; // decoded chain
 
-    public CertificateData(String domain, String privateKey, String chain, DynamicCertificateState state,
+    public CertificateData(String domain, String chain, DynamicCertificateState state,
                            String orderLocation, String challengeData) {
         this.domain = domain;
-        this.privateKey = privateKey;
         this.chain = chain;
         this.state = state;
         this.pendingOrderLocation = orderLocation;
@@ -60,10 +58,6 @@ public class CertificateData {
 
     public String getDomain() {
         return domain;
-    }
-
-    public String getPrivateKey() {
-        return privateKey;
     }
 
     public String getChain() {
@@ -84,10 +78,6 @@ public class CertificateData {
 
     public void setDomain(String domain) {
         this.domain = domain;
-    }
-
-    public void setPrivateKey(String keypair) {
-        this.privateKey = keypair;
     }
 
     public void setChain(String chain) {
@@ -166,7 +156,6 @@ public class CertificateData {
     public int hashCode() {
         int hash = 7;
         hash = 89 * hash + Objects.hashCode(this.domain);
-        hash = 89 * hash + Objects.hashCode(this.privateKey);
         hash = 89 * hash + Objects.hashCode(this.chain);
         hash = 89 * hash + Objects.hashCode(this.state);
         hash = 89 * hash + Objects.hashCode(this.pendingOrderLocation);
@@ -197,9 +186,6 @@ public class CertificateData {
         if (!Objects.equals(this.domain, other.domain)) {
             return false;
         }
-        if (!Objects.equals(this.privateKey, other.privateKey)) {
-            return false;
-        }
         if (!Objects.equals(this.chain, other.chain)) {
             return false;
         }
@@ -218,7 +204,7 @@ public class CertificateData {
     @Override
     public String toString() {
         return "CertificateData{" + "domain=" + domain + ","
-                +" state=" + state + ", manual=" + manual
+                + " state=" + state + ", manual=" + manual
                 + ",expiringDate=" + expiringDate + ",serialNumber " + serialNumber + '}';
     }
 

--- a/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
@@ -142,6 +142,7 @@ public class HttpProxyServer implements AutoCloseable {
     @Getter
     private final ProxyRequestsManager proxyRequestsManager;
 
+    @Getter
     private String peerId = "localhost";
     private String zkAddress;
     private Properties zkProperties = new Properties();
@@ -684,7 +685,7 @@ public class HttpProxyServer implements AutoCloseable {
         applyDynamicConfiguration(newConfigurationStore, false);
 
         // this will trigger a reload on other peers
-        groupMembershipHandler.fireEvent("configurationChange");
+        groupMembershipHandler.fireEvent("configurationChange", null);
     }
 
     private void applyDynamicConfiguration(ConfigurationStore newConfigurationStore, boolean atBoot) throws InterruptedException, ConfigurationChangeInProgressException {
@@ -793,7 +794,7 @@ public class HttpProxyServer implements AutoCloseable {
     private class ConfigurationChangeCallback implements GroupMembershipHandler.EventCallback {
 
         @Override
-        public void eventFired(String eventId) {
+        public void eventFired(String eventId, Map<String, Object> data) {
             LOG.log(Level.INFO, "Configuration changed");
             try {
                 dynamicConfigurationStore.reload();

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
@@ -49,6 +49,7 @@ import org.carapaceproxy.core.RuntimeServerConfiguration;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.WAITING;
 import org.carapaceproxy.server.config.SSLCertificateConfiguration;
 import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.MANUAL;
+import static org.carapaceproxy.server.config.SSLCertificateConfiguration.WILDCARD_SYMBOL;
 import static org.carapaceproxy.utils.CertificatesUtils.isCertificateExpired;
 import static org.carapaceproxy.utils.CertificatesUtils.readChainFromKeystore;
 import java.io.File;
@@ -638,7 +639,10 @@ public class DynamicCertificatesManager implements Runnable {
             CertificateData oldCert = oldCertificates != null ? oldCertificates.get(cert.getDomain()) : null;
             return cert != null && !cert.isManual() && (oldCert == null || (cert.getState() == AVAILABLE && oldCert.getState() != AVAILABLE));
         }).forEach(cert -> {
-            var parent = new File(getConfig().getLocalCertificatesStorePath(), cert.getDomain());
+            final var domainDir = cert.getDomain().startsWith(WILDCARD_SYMBOL)
+                    ? cert.getDomain().substring(WILDCARD_SYMBOL.length())
+                    : cert.getDomain();
+            var parent = new File(getConfig().getLocalCertificatesStorePath(), domainDir);
             parent.mkdirs();
             LOG.log(Level.INFO, "Store certificate {0} to local path {1}", new Object[]{
                 cert.getDomain(), parent.getAbsolutePath()

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
@@ -19,6 +19,7 @@
  */
 package org.carapaceproxy.server.certificates;
 
+import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64DecodeCertificateChain;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64EncodeCertificateChain;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.AVAILABLE;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.DNS_CHALLENGE_WAIT;
@@ -50,16 +51,23 @@ import org.carapaceproxy.server.config.SSLCertificateConfiguration;
 import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.MANUAL;
 import static org.carapaceproxy.utils.CertificatesUtils.isCertificateExpired;
 import static org.carapaceproxy.utils.CertificatesUtils.readChainFromKeystore;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.net.InetAddress;
 import java.net.URL;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
+import org.bouncycastle.util.io.pem.PemObject;
+import org.bouncycastle.util.io.pem.PemWriter;
 import org.carapaceproxy.core.HttpProxyServer;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.glassfish.jersey.internal.guava.ThreadFactoryBuilder;
@@ -91,6 +99,7 @@ public class DynamicCertificatesManager implements Runnable {
 
     private static final Logger LOG = Logger.getLogger(DynamicCertificatesManager.class.getName());
     private static final String EVENT_CERTIFICATES_STATE_CHANGED = "certificates_state_changed";
+    private static final String EVENT_CERTIFICATES_REQUEST_STORE = "certificates_request_store";
 
     private Map<String, CertificateData> certificates = new ConcurrentHashMap();
     private ACMEClient acmeClient; // Let's Encrypt client
@@ -127,6 +136,7 @@ public class DynamicCertificatesManager implements Runnable {
     public void attachGroupMembershipHandler(GroupMembershipHandler groupMembershipHandler) {
         this.groupMembershipHandler = groupMembershipHandler;
         groupMembershipHandler.watchEvent(EVENT_CERTIFICATES_STATE_CHANGED, new OnCertificatesStateChanged());
+        groupMembershipHandler.watchEvent(EVENT_CERTIFICATES_REQUEST_STORE, new OnCertificatesRequestStore());
     }
 
     @VisibleForTesting
@@ -213,7 +223,7 @@ public class DynamicCertificatesManager implements Runnable {
                                                                     int daysBeforeRenewal) throws GeneralSecurityException, MalformedURLException {
         CertificateData cert = store.loadCertificateForDomain(domain);
         if (cert == null) {
-            cert = new CertificateData(domain, "", "", WAITING, "", "");
+            cert = new CertificateData(domain, "", WAITING, "", "");
         } else if (cert.getChain() != null && !cert.getChain().isEmpty()) {
             byte[] keystoreData = Base64.getDecoder().decode(cert.getChain());
             cert.setKeystoreData(keystoreData);
@@ -276,16 +286,18 @@ public class DynamicCertificatesManager implements Runnable {
     }
 
     private void certificatesLifecycle() {
-        boolean flushCache = false;
+        var flushCache = false;
         List<CertificateData> _certificates = certificates.entrySet().stream()
                 .filter(e -> !e.getValue().isManual())
                 .sorted((e1, e2) -> e1.getKey().compareTo(e2.getKey()))
                 .map(e -> e.getValue())
                 .collect(Collectors.toList());
-        for (CertificateData cert : _certificates) {
-            boolean updateCertificate = true;
-            final String domain = cert.getDomain();
+        for (CertificateData data : _certificates) {
+            var updateCertificate = true;
+            final var domain = data.getDomain();
             try {
+                // this has to be always fetch from db!
+                CertificateData cert = loadOrCreateDynamicCertificateForDomain(domain, data.isWildcard(), false, data.getDaysBeforeRenewal());
                 switch (cert.getState()) {
                     case WAITING: // certificate waiting to be issues/renew
                     case DOMAIN_UNREACHABLE: { // certificate domain reported as unreachable for issuing/renewing
@@ -373,7 +385,7 @@ public class DynamicCertificatesManager implements Runnable {
             }
         }
         if (flushCache) {
-            groupMembershipHandler.fireEvent(EVENT_CERTIFICATES_STATE_CHANGED);
+            groupMembershipHandler.fireEvent(EVENT_CERTIFICATES_STATE_CHANGED, null);
             // remember that events  are not delivered to the local JVM
             reloadCertificatesFromDB();
         }
@@ -497,6 +509,7 @@ public class DynamicCertificatesManager implements Runnable {
         return pair;
     }
 
+    @VisibleForTesting
     public DynamicCertificateState getStateOfCertificate(String id) {
         if (certificates.containsKey(id)) {
             CertificateData cert = store.loadCertificateForDomain(id);
@@ -508,6 +521,7 @@ public class DynamicCertificatesManager implements Runnable {
         return null;
     }
 
+    @VisibleForTesting
     public void setStateOfCertificate(String id, DynamicCertificateState state) {
         if (certificates.containsKey(id)) {
             CertificateData cert = store.loadCertificateForDomain(id);
@@ -517,10 +531,14 @@ public class DynamicCertificatesManager implements Runnable {
                 // remember that events  are not delivered to the local JVM
                 reloadCertificatesFromDB();
                 if (groupMembershipHandler != null) {
-                    groupMembershipHandler.fireEvent(EVENT_CERTIFICATES_STATE_CHANGED);
+                    groupMembershipHandler.fireEvent(EVENT_CERTIFICATES_STATE_CHANGED, null);
                 }
             }
         }
+    }
+
+    private RuntimeServerConfiguration getConfig() {
+        return server.getCurrentConfiguration();
     }
 
     /**
@@ -528,7 +546,7 @@ public class DynamicCertificatesManager implements Runnable {
      * @param domain
      * @return PKCS12 Keystore content
      */
-    public byte[] getCertificateForDomain(String domain) throws GeneralSecurityException {
+    public byte[] getCertificateForDomain(String domain) {
         CertificateData cert = certificates.get(domain); // certs always retrived from cache
         if (cert == null || cert.getKeystoreData() == null || cert.getKeystoreData().length == 0) {
             LOG.log(Level.SEVERE, "No dynamic certificate available for domain {0}", domain);
@@ -537,50 +555,139 @@ public class DynamicCertificatesManager implements Runnable {
         return cert.getKeystoreData();
     }
 
-    public CertificateData getCertificateDataForDomain(String domain) throws GeneralSecurityException {
+    public CertificateData getCertificateDataForDomain(String domain) {
         return certificates.get(domain);
     }
 
     private class OnCertificatesStateChanged implements GroupMembershipHandler.EventCallback {
 
         @Override
-        public void eventFired(String eventId) {
+        public void eventFired(String eventId, Map<String, Object> data) {
             LOG.log(Level.INFO, "Certificates state changed");
             try {
                 reloadCertificatesFromDB();
             } catch (Exception err) {
-                LOG.log(Level.SEVERE, "Cannot apply new configuration");
+                LOG.log(Level.SEVERE, "Failed to reload certificates from db. Cause: {0}", err);
             }
         }
 
         @Override
         public void reconnected() {
-            LOG.log(Level.INFO, "Configuration listener - reloading configuration after ZK reconnection");
+            LOG.log(Level.INFO, "Reloading certificates after ZK reconnection");
             try {
                 reloadCertificatesFromDB();
             } catch (Exception err) {
-                LOG.log(Level.SEVERE, "Cannot apply new configuration");
+                LOG.log(Level.SEVERE, "Failed to reload certificates from db. Cause: {0}", err);
             }
+        }
+    }
+
+    private class OnCertificatesRequestStore implements GroupMembershipHandler.EventCallback {
+
+        @Override
+        public void eventFired(String eventId, Map<String, Object> data) {
+            LOG.log(Level.INFO, "Certificates request store");
+            try {
+                final var certs = (List<String>) data.get("certs");
+                final var _certificates = certs.isEmpty()
+                        ? DynamicCertificatesManager.this.certificates.values()
+                        : certs.stream()
+                                .map(d -> getCertificateDataForDomain(d))
+                                .collect(Collectors.toList());
+                storeLocalCertificates(_certificates, null);
+            } catch (Exception err) {
+                LOG.log(Level.SEVERE, "Failed to store certificates. Cause: {0}", err);
+            }
+        }
+
+        @Override
+        public void reconnected() {
         }
     }
 
     private void reloadCertificatesFromDB() {
         LOG.log(Level.INFO, "Reloading certificates from db");
         try {
-            Map<String, CertificateData> _certificates = new ConcurrentHashMap<>();
+            Map<String, CertificateData> newCertificates = new ConcurrentHashMap<>();
             for (Entry<String, CertificateData> entry : certificates.entrySet()) {
                 String domain = entry.getKey();
                 CertificateData cert = entry.getValue();
                 // "wildcard" and "manual" flags and "daysBeforeRenewal" are not stored in db > have to be re-set from existing config
                 CertificateData freshCert = loadOrCreateDynamicCertificateForDomain(domain, cert.isWildcard(), cert.isManual(), cert.getDaysBeforeRenewal());
-                _certificates.put(domain, freshCert);
+                newCertificates.put(domain, freshCert);
                 LOG.log(Level.INFO, "RELOADED certificate for domain {0}: {1}", new Object[]{domain, freshCert});
             }
-            this.certificates = _certificates; // only certificates/domains specified in the config have to be managed.
+            var oldCertificates = this.certificates;
+            this.certificates = newCertificates; // only certificates/domains specified in the config have to be managed.
             server.getListeners().reloadCurrentConfiguration();
+            // storing certificates on local path
+            storeLocalCertificates(newCertificates.values(), oldCertificates);
         } catch (GeneralSecurityException | MalformedURLException | InterruptedException e) {
             throw new DynamicCertificatesManagerException("Unable to load dynamic certificates from db.", e);
         }
     }
 
+    private void storeLocalCertificates(Collection<CertificateData> newCertificates, Map<String, CertificateData> oldCertificates) {
+        if (getConfig().getLocalCertificatesStorePath() == null
+                || (!getConfig().getLocalCertificatesStorePeersIds().isEmpty()
+                && !getConfig().getLocalCertificatesStorePeersIds().contains(server.getPeerId()))) {
+            return;
+        }
+
+        newCertificates.stream().filter(cert -> {
+            CertificateData oldCert = oldCertificates != null ? oldCertificates.get(cert.getDomain()) : null;
+            return cert != null && !cert.isManual() && (oldCert == null || (cert.getState() == AVAILABLE && oldCert.getState() != AVAILABLE));
+        }).forEach(cert -> {
+            var parent = new File(getConfig().getLocalCertificatesStorePath(), cert.getDomain());
+            parent.mkdirs();
+            LOG.log(Level.INFO, "Store certificate {0} to local path {1}", new Object[]{
+                cert.getDomain(), parent.getAbsolutePath()
+            });
+            try (var fos = new FileOutputStream(new File(parent, "privatekey.pem"));
+                    var osw = new OutputStreamWriter(fos);
+                    var writer = new PemWriter(osw)) {
+                var key = loadOrCreateKeyPairForDomain(cert.getDomain()).getPrivate();
+                writer.writeObject(new PemObject("", key.getEncoded()));
+            } catch (IOException ex) {
+                LOG.log(Level.SEVERE, "Failed to save privatekey for certificate domain {0} to local path {1}", new Object[]{
+                    cert.getDomain(), parent.getAbsolutePath()
+                });
+            }
+            try (var fos = new FileOutputStream(new File(parent, "chain.pem"));
+                    var fos2 = new FileOutputStream(new File(parent, "fullchain.pem"));
+                    var osw = new OutputStreamWriter(fos);
+                    var osw2 = new OutputStreamWriter(fos2);
+                    var writer = new PemWriter(osw);
+                    var writer2 = new PemWriter(osw2)) {
+                var chain = base64DecodeCertificateChain(cert.getChain());
+                for (int i = 0; i < chain.length; i++) {
+                    byte[] encoded = chain[i].getEncoded();
+                    if (i > 0) {
+                        writer.writeObject(new PemObject("", encoded));
+                    }
+                    writer2.writeObject(new PemObject("", encoded));
+                }
+            } catch (IOException ex) {
+                LOG.log(Level.SEVERE, "Failed to save chains for certificate domain {0} to local path {1}", new Object[]{
+                    cert.getDomain(), parent.getAbsolutePath()
+                });
+            } catch (GeneralSecurityException ex) {
+                LOG.log(Level.SEVERE, "Failed to read certificate data for domain {0}", new Object[]{cert.getDomain()});
+            }
+        });
+    }
+
+    public void forceStoreLocalCertificates(String... certs) {
+        final var _certs = Arrays.asList(certs);
+        groupMembershipHandler.fireEvent(EVENT_CERTIFICATES_REQUEST_STORE, Map.of("certs", _certs));
+
+        // remember that events  are not delivered to the local JVM
+        final var _certificates = _certs.isEmpty()
+                ? this.certificates.values()
+                : _certs.stream()
+                        .map(d -> getCertificateDataForDomain(d))
+                        .collect(Collectors.toList());
+
+        storeLocalCertificates(_certificates, null);
+    }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreTest.java
@@ -259,12 +259,12 @@ public class ConfigurationStoreTest {
 
         // Certificates saving
         CertificateData cert1 = new CertificateData(
-                d1, "encodedPK1", "encodedChain1", DynamicCertificateState.AVAILABLE, order, challenge
+                d1, "encodedChain1", DynamicCertificateState.AVAILABLE, order, challenge
         );
         store.saveCertificate(cert1);
 
         CertificateData cert2 = new CertificateData(
-                d2, "encodedPK2", "encodedChain2", DynamicCertificateState.WAITING, null, null
+                d2, "encodedChain2", DynamicCertificateState.WAITING, null, null
         );
         store.saveCertificate(cert2);
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
@@ -138,20 +138,20 @@ public class DynamicCertificatesManagerTest {
 
         // yet available certificate
         String d0 = "localhost0";
-        CertificateData cd0 = new CertificateData(d0, "", chain, AVAILABLE, "", "");
+        CertificateData cd0 = new CertificateData(d0, chain, AVAILABLE, "", "");
         when(store.loadCertificateForDomain(eq(d0))).thenReturn(cd0);
         // certificate to order
         String d1 = "localhost1";
-        CertificateData cd1 = new CertificateData(d1, "", "", WAITING, "", "");
+        CertificateData cd1 = new CertificateData(d1, "", WAITING, "", "");
         when(store.loadCertificateForDomain(eq(d1))).thenReturn(cd1);
         man.setConfigurationStore(store);
         // manual certificate
         String d2 = "manual";
-        CertificateData cd2 = new CertificateData(d2, "", chain, AVAILABLE, "", "");
+        CertificateData cd2 = new CertificateData(d2, chain, AVAILABLE, "", "");
         when(store.loadCertificateForDomain(eq(d2))).thenReturn(cd2);
         // empty manual certificate
         String d3 = "emptymanual";
-        CertificateData cd3 = new CertificateData(d3, "", "", AVAILABLE, "", "");
+        CertificateData cd3 = new CertificateData(d3, "", AVAILABLE, "", "");
         when(store.loadCertificateForDomain(eq(d3))).thenReturn(cd3);
 
         man.setConfigurationStore(store);
@@ -173,6 +173,7 @@ public class DynamicCertificatesManagerTest {
         ConfigurationStore configStore = new PropertiesConfigurationStore(props);
         RuntimeServerConfiguration conf = new RuntimeServerConfiguration();
         conf.configure(configStore);
+        when(parent.getCurrentConfiguration()).thenReturn(conf);
         man.reloadConfiguration(conf);
 
         assertCertificateState(d0, AVAILABLE, man);
@@ -306,7 +307,7 @@ public class DynamicCertificatesManagerTest {
 
         // certificate to order
         String domain = "*.localhost";
-        CertificateData cd1 = new CertificateData(domain, "", "", WAITING, "", "");
+        CertificateData cd1 = new CertificateData(domain, "", WAITING, "", "");
         when(store.loadCertificateForDomain(eq(domain))).thenReturn(cd1);
         man.setConfigurationStore(store);
 
@@ -319,6 +320,7 @@ public class DynamicCertificatesManagerTest {
         ConfigurationStore configStore = new PropertiesConfigurationStore(props);
         RuntimeServerConfiguration conf = new RuntimeServerConfiguration();
         conf.configure(configStore);
+        when(parent.getCurrentConfiguration()).thenReturn(conf);
         man.reloadConfiguration(conf);
 
         CertificateData certData = man.getCertificateDataForDomain(domain);
@@ -410,7 +412,7 @@ public class DynamicCertificatesManagerTest {
         when(store.loadKeyPairForDomain(anyString())).thenReturn(keyPair);
 
         // certificate to order
-        CertificateData cd1 = new CertificateData(domain, "", "", WAITING, "", "");
+        CertificateData cd1 = new CertificateData(domain, "", WAITING, "", "");
         when(store.loadCertificateForDomain(eq(domain))).thenReturn(cd1);
         man.setConfigurationStore(store);
 
@@ -427,6 +429,7 @@ public class DynamicCertificatesManagerTest {
         ConfigurationStore configStore = new PropertiesConfigurationStore(props);
         RuntimeServerConfiguration conf = new RuntimeServerConfiguration();
         conf.configure(configStore);
+        when(parent.getCurrentConfiguration()).thenReturn(conf);
         man.reloadConfiguration(conf);
 
         int saveCounter = 0; // at every run the certificate has to be saved to the db (whether not AVAILABLE).

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/CertificatesTestUtils.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/CertificatesTestUtils.java
@@ -113,7 +113,8 @@ public class CertificatesTestUtils {
         return new X509Certificate[]{
             endUserCert,
             intermediateCA,
-            rootCA,};
+            rootCA
+        };
     }
 
     public static byte[] generateSampleChainData() throws Exception {

--- a/carapace-ui/src/main/webapp/src/components/CacheStatus.vue
+++ b/carapace-ui/src/main/webapp/src/components/CacheStatus.vue
@@ -1,7 +1,9 @@
 <template>
     <div>
-        <h2>Cache</h2>
-        <button class="btn btn-dark float-right" v-on:click="flushCache">Flush cache</button>
+        <div class="page-header">
+            <h2>Cache</h2>
+            <b-button @click="flushCache">Flush cache</b-button>
+        </div>
         <form class="float-left w-75">
             <div class="form-group row">
                 <label class="col-sm-4 col-form-label">Status:</label>
@@ -11,7 +13,7 @@
                         readonly
                         class="form-control-plaintext"
                         v-model="status.result"
-                    />
+                        />
                 </div>
             </div>
             <div class="form-group row">
@@ -22,7 +24,7 @@
                         readonly
                         class="form-control-plaintext"
                         v-model="status.cachesize"
-                    />
+                        />
                 </div>
             </div>
             <div class="form-group row">
@@ -33,7 +35,7 @@
                         readonly
                         class="form-control-plaintext"
                         v-model="status.misses"
-                    />
+                        />
                 </div>
             </div>
             <div class="form-group row">
@@ -44,7 +46,7 @@
                         readonly
                         class="form-control-plaintext"
                         v-model="status.directMemoryUsed"
-                    />
+                        />
                 </div>
             </div>
             <div class="form-group row">
@@ -55,7 +57,7 @@
                         readonly
                         class="form-control-plaintext"
                         v-model="status.heapMemoryUsed"
-                    />
+                        />
                 </div>
             </div>
         </form>
@@ -64,61 +66,69 @@
 </template>
 
 <script>
-import { doGet } from "./../mockserver";
-import { formatTimestamp } from "./../lib/formatter";
-export default {
-    name: "CacheStatus",
-    data() {
-        return {
-            status: {},
-            cacheitems: []
-        };
-    },
-    created() {
-        this.loadData();
-    },
-    computed: {
-        fields() {
-            return [
-                { key: "key", label: "Key", sortable: true },
-                { key: "method", label: "Method", sortable: true },
-                { key: "hits", label: "Hits", sortable: true },
-                { key: "heapSize", label: "Heap Memory Size", sortable: true },
-                {
-                    key: "directSize",
-                    label: "Direct Memory Size",
-                    sortable: true
-                },
-                { key: "totalSize", label: "Entry Size", sortable: true },
-                { key: "creationTs", label: "Creation", sortable: true },
-                { key: "expireTs", label: "Expire", sortable: true }
-            ];
-        }
-    },
-    methods: {
-        loadData() {
-            doGet("/api/cache/info", data => {
-                this.status = data;
-            });
-            doGet("/api/cache/inspect", data => {
-                data.forEach(it => {
-                    it.key = it.scheme + '://' + it.host + it.uri;
-                    it.creationTs = formatTimestamp(it.creationTs);
-                    it.expireTs = formatTimestamp(it.expireTs);
-                    this.cacheitems.push(it);
+    import { doGet } from "./../mockserver";
+    import { formatTimestamp } from "./../lib/formatter";
+    export default {
+        name: "CacheStatus",
+        data() {
+            return {
+                status: {},
+                cacheitems: []
+            };
+        },
+        created() {
+            this.loadData();
+        },
+        computed: {
+            fields() {
+                return [
+                    {key: "key", label: "Key", sortable: true},
+                    {key: "method", label: "Method", sortable: true},
+                    {key: "hits", label: "Hits", sortable: true},
+                    {key: "heapSize", label: "Heap Memory Size", sortable: true},
+                    {
+                        key: "directSize",
+                        label: "Direct Memory Size",
+                        sortable: true
+                    },
+                    {key: "totalSize", label: "Entry Size", sortable: true},
+                    {key: "creationTs", label: "Creation", sortable: true},
+                    {key: "expireTs", label: "Expire", sortable: true}
+                ];
+            }
+        },
+        methods: {
+            loadData() {
+                doGet("/api/cache/info", data => {
+                    this.status = data;
                 });
-            });
-        },
-        getKey(item) {
-            return item.host + item.uri;
-        },
-        flushCache() {
-            // eslint-disable-next-line
-            doGet("/api/cache/flush", data => {
-                this.cacheitems = [];
-                this.loadData();
-            });
+                doGet("/api/cache/inspect", data => {
+                    data.forEach(it => {
+                        it.key = it.scheme + '://' + it.host + it.uri;
+                        it.creationTs = formatTimestamp(it.creationTs);
+                        it.expireTs = formatTimestamp(it.expireTs);
+                        this.cacheitems.push(it);
+                    });
+                });
+            },
+            getKey(item) {
+                return item.host + item.uri;
+            },
+            flushCache() {
+                // eslint-disable-next-line
+                doGet("/api/cache/flush", data => {
+                    this.cacheitems = [];
+                    this.loadData();
+                });
+            }
         }
-    }
-};
+    };
 </script>
+
+<style scoped lang="scss">
+    .page-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+    }
+</style>

--- a/carapace-ui/src/main/webapp/src/components/Certificate.vue
+++ b/carapace-ui/src/main/webapp/src/components/Certificate.vue
@@ -2,6 +2,14 @@
     <div>
         <div v-if="found">
             <h2>Certificate {{$route.params.id}}</h2>
+            <b-alert id="status-alert"
+                     fade
+                     dismissible
+                     :show="opMessage ? 10 : 0"
+                     @dismissed="opMessage = ''"
+                     :variant="opSuccess ? 'success' : 'danger'">
+                {{opMessage}}
+            </b-alert>
             <div class="panel panel-info">
                 <div class="panel-body">
                     <ul class="list-group">
@@ -19,8 +27,14 @@
                         <li v-if="certificate.mode == 'acme'" class="list-group-item"><strong>Days Before Renewal:</strong> {{certificate.daysBeforeRenewal}}</li>
                         <li class="list-group-item"><strong>Serial Number:</strong> {{certificate.serialNumber}}</li>
                         <li v-if="certificate.dynamic" class="p-2 text-center">
-                        <b-button :href="'/api/certificates/' + certificate.id + '/download'" variant="primary">
+                        <b-button :href="'/api/certificates/' + certificate.id + '/download'" class="btn">
                             Download
+                        </b-button>
+                        <b-button v-if="certificate.mode == 'acme' && localStorePath"
+                                  @click="openConfirmModal"
+                                  variant="outline-secondary"
+                                  class="btn">
+                            Dump
                         </b-button>
                         </li>
                         <li v-else class="list-group-item">
@@ -40,19 +54,23 @@
 </template>
 
 <script>
-    import { doGet } from './../mockserver'
+    import { doGet, doPost } from './../mockserver'
     export default {
         name: 'Certificate',
         data() {
             return {
+                certificate: {},
                 found: true,
-                certificate: {}
+                localStorePath: null,
+                opSuccess: null,
+                opMessage: ""
             }
         },
         created() {
             var url = "/api/certificates/" + (this.$route.params.id || 0)
             doGet(url, data => {
-                this.certificate = data
+                this.certificate = data.certificates[0] || {}
+                this.localStorePath = data.localStorePath
                 if (!data) {
                     this.found = false
                 }
@@ -70,17 +88,65 @@
                     return "error"
                 }
                 return "info";
+            },
+            openConfirmModal() {
+                const message = this.$createElement('div', {
+                    domProps: {
+                        innerHTML: 'The certificate gonna be dumped to path: <strong>'
+                                + this.localStorePath + this.certificate.id + '</strong>'
+                                + '<br>The existent dump gonna be overwritten, proceed?'
+                    }
+                })
+                this.$bvModal.msgBoxConfirm([message], {
+                    title: 'Attention',
+                    okVariant: 'warning',
+                    okTitle: 'Yes',
+                    footerClass: 'p-2',
+                    hideHeaderClose: false,
+                    centered: true
+                }).then(value => {
+                    if (value != true) {
+                        return;
+                    }
+                    doPost("/api/certificates/" + this.certificate.id + "/store",
+                            null,
+                            resp => {
+                                this.opSuccess = resp.ok;
+                                if (resp.ok) {
+                                    this.opMessage = 'Certificate dumped';
+                                } else {
+                                    this.opMessage = 'Unable to dump certificate to path: ' + this.localStorePath + '. Cause: ' + resp.error;
+                                }
+                            },
+                            error => {
+                                this.opSuccess = false;
+                                this.opMessage = 'Unable to dump certificate to path: ' + this.localStorePath + '. Cause: ' + error;
+                            }
+                    );
+                })
             }
         }
     }
 </script>
 
-<style scoped>
+<style scoped lang="scss">
     .panel {
         max-width: 30rem;
     }
 
     li {
         word-wrap: break-word;
+
+        .btn {
+            margin: auto 0.5rem;
+        }
+
+    }
+    #status-alert {
+        position: absolute;
+        top: 2rem;
+        left: 25%;
+        right: 25%;
+        z-index: 999;
     }
 </style>

--- a/carapace-ui/src/main/webapp/src/components/CertificatesStatus.vue
+++ b/carapace-ui/src/main/webapp/src/components/CertificatesStatus.vue
@@ -1,6 +1,21 @@
 <template>
     <div>
-        <h2>Certificates</h2>
+        <div class="page-header">
+            <h2>Certificates</h2>
+            <b-button v-if="localStorePath"
+                      @click="openConfirmModal"                      
+                      class="btn">
+                Dump all certificates
+            </b-button>
+        </div>
+        <b-alert id="status-alert"
+                 fade
+                 dismissible
+                 :show="opMessage ? 10 : 0"
+                 @dismissed="opMessage = ''"
+                 :variant="opSuccess ? 'success' : 'danger'">
+            {{opMessage}}
+        </b-alert>
         <div v-if="expiredCertificates.length > 0" class="box-warning">
             <strong>These certificates are expired:</strong>
             <ul>
@@ -20,19 +35,23 @@
 </template>
 
 <script>
-    import { doGet } from "./../mockserver";
+    import { doGet, doPost } from './../mockserver'
     import { toBooleanSymbol } from "./../lib/formatter";
     export default {
         name: "Certificates",
         data() {
             return {
                 certificates: [],
-                loading: true
+                localStorePath: null,
+                loading: true,
+                opSuccess: null,
+                opMessage: ""
             };
         },
         created() {
             doGet("/api/certificates", data => {
-                this.certificates = Object.values(data || {})
+                this.certificates = data.certificates || {}
+                this.localStorePath = data.localStorePath
                 this.loading = false
             });
         },
@@ -61,7 +80,7 @@
             },
             expiredCertificates() {
                 return (this.certificates || []).filter(c => c.status === "expired")
-            }
+            },
         },
         methods: {
             showCertDetail(cert) {
@@ -78,7 +97,58 @@
                     return "error"
                 }
                 return "info";
+            },
+            openConfirmModal() {
+                const message = this.$createElement('div', {
+                    domProps: {
+                        innerHTML: 'All certificates gonna be dumped to path: <strong>' + this.localStorePath + '</strong>'
+                                + '<br>The existent dump gonna be overwritten and might take several time, proceed?'
+                    }
+                })
+                this.$bvModal.msgBoxConfirm([message], {
+                    title: 'Attention',
+                    okVariant: 'warning',
+                    okTitle: 'Yes',
+                    footerClass: 'p-2',
+                    hideHeaderClose: false,
+                    centered: true
+                }).then(value => {
+                    if (value != true) {
+                        return;
+                    }
+                    doPost("/api/certificates/storeall",
+                            null,
+                            resp => {
+                                this.opSuccess = resp.ok;
+                                if (resp.ok) {
+                                    this.opMessage = 'Certificates dump started';
+                                } else {
+                                    this.opMessage = 'Unable to dump certificates to path: ' + this.localStorePath + '. Cause: ' + resp.error;
+                                }
+                            },
+                            error => {
+                                this.opSuccess = false;
+                                this.opMessage = 'Unable to dump certificates to path: ' + this.localStorePath + '. Cause: ' + error;
+                            }
+                    );
+                })
             }
         }
     };
 </script>
+
+<style scoped lang="scss">
+    .page-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+    }
+
+    #status-alert {
+        position: absolute;
+        top: 2rem;
+        left: 25%;
+        right: 25%;
+        z-index: 999;
+    }
+</style>

--- a/carapace-ui/src/main/webapp/src/components/Configuration.vue
+++ b/carapace-ui/src/main/webapp/src/components/Configuration.vue
@@ -1,14 +1,13 @@
 <template>
     <div>
-        <h2>Configuration</h2>
-        <div id="maintenance-switch" >
-            <b-form-checkbox
-                v-model="checked" 
-                name="check-button" 
-                size="lg" 
-                @change="$bvModal.show('maintenance')" 
-                switch>
-                Maintenance Mode <b>(Enable: {{ checked }})</b>
+        <div class="page-header">
+            <h2>Configuration</h2>
+            <b-form-checkbox name="check-button"
+                             v-model="checked"
+                             size="lg"
+                             switch
+                             @change="onMaintenanceModeChange()">
+                Maintenance Mode
             </b-form-checkbox>
         </div>
         <b-alert
@@ -18,7 +17,7 @@
             :show="opMessage ? 10 : 0"
             @dismissed="opMessage = ''"
             :variant="opSuccess ? 'success' : 'danger'"
-        >{{opMessage}}</b-alert>
+            >{{opMessage}}</b-alert>
         <b-form-textarea
             id="config-editor"
             rows="30"
@@ -26,23 +25,22 @@
             no-resize
             v-model="configuration"
             :state="opSuccess"
-            placeholder="Edit Dynamic Configuration"
-            class="mb-2"
-        ></b-form-textarea>
+            placeholder="Edit Dynamic Configuration">
+        </b-form-textarea>
         <div>
-            <b-button variant="outline-primary" @click="fetch">Fetch</b-button>
-            <b-button variant="outline-primary" @click="validate">Validate</b-button>
-            <b-button variant="primary" @click="save">Save</b-button>
+            <b-button variant="outline-secondary" @click="fetch">Fetch</b-button>
+            <b-button variant="outline-secondary" @click="validate">Validate</b-button>
+            <b-button @click="save">Save</b-button>
         </div>
         <div>
-            <b-modal 
-            id="maintenance" 
-            title="Maintenance"
-            cancel-title="Close"
-            no-close-on-backdrop
-            @ok="setupMaintenanceMode"
-            @hidden="reset"
-            >
+            <b-modal
+                id="maintenance"
+                title="Maintenance"
+                cancel-title="Close"
+                no-close-on-backdrop
+                @ok="setupMaintenanceMode"
+                @hidden="reset"
+                >
                 <p class="my-4" v-if="checked">You are about to enable maintenance mode</p>
                 <p class="my-4" v-else>You are about to disable maintenance mode</p>
             </b-modal>
@@ -51,129 +49,143 @@
 </template>
 
 <script>
-import { doGet } from "./../mockserver";
-import { doPost } from "./../mockserver";
+    import { doGet } from "./../mockserver";
+    import { doPost } from "./../mockserver";
 
-export default {
-    name: "Configuration",
-    data() {
-        return {
-            configuration: "",
-            opSuccess: null,
-            opMessage: "",
-            checked: false
-        };
-    },
-    created() {
-        this.fetch();
-        this.getMaintenanceStatus();
-    },
-    methods: {
-        save() {
-            doPost(
-                "/api/config/apply",
-                this.configuration,
-                data => {
-                    this.opSuccess = data.ok;
-                    this.opMessage = data.ok
-                        ? "Configuration saved successfully."
-                        : "Error: unable to save the configuration. Reason: " + data.error;
-                },
-                error => {
-                    this.opSuccess = false;
-                    this.opMessage =
-                        "Error: unable to save the configuration (" +
-                        error +
-                        ").";
-                }
-            );
+    export default {
+        name: "Configuration",
+        data() {
+            return {
+                configuration: "",
+                opSuccess: null,
+                opMessage: "",
+                checked: false
+            };
         },
-        fetch() {
-            doGet(
-                "/api/config",
-                conf => {
-                    this.configuration = conf;
-                    this.opSuccess = true;
-                    this.opMessage = "";
-                },
-                error => {
-                    this.opSuccess = false;
-                    this.opMessage =
-                        "Error: unable to fetch current configuration (" +
-                        error +
-                        ").";
-                }
-            );
+        created() {
+            this.fetch();
+            this.getMaintenanceStatus();
         },
-        validate() {
-            doPost(
-                "/api/config/validate",
-                this.configuration,
-                data => {
-                    this.opSuccess = data.ok;
-                    this.opMessage = data.ok
-                        ? "Configuration is ok."
-                        : "Error: configuration contains some errors. Details: " + data.error;
-                },
-                error => {
-                    this.opSuccess = false;
-                    this.opMessage =
-                        "Error: unable to validate the configuration (" +
-                        error +
-                        ").";
-                }
-            );
-        },
-       setupMaintenanceMode(bvModalEvent) {
-           bvModalEvent.preventDefault()
-           doPost("/api/config/maintenance?enable=" + this.checked,
-               this.checked,
-               data => {
-                   this.checked = data.ok;
-                   this.opSuccess = true;
-                   this.opMessage = data.ok
-                        ? "Maintenance mode has been enabled.\n Refresh page to see the change."
-                        : "Maintenance mode has been disabled.\n Refresh page to see the change.";
-               },
-               error => {
-                   this.opSuccess = false;
-                   this.opMessage = "Something went wrong (" + error + ")";
-               }
-           );
-           this.$nextTick(() => {
-             this.$bvModal.hide('maintenance')
-           })
-       },
-       getMaintenanceStatus() {
-            doGet("/api/config/maintenance", data => {
-                this.checked = data.ok;
-            });
-       },
-       reset() {
-           this.getMaintenanceStatus();
-       },
-    }
-};
+        methods: {
+            save() {
+                doPost(
+                        "/api/config/apply",
+                        this.configuration,
+                        data => {
+                            this.opSuccess = data.ok;
+                            this.opMessage = data.ok
+                                    ? "Configuration saved successfully."
+                                    : "Error: unable to save the configuration. Reason: " + data.error;
+                        },
+                        error => {
+                            this.opSuccess = false;
+                            this.opMessage =
+                                    "Error: unable to save the configuration (" +
+                                    error +
+                                    ").";
+                        }
+                );
+            },
+            fetch() {
+                doGet(
+                        "/api/config",
+                        conf => {
+                            this.configuration = conf;
+                            this.opSuccess = true;
+                            this.opMessage = "";
+                        },
+                        error => {
+                            this.opSuccess = false;
+                            this.opMessage =
+                                    "Error: unable to fetch current configuration (" +
+                                    error +
+                                    ").";
+                        }
+                );
+            },
+            validate() {
+                doPost(
+                        "/api/config/validate",
+                        this.configuration,
+                        data => {
+                            this.opSuccess = data.ok;
+                            this.opMessage = data.ok
+                                    ? "Configuration is ok."
+                                    : "Error: configuration contains some errors. Details: " + data.error;
+                        },
+                        error => {
+                            this.opSuccess = false;
+                            this.opMessage =
+                                    "Error: unable to validate the configuration (" +
+                                    error +
+                                    ").";
+                        }
+                );
+            },
+            onMaintenanceModeChange() {
+                const newChecked = this.checked;
+                this.checked = !newChecked;
+                const message = this.$createElement('div', {
+                    domProps: {
+                        innerHTML: 'System gonna <strong>' + (newChecked ? 'enter' : 'exit') + '</strong> maintenance mode, proceed?'
+                    }
+                });
+                this.$bvModal.msgBoxConfirm(message, {
+                    title: 'Attention',
+                    okVariant: newChecked ? 'warning' : "success",
+                    okTitle: 'Yes',
+                    footerClass: 'p-2',
+                    hideHeaderClose: false,
+                    centered: true
+                }).then(value => {
+                    if (value != true) {
+                        return;
+                    }
+                    doPost("/api/config/maintenance?enable=" + newChecked,
+                            newChecked,
+                            () => window.location.reload(),
+                            error => {
+                                this.opSuccess = false;
+                                this.opMessage = "Something went wrong (" + error + ")";
+                            }
+                    );
+                })
+            },
+            getMaintenanceStatus() {
+                doGet("/api/config/maintenance", data => {
+                    this.checked = data.ok;
+                });
+            },
+            reset() {
+                this.getMaintenanceStatus();
+            }
+        }
+    };
 </script>
 
-<style scoped>
-#config-editor {
-    height: 72vh;
-}
+<style lang="scss" scoped>
+    @import "../variables.scss";
 
-#status-alert {
-    position: absolute;
-    top: 2rem;
-    left: 25%;
-    right: 25%;
-    z-index: 999;
-}
+    .page-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+    }
 
-#maintenance-switch {
-    float: right;
-}
+    #config-editor {
+        height: 72vh;
+        margin: 0.5rem auto;
+    }
 
-button {
-    margin-right: 0.5rem;
-}
+    #status-alert {
+        position: absolute;
+        top: 2rem;
+        left: 25%;
+        right: 25%;
+        z-index: 999;
+    }
+
+    button {
+        margin-right: 0.5rem;
+    }
 </style>

--- a/carapace-ui/src/main/webapp/src/components/Navbar.vue
+++ b/carapace-ui/src/main/webapp/src/components/Navbar.vue
@@ -4,7 +4,7 @@
             <img id="logo" :src="logo" height="45px" width="45px" />
             <span id="label">{{label}}</span>
         </a>
-        <b v-if="maintenanceStatus">MAINTENANCE MODE IS ENABLE</b>
+        <b v-if="maintenanceStatus">SYSTEM IS IN MAINTENANCE MODE</b>
         <router-link to="/peers">
             <b>Node:</b> {{nodeId}}
         </router-link>

--- a/carapace-ui/src/main/webapp/src/components/Sidebar.vue
+++ b/carapace-ui/src/main/webapp/src/components/Sidebar.vue
@@ -69,7 +69,6 @@ export default {
     max-width: $sidebar-width;
     background: $sidebar-background;
     color: $white;
-    transition: all 0.15s linear;
     text-align: left;
     -webkit-box-shadow: 2px 0px 7px -2px $shadow;
     box-shadow: 2px 0px 7px -2px $shadow;
@@ -98,7 +97,6 @@ export default {
     &.collapsed {
         min-width: $sidebar-collapsed-width;
         max-width: $sidebar-collapsed-width;
-        transition: all 0.15s linear;
 
         #sidebar-toogle-button {
             svg {


### PR DESCRIPTION
Addes these dynamic props:

- dynamiccertificatesmanager.localcertificates.store.path: to enable the local store of acme certificates to specified path

- dynamiccertificatesmanager.localcertificates.peers.ids: to enable the local store for specific peers (default is enabled for all pees)

All acme certificates are dumped in local storage when became  AVAILABLE or when forced from admin (by dumping a specified cert or all of them).

Added support to attach data to zookeeper events.
Also, the column privateKey of digital_certificates table has been dropped.
Finally a fix to maintenance mode , buttons and sidebar styles