### PR TITLE
Inject timestamp formatter in Entry instead of a pattern

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/RequestsLogger.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/RequestsLogger.java
@@ -35,9 +35,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Locale;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -368,7 +369,7 @@ public class RequestsLogger implements Runnable, Closeable {
 
         private final ST format;
 
-        public Entry(final ProxyRequest request, final String format, final SimpleDateFormat tsFormatter) {
+        public Entry(final ProxyRequest request, final String format, final DateTimeFormatter tsFormatter) {
             this.format = new ST(format);
 
             this.format.add("client_ip", request.getRemoteAddress().getAddress().getHostAddress());
@@ -376,7 +377,7 @@ public class RequestsLogger implements Runnable, Closeable {
             this.format.add("method", request.getRequest().method().name());
             this.format.add("host", request.getRequest().requestHeaders().getAsString(HttpHeaderNames.HOST));
             this.format.add("uri", request.getUri());
-            this.format.add("timestamp", tsFormatter.format(new Timestamp(request.getStartTs())));
+            this.format.add("timestamp", tsFormatter.format(Instant.ofEpochMilli(request.getStartTs())));
             this.format.add("total_time", request.getLastActivity() - request.getStartTs());
             this.format.add("action_id", request.getAction().action);
             this.format.add("route_id", request.getAction().routeId);

--- a/carapace-server/src/main/java/org/carapaceproxy/core/RequestsLogger.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/RequestsLogger.java
@@ -214,11 +214,12 @@ public class RequestsLogger implements Runnable, Closeable {
             closeAccessLogFile();
             // File opening will be retried at next cycle start
         }
+        this.currentConfiguration.generateAccessLogTimestampFormatter();
         newConfiguration = null;
     }
 
     public void logRequest(ProxyRequest request) {
-        Entry entry = new Entry(request, currentConfiguration.getAccessLogFormat(), currentConfiguration.getAccessLogTimestampFormat());
+        Entry entry = new Entry(request, currentConfiguration.getAccessLogFormat(), currentConfiguration.getAccessLogTimestampFormatter());
 
         if (closeRequested) {
             LOG.log(Level.SEVERE, "Request {0} not logged to access log because RequestsLogger is closed", entry.render());
@@ -367,9 +368,7 @@ public class RequestsLogger implements Runnable, Closeable {
 
         private final ST format;
 
-        public Entry(ProxyRequest request, String format, String timestampFormat) {
-            SimpleDateFormat tsFormatter = new SimpleDateFormat(timestampFormat);
-
+        public Entry(final ProxyRequest request, final String format, final SimpleDateFormat tsFormatter) {
             this.format = new ST(format);
 
             this.format.add("client_ip", request.getRemoteAddress().getAddress().getHostAddress());

--- a/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
@@ -27,7 +27,6 @@ import java.io.File;
 import java.security.NoSuchAlgorithmException;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -78,9 +77,7 @@ public class RuntimeServerConfiguration {
     private boolean cacheDisabledForSecureRequestsWithoutPublic = false;
     private String mapperClassname;
     private String accessLogPath = "access.log";
-
     private String accessLogTimestampFormat = "yyyy-MM-dd HH:mm:ss.SSS";
-
     private String accessLogFormat =
             "[<timestamp>] [<method> <host> <uri>] [uid:<user_id>, sid:<session_id>, ip:<client_ip>] "
             + "server=<server_ip>, act=<action_id>, route=<route_id>, backend=<backend_id>. "
@@ -437,4 +434,5 @@ public class RuntimeServerConfiguration {
                 .findFirst()
                 .orElse(null);
     }
+
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.security.NoSuchAlgorithmException;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -79,7 +80,7 @@ public class RuntimeServerConfiguration {
     private String accessLogPath = "access.log";
 
     private String accessLogTimestampFormat = "yyyy-MM-dd HH:mm:ss.SSS";
-    private SimpleDateFormat accessLogTimestampFormatter;
+    private DateTimeFormatter accessLogTimestampFormatter;
 
     private String accessLogFormat =
             "[<timestamp>] [<method> <host> <uri>] [uid:<user_id>, sid:<session_id>, ip:<client_ip>] "
@@ -439,6 +440,6 @@ public class RuntimeServerConfiguration {
     }
 
     public void generateAccessLogTimestampFormatter() {
-        this.setAccessLogTimestampFormatter(new SimpleDateFormat(getAccessLogTimestampFormat()));
+        this.setAccessLogTimestampFormatter(DateTimeFormatter.ofPattern(getAccessLogTimestampFormat()));
     }
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
@@ -77,7 +77,10 @@ public class RuntimeServerConfiguration {
     private boolean cacheDisabledForSecureRequestsWithoutPublic = false;
     private String mapperClassname;
     private String accessLogPath = "access.log";
+
     private String accessLogTimestampFormat = "yyyy-MM-dd HH:mm:ss.SSS";
+    private SimpleDateFormat accessLogTimestampFormatter;
+
     private String accessLogFormat =
             "[<timestamp>] [<method> <host> <uri>] [uid:<user_id>, sid:<session_id>, ip:<client_ip>] "
             + "server=<server_ip>, act=<action_id>, route=<route_id>, backend=<backend_id>. "
@@ -435,4 +438,7 @@ public class RuntimeServerConfiguration {
                 .orElse(null);
     }
 
+    public void generateAccessLogTimestampFormatter() {
+        this.setAccessLogTimestampFormatter(new SimpleDateFormat(getAccessLogTimestampFormat()));
+    }
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
@@ -80,7 +80,6 @@ public class RuntimeServerConfiguration {
     private String accessLogPath = "access.log";
 
     private String accessLogTimestampFormat = "yyyy-MM-dd HH:mm:ss.SSS";
-    private DateTimeFormatter accessLogTimestampFormatter;
 
     private String accessLogFormat =
             "[<timestamp>] [<method> <host> <uri>] [uid:<user_id>, sid:<session_id>, ip:<client_ip>] "
@@ -437,9 +436,5 @@ public class RuntimeServerConfiguration {
                 .filter(s -> s.getHost().equalsIgnoreCase(hostPort.host()) && s.getPort() == hostPort.port())
                 .findFirst()
                 .orElse(null);
-    }
-
-    public void generateAccessLogTimestampFormatter() {
-        this.setAccessLogTimestampFormatter(DateTimeFormatter.ofPattern(getAccessLogTimestampFormat()));
     }
 }


### PR DESCRIPTION
* cache a `SimpleDateFormatter` in configuration
* inject the formatter instead of the pattern when building `Entries`

Fixes #394
