### PR TITLE
Fix failing tests

### DIFF
--- a/carapace-server/src/test/java/org/carapaceproxy/backends/ChunkedEncodingResponseTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/ChunkedEncodingResponseTest.java
@@ -20,7 +20,9 @@
 package org.carapaceproxy.backends;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import io.netty.handler.codec.http.HttpHeaderNames;
+import java.util.Objects;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.HttpGet;
@@ -34,13 +36,17 @@ import org.carapaceproxy.utils.TestEndpointMapper;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.TRANSFER_ENCODING;
 import static org.junit.Assert.*;
 
 /**
  * @author enrico.olivelli
  */
+@RunWith(JUnitParamsRunner.class)
 public class ChunkedEncodingResponseTest {
 
     @Rule
@@ -50,7 +56,7 @@ public class ChunkedEncodingResponseTest {
     public TemporaryFolder tmpDir = new TemporaryFolder();
 
     @Test
-    public void testSimpleChunckedResponseNoCache() throws Exception {
+    public void testSimpleChunkedResponseNoCache() throws Exception {
         wireMockRule.stubFor(
                 get(urlEqualTo("/index.html")).
                         willReturn(aResponse()
@@ -62,7 +68,7 @@ public class ChunkedEncodingResponseTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         CarapaceLogger.setLoggingDebugEnabled(true);
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder())) {
             server.start();
             int port = server.getLocalPort();
 
@@ -70,32 +76,41 @@ public class ChunkedEncodingResponseTest {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("12\r\n"
-                        + "it <b>works</b> !!\r\n"
-                        + "0\r\n\r\n"));
-                assertTrue(resp.getBodyString().equals("it <b>works</b> !!"));
+                assertTrue(s.contains("""
+                        12\r
+                        it <b>works</b> !!\r
+                        0\r
+                        \r
+                        """));
+                assertEquals("it <b>works</b> !!", resp.getBodyString());
 
                 resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 System.out.println("s:" + resp);
-                assertTrue(resp.toString().contains("12\r\n"
-                        + "it <b>works</b> !!\r\n"
-                        + "0\r\n\r\n"));
-                assertTrue(resp.getBodyString().equals("it <b>works</b> !!"));
+                assertTrue(resp.toString().contains("""
+                        12\r
+                        it <b>works</b> !!\r
+                        0\r
+                        \r
+                        """));
+                assertEquals("it <b>works</b> !!", resp.getBodyString());
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("12\r\n"
-                        + "it <b>works</b> !!\r\n"
-                        + "0\r\n\r\n"));
+                assertTrue(s.contains("""
+                        12\r
+                        it <b>works</b> !!\r
+                        0\r
+                        \r
+                        """));
             }
             assertEquals(0, server.getCache().getCacheSize());
         }
     }
 
     @Test
-    public void testSimpleChunckedResponseWithCache() throws Exception {
+    public void testSimpleChunkedResponseWithCache() throws Exception {
         wireMockRule.stubFor(
                 get(urlEqualTo("/index.html")).
                         willReturn(aResponse()
@@ -106,36 +121,46 @@ public class ChunkedEncodingResponseTest {
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.port(), true);
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder())) {
             server.start();
             int port = server.getLocalPort();
+            resetCache(server);
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client
                         .executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("12\r\n"
-                        + "it <b>works</b> !!\r\n"
-                        + "0\r\n\r\n"));
-                assertTrue(resp.getBodyString().equals("it <b>works</b> !!"));
+                assertTrue(s.contains("""
+                        12\r
+                        it <b>works</b> !!\r
+                        0\r
+                        \r
+                        """));
+                assertEquals("it <b>works</b> !!", resp.getBodyString());
 
                 resp = client
                         .executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 System.out.println("s:" + resp);
-                assertTrue(resp.toString().contains("12\r\n"
-                        + "it <b>works</b> !!\r\n"
-                        + "0\r\n\r\n"));
-                assertTrue(resp.getBodyString().equals("it <b>works</b> !!"));
+                assertTrue(resp.toString().contains("""
+                        12\r
+                        it <b>works</b> !!\r
+                        0\r
+                        \r
+                        """));
+                assertEquals("it <b>works</b> !!", resp.getBodyString());
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client
                         .executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("12\r\n"
-                        + "it <b>works</b> !!\r\n"
-                        + "0\r\n\r\n"));
+                assertTrue(s.contains("""
+                        12\r
+                        it <b>works</b> !!\r
+                        0\r
+                        \r
+                        """));
             }
             assertEquals(1, server.getCache().getCacheSize());
             assertEquals(2, server.getCache().getStats().getHits());
@@ -145,7 +170,8 @@ public class ChunkedEncodingResponseTest {
 
 
     @Test
-    public void testChunkedHttp10() throws Exception {
+    @Parameters(method = "parametersForChunkedHttp10Test")
+    public void testChunkedHttp(final HttpVersion httpVersion, final boolean inCache) throws Exception {
         wireMockRule.stubFor(
                 get(urlEqualTo("/index.html")).
                         willReturn(aResponse()
@@ -156,63 +182,58 @@ public class ChunkedEncodingResponseTest {
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.port(), true);
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
-        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
+        try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder())) {
             server.start();
             int port = server.getLocalPort();
-
             server.getCurrentConfiguration().setHttp10BackwardCompatibilityEnabled(true);
+            resetCache(server);
 
-            CloseableHttpClient httpclient = HttpClients.createDefault();
-            HttpGet request = new HttpGet("http://localhost:" + port + "/index.html");
-            request.setProtocolVersion(HttpVersion.HTTP_1_1);
-            HttpResponse httpresponse = httpclient.execute(request);
+            try (CloseableHttpClient client = HttpClients.createDefault()) {
+                if (inCache) {
+                    HttpGet request = new HttpGet("http://localhost:" + port + "/index.html");
+                    request.setProtocolVersion(httpVersion);
+                    client.execute(request);
+                }
 
-            assertEquals("chunked",
-                    httpresponse.getFirstHeader(String.valueOf(HttpHeaderNames.TRANSFER_ENCODING)).getValue());
-            assertNull(httpresponse.getFirstHeader(String.valueOf(HttpHeaderNames.CONTENT_LENGTH)));
+                HttpGet request = new HttpGet("http://localhost:" + port + "/index.html");
+                request.setProtocolVersion(httpVersion);
+                HttpResponse response = client.execute(request);
 
-            server.getCache().getStats().resetCacheMetrics();
-            server.getCache().clear();
-            assertEquals(0, server.getCache().getCacheSize());
-            assertEquals(0, server.getCache().getStats().getHits());
-
-            request.setProtocolVersion(HttpVersion.HTTP_1_0);
-            httpresponse = httpclient.execute(request);
-
-            assertNull(httpresponse.getFirstHeader(String.valueOf(HttpHeaderNames.TRANSFER_ENCODING)));
-            assertNotNull(httpresponse.getFirstHeader(String.valueOf(HttpHeaderNames.CONTENT_LENGTH)));
-            assertNull(httpresponse.getFirstHeader("X-cached"));
-
-            //File must be in cache
-            assertEquals(1, server.getCache().getCacheSize());
-
-            CloseableHttpClient httpclient2 = HttpClients.createDefault();
-
-            request.setProtocolVersion(HttpVersion.HTTP_1_1);
-            httpresponse = httpclient2.execute(request);
-
-            //Response must come from cache
-            assertEquals(1, server.getCache().getStats().getHits());
-
-            //Http 1.1 chunked encoding
-            assertEquals("chunked",
-                    httpresponse.getFirstHeader(String.valueOf(HttpHeaderNames.TRANSFER_ENCODING)).getValue());
-            assertNull(httpresponse.getFirstHeader(String.valueOf(HttpHeaderNames.CONTENT_LENGTH)));
-            assertNotNull(httpresponse.getFirstHeader("X-cached"));
-
-
-            request.setProtocolVersion(HttpVersion.HTTP_1_0);
-            httpresponse = httpclient2.execute(request);
-
-            //Response must come from cache
-            assertEquals(2, server.getCache().getStats().getHits());
-            //Http 1.0 no chunked encoding
-            assertNull(httpresponse.getFirstHeader(String.valueOf(HttpHeaderNames.TRANSFER_ENCODING)));
-            assertNotNull(httpresponse.getFirstHeader(String.valueOf(HttpHeaderNames.CONTENT_LENGTH)));
-            assertNotNull(httpresponse.getFirstHeader("X-cached"));
+                if (Objects.equals(httpVersion, HttpVersion.HTTP_1_0)) {
+                    assertNull(response.getFirstHeader(TRANSFER_ENCODING.toString()));
+                    assertNotNull(response.getFirstHeader(CONTENT_LENGTH.toString()));
+                } else {
+                    assertEquals("chunked", response.getFirstHeader(TRANSFER_ENCODING.toString()).getValue());
+                    assertNull(response.getFirstHeader(CONTENT_LENGTH.toString()));
+                }
+                if (inCache) {
+                    assertNotNull(response.getFirstHeader("X-cached"));
+                    assertEquals(1, server.getCache().getStats().getHits());
+                } else {
+                    assertNull(response.getFirstHeader("X-cached"));
+                    assertEquals(0, server.getCache().getStats().getHits());
+                }
+            }
 
         }
     }
 
+    private static void resetCache(final HttpProxyServer server) {
+        server.getCache().reloadConfiguration(server.getCurrentConfiguration());
+        server.getCache().getStats().resetCacheMetrics();
+        server.getCache().clear();
+        assertEquals(0, server.getCache().getCacheSize());
+        assertEquals(0, server.getCache().getStats().getHits());
+        assertEquals(0, server.getCache().getStats().getMisses());
+    }
+
+    public static Object[] parametersForChunkedHttp10Test() {
+        return new Object[] {
+                new Object[] { HttpVersion.HTTP_1_0, false },
+                new Object[] { HttpVersion.HTTP_1_0, true },
+                new Object[] { HttpVersion.HTTP_1_1, false },
+                new Object[] { HttpVersion.HTTP_1_1, true },
+        };
+    }
 
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
@@ -487,7 +487,7 @@ public class BasicStandardEndpointMapperTest {
     }
 
     @Test
-    public void testCustomAndDebbugingHeaders() throws Exception {
+    public void testCustomAndDebuggingHeaders() throws Exception {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(200)

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <!-- test dependecies -->
         <libs.junit>4.13.2</libs.junit>
         <libs.junitparams>1.1.1</libs.junitparams>
-        <libs.wiremock>2.32.0</libs.wiremock>
+        <libs.wiremock>2.35.0</libs.wiremock>
         <libs.powermock>2.0.9</libs.powermock>
         <libs.mockito>3.12.4</libs.mockito>
         <libs.hamcrest>2.2</libs.hamcrest>


### PR DESCRIPTION
* update WireMock
* fix `org.carapaceproxy.backends.ChunkedEncodingResponseTest`
* fix `org.carapaceproxy.server.mapper.BasicStandardEndpointMapperTest`

This fixes #397