### PR TITLE
Use Epol EpollEventLoopGroup if supported by OS

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/api/ConnectionPoolsResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/ConnectionPoolsResource.java
@@ -63,6 +63,7 @@ public class ConnectionPoolsResource {
         private int keepaliveIdle;
         private int keepaliveInterval;
         private int keepaliveCount;
+        private boolean keepAlive;
         private boolean enabled;
 
         private int totalConnections;
@@ -95,6 +96,7 @@ public class ConnectionPoolsResource {
                     conf.getKeepaliveIdle(),
                     conf.getKeepaliveInterval(),
                     conf.getKeepaliveCount(),
+                    conf.isKeepAlive(),
                     conf.isEnabled(),
                     poolsStats.getOrDefault(conf.getId(), 0)
             );
@@ -116,6 +118,7 @@ public class ConnectionPoolsResource {
                 defaultConnectionPool.getKeepaliveIdle(),
                 defaultConnectionPool.getKeepaliveInterval(),
                 defaultConnectionPool.getKeepaliveCount(),
+                defaultConnectionPool.isKeepAlive(),
                 defaultConnectionPool.isEnabled(),
                 poolsStats.getOrDefault(defaultConnectionPool.getId(), 0)
         ));

--- a/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
@@ -27,6 +27,9 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.OpenSslCachingX509KeyManagerFactory;
@@ -223,6 +226,7 @@ public class Listeners {
                 .metrics(true, Function.identity())
                 .option(ChannelOption.SO_BACKLOG, 128)
                 .childOption(ChannelOption.SO_KEEPALIVE, true)
+                .runOn(Epoll.isAvailable() ? new EpollEventLoopGroup() : new NioEventLoopGroup())
                 .doOnChannelInit((observer, channel, remoteAddress) -> {
                     channel.pipeline().addFirst("idleStateHandler", new IdleStateHandler(0, 0, currentConfiguration.getClientsIdleTimeoutSeconds()));
                     if (config.isSsl()) {

--- a/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
@@ -28,8 +28,10 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioChannelOption;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.OpenSslCachingX509KeyManagerFactory;
@@ -66,6 +68,8 @@ import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.net.ssl.KeyManagerFactory;
+
+import jdk.net.ExtendedSocketOptions;
 import lombok.Data;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
@@ -224,11 +228,21 @@ public class Listeners {
                 .port(hostPort.port())
                 //.protocol(HttpProtocol.H2) // HTTP/2.0 setup
                 .metrics(true, Function.identity())
-                .option(ChannelOption.SO_BACKLOG, 128)
-                .childOption(ChannelOption.SO_KEEPALIVE, true)
+                .option(ChannelOption.SO_BACKLOG, config.getSoBacklog())
+                .childOption(ChannelOption.SO_KEEPALIVE, config.isKeepAlive())
                 .runOn(Epoll.isAvailable() ? new EpollEventLoopGroup() : new NioEventLoopGroup())
+                .childOption(Epoll.isAvailable()
+                        ? EpollChannelOption.TCP_KEEPIDLE
+                        : NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPIDLE), config.getKeepAliveIdle())
+                .childOption(Epoll.isAvailable()
+                        ? EpollChannelOption.TCP_KEEPINTVL
+                        : NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPINTERVAL), config.getKeepAliveInterval())
+                .childOption(Epoll.isAvailable()
+                        ? EpollChannelOption.TCP_KEEPCNT
+                        : NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPCOUNT), config.getKeepAliveCount())
+                .idleTimeout(Duration.ofMillis(currentConfiguration.getIdleTimeout()))
+                .maxKeepAliveRequests(config.getMaxKeepAliveRequests())
                 .doOnChannelInit((observer, channel, remoteAddress) -> {
-                    channel.pipeline().addFirst("idleStateHandler", new IdleStateHandler(0, 0, currentConfiguration.getClientsIdleTimeoutSeconds()));
                     if (config.isSsl()) {
                         SniHandler sni = new SniHandler(listeningChannel) {
                             @Override

--- a/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
@@ -240,9 +240,9 @@ public class Listeners {
                 .childOption(Epoll.isAvailable()
                         ? EpollChannelOption.TCP_KEEPCNT
                         : NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPCOUNT), config.getKeepAliveCount())
-                .idleTimeout(Duration.ofMillis(currentConfiguration.getIdleTimeout()))
                 .maxKeepAliveRequests(config.getMaxKeepAliveRequests())
                 .doOnChannelInit((observer, channel, remoteAddress) -> {
+                    channel.pipeline().addFirst("idleStateHandler", new IdleStateHandler(0, 0, currentConfiguration.getClientsIdleTimeoutSeconds()));
                     if (config.isSsl()) {
                         SniHandler sni = new SniHandler(listeningChannel) {
                             @Override

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -353,7 +353,7 @@ public class ProxyRequestsManager {
                     .compress(parent.getCurrentConfiguration().isRequestCompressionEnabled())
                     .responseTimeout(Duration.ofMillis(connectionConfig.getStuckRequestTimeout()))
                     .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectionConfig.getConnectTimeout())
-                    .option(ChannelOption.SO_KEEPALIVE, true) // Enables TCP keepalive: TCP starts sending keepalive probes when a connection is idle for some time.
+                    .option(ChannelOption.SO_KEEPALIVE, connectionConfig.isKeepAlive()) // Enables TCP keepalive: TCP starts sending keepalive probes when a connection is idle for some time.
                     .option(Epoll.isAvailable()
                             ? EpollChannelOption.TCP_KEEPIDLE
                             : NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPIDLE), connectionConfig.getKeepaliveIdle())

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -25,6 +25,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollChannelOption;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioChannelOption;
 import io.netty.handler.codec.http.*;
 import io.prometheus.client.Counter;
@@ -347,6 +349,7 @@ public class ProxyRequestsManager {
                     .host(endpointHost)
                     .port(endpointPort)
                     .followRedirect(false) // client has to request the redirect, not the proxy
+                    .runOn(Epoll.isAvailable() ? new EpollEventLoopGroup() : new NioEventLoopGroup())
                     .compress(parent.getCurrentConfiguration().isRequestCompressionEnabled())
                     .responseTimeout(Duration.ofMillis(connectionConfig.getStuckRequestTimeout()))
                     .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectionConfig.getConnectTimeout())

--- a/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
@@ -69,9 +69,13 @@ public class RuntimeServerConfiguration {
     private int connectTimeout = 10_000;
     private int borrowTimeout = 60_000;
     private int disposeTimeout = 300_000; // 5 min;
+    private int soBacklog = 128;
     private int keepaliveIdle = 300; // sec
     private int keepaliveInterval = 60; // sec
     private int keepaliveCount = 8;
+    private boolean clientKeepAlive = true;
+    private boolean serverKeepAlive = true;
+    private int maxKeepAliveRequests = 1000;
     private long cacheMaxSize = 0;
     private long cacheMaxFileSize = 0;
     private boolean cacheDisabledForSecureRequestsWithoutPublic = false;
@@ -120,6 +124,7 @@ public class RuntimeServerConfiguration {
                 keepaliveIdle,
                 keepaliveInterval,
                 keepaliveCount,
+                true,
                 true
         );
     }
@@ -297,7 +302,14 @@ public class RuntimeServerConfiguration {
                         properties.getBoolean(prefix + "ssl", false),
                         properties.getString(prefix + "sslciphers", ""),
                         properties.getString(prefix + "defaultcertificate", "*"),
-                        properties.getValues(prefix + "sslprotocols", DEFAULT_SSL_PROTOCOLS)
+                        properties.getValues(prefix + "sslprotocols", DEFAULT_SSL_PROTOCOLS),
+                        properties.getInt(prefix + "sobacklog", soBacklog),
+                        properties.getBoolean(prefix + "keepalive",  serverKeepAlive),
+                        properties.getInt(prefix + "keepaliveidle", keepaliveIdle),
+                        properties.getInt(prefix + "keepaliveinterval", keepaliveInterval),
+                        properties.getInt(prefix + "keepalivecount", keepaliveCount),
+                        properties.getInt(prefix + "maxkeepaliverequests", maxKeepAliveRequests)
+
                 ));
             }
         }
@@ -347,6 +359,7 @@ public class RuntimeServerConfiguration {
             int keepaliveinterval = properties.getInt(prefix + "keepaliveinterval", keepaliveInterval);
             int keepalivecount = properties.getInt(prefix + "keepalivecount", keepaliveCount);
             boolean enabled = properties.getBoolean(prefix + "enabled", false);
+            boolean keepAlive = properties.getBoolean(prefix + "keepalive", true);
 
             ConnectionPoolConfiguration connectionPool = new ConnectionPoolConfiguration(
                     id, domain,
@@ -359,6 +372,7 @@ public class RuntimeServerConfiguration {
                     keepaliveidle,
                     keepaliveinterval,
                     keepalivecount,
+                    keepAlive,
                     enabled
             );
             connectionPools.add(connectionPool);
@@ -377,6 +391,7 @@ public class RuntimeServerConfiguration {
                 getKeepaliveIdle(),
                 getKeepaliveInterval(),
                 getKeepaliveCount(),
+                isClientKeepAlive(),
                 true
         );
         LOG.log(Level.INFO, "Configured default connectionpool: {0}", defaultConnectionPool);

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/ConnectionPoolConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/ConnectionPoolConfiguration.java
@@ -40,6 +40,7 @@ public class ConnectionPoolConfiguration {
     private int keepaliveIdle;
     private int keepaliveInterval;
     private int keepaliveCount;
+    private boolean keepAlive;
 
     private boolean enabled;
 

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/NetworkListenerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/NetworkListenerConfiguration.java
@@ -37,6 +37,12 @@ public class NetworkListenerConfiguration {
     private final String sslCiphers;
     private final String defaultCertificate;
     private Set<String> sslProtocols = Collections.emptySet();
+    private int soBacklog;
+    private boolean keepAlive;
+    private int keepAliveIdle;
+    private int keepAliveInterval;
+    private int keepAliveCount;
+    private int maxKeepAliveRequests;
 
     public HostPort getKey() {
         return new HostPort(host, port);
@@ -45,15 +51,8 @@ public class NetworkListenerConfiguration {
     public record HostPort(String host, int port) {}
 
     public NetworkListenerConfiguration(String host, int port) {
-        this(host, port, false, null, null, Collections.emptySet());
-    }
-
-    public NetworkListenerConfiguration(String host,
-                                        int port,
-                                        boolean ssl,
-                                        String sslCiphers,
-                                        String defaultCertificate) {
-        this(host, port, ssl, sslCiphers, defaultCertificate, DEFAULT_SSL_PROTOCOLS);
+        this(host, port, false, null, null, Collections.emptySet(),
+                128,true, 300, 60, 8, 1000);
     }
 
     public NetworkListenerConfiguration(String host,
@@ -61,7 +60,28 @@ public class NetworkListenerConfiguration {
                                         boolean ssl,
                                         String sslCiphers,
                                         String defaultCertificate,
-                                        Set<String> sslProtocols) {
+                                        int soBacklog,
+                                        boolean keepAlive,
+                                        int keepAliveIdle,
+                                        int keepAliveInterval,
+                                        int keepAliveCount,
+                                        int maxKeepAliveRequests) {
+        this(host, port, ssl, sslCiphers, defaultCertificate, DEFAULT_SSL_PROTOCOLS,
+                soBacklog, keepAlive, keepAliveIdle, keepAliveInterval, keepAliveCount, maxKeepAliveRequests);
+    }
+
+    public NetworkListenerConfiguration(String host,
+                                        int port,
+                                        boolean ssl,
+                                        String sslCiphers,
+                                        String defaultCertificate,
+                                        Set<String> sslProtocols,
+                                        int soBacklog,
+                                        boolean keepAlive,
+                                        int keepAliveIdle,
+                                        int keepAliveInterval,
+                                        int keepAliveCount,
+                                        int maxKeepAliveRequests) {
         this.host = host;
         this.port = port;
         this.ssl = ssl;
@@ -70,6 +90,12 @@ public class NetworkListenerConfiguration {
         if (ssl) {
             this.sslProtocols = sslProtocols;
         }
+        this.soBacklog = soBacklog;
+        this.keepAlive = keepAlive;
+        this.keepAliveIdle = keepAliveIdle;
+        this.keepAliveInterval = keepAliveInterval;
+        this.keepAliveCount = keepAliveCount;
+        this.maxKeepAliveRequests = maxKeepAliveRequests;
     }
 
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/RawClientTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/RawClientTest.java
@@ -739,7 +739,8 @@ public class RawClientTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot());) {
             server.addCertificate(new SSLCertificateConfiguration("localhost", null, "localhost.p12", "testproxy", STATIC));
-            server.addListener(new NetworkListenerConfiguration("localhost", 0, scheme.equals("https"), null, "localhost"));
+            server.addListener(new NetworkListenerConfiguration("localhost", 0, scheme.equals("https"), null, "localhost", 128,
+                    true, 300, 60, 8, 100));
 
             server.start();
             int port = server.getLocalPort();

--- a/carapace-server/src/test/java/org/carapaceproxy/SimpleHTTPProxyTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/SimpleHTTPProxyTest.java
@@ -108,7 +108,7 @@ public class SimpleHTTPProxyTest {
 
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot());) {
             server.addCertificate(new SSLCertificateConfiguration("localhost", null, certificate, "changeit", STATIC));
-            server.addListener(new NetworkListenerConfiguration("localhost", 0, true, null, "localhost"));
+            server.addListener(new NetworkListenerConfiguration("localhost", 0, true, null, "localhost", 128, true, 300, 60, 8, 1000));
             server.start();
             int port = server.getLocalPort();
 

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/ConnectionPoolTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/ConnectionPoolTest.java
@@ -165,7 +165,7 @@ public class ConnectionPoolTest extends UseAdminServer {
 
         // default pool
         ConnectionPoolConfiguration defaultPool = new ConnectionPoolConfiguration(
-                "*", "*", 10, 5_000, 10_000, 15_000, 20_000, 50_000, 500, 50, 5, true
+                "*", "*", 10, 5_000, 10_000, 15_000, 20_000, 50_000, 500, 50, 5, true,true
         );
         {
             ConnectionProvider provider = connectionPools.get(defaultPool);
@@ -177,7 +177,7 @@ public class ConnectionPoolTest extends UseAdminServer {
 
         // pool with defaults
         ConnectionPoolConfiguration poolWithDefaults = new ConnectionPoolConfiguration(
-                "localhost", "localhost", 10, 5_000, 10_000, 15_000, 20_000, 50_000, 500, 50, 5, true
+                "localhost", "localhost", 10, 5_000, 10_000, 15_000, 20_000, 50_000, 500, 50, 5, true, true
         );
         {
             ConnectionProvider provider = connectionPools.get(poolWithDefaults);
@@ -189,7 +189,7 @@ public class ConnectionPoolTest extends UseAdminServer {
 
         // custom pool
         ConnectionPoolConfiguration customPool = new ConnectionPoolConfiguration(
-                "localhosts", "localhost[0-9]", 20, 21_000, 22_000, 23_000, 24_000, 25_000, 250, 25, 2, true
+                "localhosts", "localhost[0-9]", 20, 21_000, 22_000, 23_000, 24_000, 25_000, 250, 25, 2, true,true
         );
         {
             ConnectionProvider provider = connectionPools.get(customPool);
@@ -294,22 +294,22 @@ public class ConnectionPoolTest extends UseAdminServer {
 
             // default pool
             assertThat(pools.get("*"), is(new ConnectionPoolsResource.ConnectionPoolBean(
-                    "*", "*", 10, 5_000, 10_000, 15_000, 20_000, 50_000, 500, 50, 5, true, 0
+                    "*", "*", 10, 5_000, 10_000, 15_000, 20_000, 50_000, 500, 50, 5, true,true, 0
             )));
 
             // pool with defaults
             assertThat(pools.get("localhost"), is(new ConnectionPoolsResource.ConnectionPoolBean(
-                    "localhost", "localhost", 10, 5_000, 10_000, 15_000, 20_000, 50_000, 500, 50, 5, true, 1
+                    "localhost", "localhost", 10, 5_000, 10_000, 15_000, 20_000, 50_000, 500, 50, 5, true,true, 1
             )));
 
             // disabled custom pool
             assertThat(pools.get("localhost2"), is(new ConnectionPoolsResource.ConnectionPoolBean(
-                    "localhost2", "localhost2", 10, 5_000, 10_000, 15_000, 20_000, 50_000, 500, 50, 5, false, 0
+                    "localhost2", "localhost2", 10, 5_000, 10_000, 15_000, 20_000, 50_000, 500, 50, 5, true, false, 0
             )));
 
             // custom pool
             assertThat(pools.get("localhosts"), is(new ConnectionPoolsResource.ConnectionPoolBean(
-                    "localhosts", "localhost[0-9]", 20, 21_000, 22_000, 23_000, 24_000, 25_000, 250, 25, 2, true, 0
+                    "localhosts", "localhost[0-9]", 20, 21_000, 22_000, 23_000, 24_000, 25_000, 250, 25, 2, true, true, 0
             )));
         }
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/listeners/ListenerConfigurationTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/listeners/ListenerConfigurationTest.java
@@ -1,0 +1,138 @@
+package org.carapaceproxy.listeners;
+
+import org.carapaceproxy.configstore.PropertiesConfigurationStore;
+import org.carapaceproxy.core.HttpProxyServer;
+import org.carapaceproxy.core.Listeners;
+import org.carapaceproxy.server.config.ConfigurationChangeInProgressException;
+import org.carapaceproxy.server.config.NetworkListenerConfiguration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ListenerConfigurationTest {
+
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
+
+    @Test
+    public void testListenerKeepAliveConfiguration() throws Exception {
+        try (HttpProxyServer server = new HttpProxyServer(null, tmpDir.newFolder());) {
+
+            {
+                Properties configuration = new Properties();
+                configuration.put("listener.1.host", "localhost");
+                configuration.put("listener.1.port", "8080");
+                configuration.put("listener.1.enabled", "true");
+
+                server.configureAtBoot(new PropertiesConfigurationStore(configuration));
+            }
+            server.start();
+
+            NetworkListenerConfiguration.HostPort listenerKey =
+                    new NetworkListenerConfiguration.HostPort("localhost", 8080);
+
+            {
+                Map<NetworkListenerConfiguration.HostPort, Listeners.ListeningChannel> listeners =
+                        server.getListeners().getListeningChannels();
+
+                //check default configuration
+                assertEquals(true, listeners.get(listenerKey).getConfig().isKeepAlive());
+                assertEquals(128, listeners.get(listenerKey).getConfig().getSoBacklog());
+                assertEquals(300, listeners.get(listenerKey).getConfig().getKeepAliveIdle());
+                assertEquals(60, listeners.get(listenerKey).getConfig().getKeepAliveInterval());
+                assertEquals(8, listeners.get(listenerKey).getConfig().getKeepAliveCount());
+                assertEquals(1000, listeners.get(listenerKey).getConfig().getMaxKeepAliveRequests());
+            }
+            //disable keepAlive
+            {
+                Properties configuration = new Properties();
+                configuration.put("listener.1.host", "localhost");
+                configuration.put("listener.1.port", "8080");
+                configuration.put("listener.1.keepalive", "false");
+                configuration.put("listener.1.enabled", "true");
+
+                reloadConfiguration(configuration, server);
+
+                Map<NetworkListenerConfiguration.HostPort, Listeners.ListeningChannel> listeners =
+                        server.getListeners().getListeningChannels();
+
+                assertEquals(1, listeners.size());
+                assertEquals(false, listeners.get(listenerKey).getConfig().isKeepAlive());
+            }
+
+            //customize keepAlive options
+            {
+                Properties configuration = new Properties();
+                // SSL Listener
+                configuration.put("listener.1.host", "localhost");
+                configuration.put("listener.1.port", "8080");
+                configuration.put("listener.1.keepalive", "true");
+                configuration.put("listener.1.keepaliveidle", "10");
+                configuration.put("listener.1.keepaliveinterval", "5");
+                configuration.put("listener.1.keepalivecount", "2");
+                configuration.put("listener.1.maxkeepaliverequests", "2");
+                configuration.put("listener.1.sobacklog", "10");
+                configuration.put("listener.1.enabled", "true");
+                reloadConfiguration(configuration, server);
+
+                Map<NetworkListenerConfiguration.HostPort, Listeners.ListeningChannel> listeners =
+                        server.getListeners().getListeningChannels();
+
+                assertEquals(true, listeners.get(listenerKey).getConfig().isKeepAlive());
+                assertEquals(10, listeners.get(listenerKey).getConfig().getSoBacklog());
+                assertEquals(10, listeners.get(listenerKey).getConfig().getKeepAliveIdle());
+                assertEquals(5, listeners.get(listenerKey).getConfig().getKeepAliveInterval());
+                assertEquals(2, listeners.get(listenerKey).getConfig().getKeepAliveCount());
+                assertEquals(2, listeners.get(listenerKey).getConfig().getMaxKeepAliveRequests());
+            }
+
+            //negative maxkeepAliverequests
+            // value accepted -1, 1, >0
+            {
+                try {
+                    Properties configuration = new Properties();
+                    configuration.put("listener.1.host", "localhost");
+                    configuration.put("listener.1.port", "8080");
+                    configuration.put("listener.1.keepalive", "true");
+                    configuration.put("listener.1.maxkeepaliverequests", "-10"); // negative value not valid
+                    configuration.put("listener.1.enabled", "true");
+
+                    reloadConfiguration(configuration, server);
+
+                } catch (IllegalArgumentException e) {
+                    assertTrue(e.getMessage().contains("maxKeepAliveRequests must be positive or -1"));
+                }
+            }
+
+            // maxkeepAliverequests = 0
+            // value accepted -1, 1, >0
+            {
+                try {
+                    Properties configuration = new Properties();
+                    configuration.put("listener.1.host", "localhost");
+                    configuration.put("listener.1.port", "8080");
+                    configuration.put("listener.1.keepalive", "true");
+                    configuration.put("listener.1.maxkeepaliverequests", "0"); //0 is not valid
+                    configuration.put("listener.1.enabled", "true");
+
+                    reloadConfiguration(configuration, server);
+
+                } catch (IllegalArgumentException e) {
+                    assertTrue(e.getMessage().contains("maxKeepAliveRequests must be positive or -1"));
+                }
+            }
+        }
+    }
+
+    private void reloadConfiguration(Properties configuration, final HttpProxyServer server) throws
+            ConfigurationChangeInProgressException, InterruptedException {
+        PropertiesConfigurationStore config = new PropertiesConfigurationStore(configuration);
+        server.applyDynamicConfigurationFromAPI(config);
+    }
+}

--- a/carapace-server/src/test/java/org/carapaceproxy/listeners/SSLSNITest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/listeners/SSLSNITest.java
@@ -74,7 +74,7 @@ public class SSLSNITest {
             server.addCertificate(new SSLCertificateConfiguration(nonLocalhost, null, certificate, "testproxy", STATIC));
             server.addListener(new NetworkListenerConfiguration(nonLocalhost, 0, true, null, nonLocalhost /*
                      * default
-                     */));
+                     */, 128, true, 300, 60, 8, 1000));
             server.start();
             int port = server.getLocalPort();
 
@@ -160,7 +160,8 @@ public class SSLSNITest {
         // TLS 1.3 support checking
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot())) {
             server.addCertificate(new SSLCertificateConfiguration(nonLocalhost, null, certificate, "testproxy", STATIC));
-            server.addListener(new NetworkListenerConfiguration(nonLocalhost, 0, true, null, nonLocalhost, Set.of("TLSv1.3")));
+            server.addListener(new NetworkListenerConfiguration(nonLocalhost, 0, true, null, nonLocalhost, Set.of("TLSv1.3"),
+                    128, true, 300, 60, 8, 1000));
             server.start();
             int port = server.getLocalPort();
             try (RawHttpClient client = new RawHttpClient(nonLocalhost, port, true, nonLocalhost)) {
@@ -175,7 +176,8 @@ public class SSLSNITest {
         for (String proto : DEFAULT_SSL_PROTOCOLS) {
             try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot())) {
                 server.addCertificate(new SSLCertificateConfiguration(nonLocalhost, null, certificate, "testproxy", STATIC));
-                server.addListener(new NetworkListenerConfiguration(nonLocalhost, 0, true, null, nonLocalhost, Set.of(proto)));
+                server.addListener(new NetworkListenerConfiguration(nonLocalhost, 0, true, null, nonLocalhost, Set.of(proto),
+                        128, true, 300, 60, 8, 1000));
                 server.start();
                 int port = server.getLocalPort();
                 try (RawHttpClient client = new RawHttpClient(nonLocalhost, port, true, nonLocalhost)) {
@@ -188,7 +190,8 @@ public class SSLSNITest {
         }
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot())) {
             server.addCertificate(new SSLCertificateConfiguration(nonLocalhost, null, certificate, "testproxy", STATIC));
-            server.addListener(new NetworkListenerConfiguration(nonLocalhost, 0, true, null, nonLocalhost));
+            server.addListener(new NetworkListenerConfiguration(nonLocalhost, 0, true, null, nonLocalhost,
+                    128, true, 300, 60, 8, 1000));
             server.start();
             int port = server.getLocalPort();
             try (RawHttpClient client = new RawHttpClient(nonLocalhost, port, true, nonLocalhost)) {
@@ -203,7 +206,8 @@ public class SSLSNITest {
         TestUtils.assertThrows(ConfigurationNotValidException.class, () -> {
             try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot())) {
                 server.addCertificate(new SSLCertificateConfiguration(nonLocalhost, null, certificate, "testproxy", STATIC));
-                server.addListener(new NetworkListenerConfiguration(nonLocalhost, 0, true, null, nonLocalhost, Set.of("TLSvWRONG")));
+                server.addListener(new NetworkListenerConfiguration(nonLocalhost, 0, true, null, nonLocalhost, Set.of("TLSvWRONG"),
+                        128, true, 300, 60, 8, 1000));
             }
         });
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheTest.java
@@ -204,7 +204,8 @@ public class CacheTest {
         EndpointStats stats;
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot());) {
             server.addCertificate(new SSLCertificateConfiguration("localhost", null, "localhost.p12", "testproxy", STATIC));
-            server.addListener(new NetworkListenerConfiguration("localhost", 0, true, null, "localhost"));
+            server.addListener(new NetworkListenerConfiguration("localhost", 0, true, null, "localhost",
+                    128, true, 300, 60, 8, 1000));
             server.start();
         }
     }
@@ -227,7 +228,8 @@ public class CacheTest {
 
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot());) {
             server.addCertificate(new SSLCertificateConfiguration("localhost", null, "localhost.p12", "testproxy", STATIC));
-            server.addListener(new NetworkListenerConfiguration("localhost", 0, true, null, "localhost"));
+            server.addListener(new NetworkListenerConfiguration("localhost", 0, true, null, "localhost",
+                    128, true, 300, 60, 8, 1000));
 
             RuntimeServerConfiguration currentConfiguration = server.getCurrentConfiguration();
             currentConfiguration.setCacheDisabledForSecureRequestsWithoutPublic(cacheDisabledForSecureRequestsWithoutPublic);
@@ -358,7 +360,8 @@ public class CacheTest {
 
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot());) {
             server.addCertificate(new SSLCertificateConfiguration("localhost", null, "localhost.p12", "testproxy", STATIC));
-            server.addListener(new NetworkListenerConfiguration("localhost", httpsPort, true, null, "localhost"));
+            server.addListener(new NetworkListenerConfiguration("localhost", httpsPort, true, null, "localhost",
+                    128, true, 300, 60, 8, 1000));
             server.addListener(new NetworkListenerConfiguration("localhost", httpPort));
             server.start();
             server.getCache().getStats().resetCacheMetrics();

--- a/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsCipherFilterTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsCipherFilterTest.java
@@ -57,7 +57,8 @@ public class XTlsCipherFilterTest {
             server.addCertificate(new SSLCertificateConfiguration("*", null, certificate, "testproxy", STATIC));
             server.addRequestFilter(new RequestFilterConfiguration(XTlsCipherRequestFilter.TYPE, Collections.emptyMap()));
             server.addRequestFilter(new RequestFilterConfiguration(XTlsProtocolRequestFilter.TYPE, Collections.emptyMap()));
-            server.addListener(new NetworkListenerConfiguration("0.0.0.0", 0, true, null, "*", Set.of("TLSv1.2")));
+            server.addListener(new NetworkListenerConfiguration("0.0.0.0", 0, true, null, "*", Set.of("TLSv1.2"),
+                    128, true, 300, 60, 8, 1000));
             server.start();
             int port = server.getLocalPort();
 
@@ -71,7 +72,8 @@ public class XTlsCipherFilterTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder())) {
             server.addCertificate(new SSLCertificateConfiguration("*", null, certificate, "testproxy", STATIC));
             server.addRequestFilter(new RequestFilterConfiguration(XTlsProtocolRequestFilter.TYPE, Collections.emptyMap()));
-            server.addListener(new NetworkListenerConfiguration("0.0.0.0", 0, true, null, "*", Set.of("TLSv1.2")));
+            server.addListener(new NetworkListenerConfiguration("0.0.0.0", 0, true, null, "*", Set.of("TLSv1.2"),
+                    128, true, 300, 60, 8, 1000));
             server.start();
             int port = server.getLocalPort();
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsProtocolFilterTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsProtocolFilterTest.java
@@ -55,7 +55,8 @@ public class XTlsProtocolFilterTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder())) {
             server.addCertificate(new SSLCertificateConfiguration("*", null, certificate, "testproxy", STATIC));
             server.addRequestFilter(new RequestFilterConfiguration(XTlsProtocolRequestFilter.TYPE, Collections.emptyMap()));
-            server.addListener(new NetworkListenerConfiguration("0.0.0.0", 0, true, null, "*", Set.of("TLSv1.2")));
+            server.addListener(new NetworkListenerConfiguration("0.0.0.0", 0, true, null, "*", Set.of("TLSv1.2"),
+                    128, true, 300, 60, 8, 1000));
             server.start();
             int port = server.getLocalPort();
 
@@ -68,7 +69,8 @@ public class XTlsProtocolFilterTest {
         //SSL request but filter is not set
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder())) {
             server.addCertificate(new SSLCertificateConfiguration("*", null, certificate, "testproxy", STATIC));
-            server.addListener(new NetworkListenerConfiguration("0.0.0.0", 0, true, null, "*", Set.of("TLSv1.2")));
+            server.addListener(new NetworkListenerConfiguration("0.0.0.0", 0, true, null, "*", Set.of("TLSv1.2"),
+                    128, true, 300, 60, 8, 1000));
             server.start();
             int port = server.getLocalPort();
 


### PR DESCRIPTION
#415 

EpollEventLoopGroup vs. NioEventLoopGroupand in high load scenarios could provide better performance in:

- CPU usage
- Memory usage
- Allocations

It would be good to include the ability to switch to EpollEventLoopGroup if the operating system supports it.