### PR TITLE
NullPointerException when http header host is null

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/SimpleHTTPResponse.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/SimpleHTTPResponse.java
@@ -64,6 +64,10 @@ public class SimpleHTTPResponse {
         return new SimpleHTTPResponse(500, res, null);
     }
 
+    public static final SimpleHTTPResponse BAD_REQUEST(String res) {
+        return new SimpleHTTPResponse(400, res, null);
+    }
+
     @Override
     public String toString() {
         return "SimpleHTTPResponse{" + "errorcode=" + errorcode + ", resource=" + resource + ", customHeaders=" + customHeaders + '}';

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequest.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequest.java
@@ -26,11 +26,14 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.ssl.SslHandler;
+
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.http.conn.util.InetAddressUtils;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration.HostPort;
 import org.carapaceproxy.server.filters.UrlEncodedQueryString;
 import org.carapaceproxy.server.mapper.MapResult;
@@ -169,6 +172,27 @@ public class ProxyRequest implements MatchingContext {
 
     public String getRequestHostname() {
         return request.requestHeaders().get(HttpHeaderNames.HOST);
+    }
+
+    public String getHostname() {
+        String requestHostname = getRequestHostname();
+        int colonIndex = requestHostname.indexOf(":");
+        if (colonIndex != -1) {
+            String portString = requestHostname.substring(colonIndex + 1);
+            try {
+                int port = Integer.parseInt(portString);
+                if (port > 0 && port <= 65535) {
+                    return requestHostname.substring(0, colonIndex);
+                }
+            } catch (NumberFormatException e) {
+                return "";
+            }
+        }
+        return requestHostname;
+    }
+
+    public boolean isValidIPAddress(String ipAddress) {
+        return InetAddressUtils.isIPv4Address(ipAddress);
     }
 
     public UrlEncodedQueryString getQueryString() {

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -130,9 +130,9 @@ public class ProxyRequestsManager {
                 case INTERNAL_ERROR:
                     return serveInternalErrorMessage(request);
                 case MAINTENANCE_MODE:
-                    return serverMaintenanceMessage(request);
+                    return serveMaintenanceMessage(request);
                 case BAD_REQUEST:
-                    return serverBadRequestMessage(request);
+                    return serveBadRequestMessage(request);
 
                 case STATIC:
                 case ACME_CHALLENGE:
@@ -212,7 +212,7 @@ public class ProxyRequestsManager {
         return writeSimpleResponse(request, response, customHeaders);
     }
 
-    private Publisher<Void> serverMaintenanceMessage(ProxyRequest request) {
+    private Publisher<Void> serveMaintenanceMessage(ProxyRequest request) {
         if (request.getResponse().hasSentHeaders()) {
             return Mono.empty();
         }
@@ -237,7 +237,7 @@ public class ProxyRequestsManager {
         return writeSimpleResponse(request, response, customHeaders);
     }
 
-    private Publisher<Void> serverBadRequestMessage(ProxyRequest request) {
+    private Publisher<Void> serveBadRequestMessage(ProxyRequest request) {
         if (request.getResponse().hasSentHeaders()) {
             return Mono.empty();
         }

--- a/carapace-server/src/main/java/org/carapaceproxy/core/StaticContentsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/StaticContentsManager.java
@@ -48,6 +48,7 @@ public class StaticContentsManager {
     public static final String DEFAULT_NOT_FOUND = CLASSPATH_RESOURCE + "/default-error-pages/404_notfound.html";
     public static final String DEFAULT_INTERNAL_SERVER_ERROR = CLASSPATH_RESOURCE + "/default-error-pages/500_internalservererror.html";
     public static final String DEFAULT_MAINTENANCE_MODE_ERROR =  CLASSPATH_RESOURCE + "/default-error-pages/500_maintenance.html";
+    public static final String DEFAULT_BAD_REQUEST =  CLASSPATH_RESOURCE + "/default-error-pages/400_badrequest.html";
 
     private static final Logger LOG = Logger.getLogger(StaticContentsManager.class.getName());
 

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/RouteConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/RouteConfiguration.java
@@ -34,6 +34,8 @@ public class RouteConfiguration {
     private String errorAction;
     private String maintenanceModeAction;
 
+    private String badRequestAction;
+
     public RouteConfiguration(String id, String action, boolean enabled, RequestMatcher matcher) {
         this.id = id;
         this.action = action;

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/EndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/EndpointMapper.java
@@ -69,6 +69,10 @@ public abstract class EndpointMapper {
         return SimpleHTTPResponse.MAINTENANCE_MODE(StaticContentsManager.DEFAULT_MAINTENANCE_MODE_ERROR);
     }
 
+    public SimpleHTTPResponse mapBadRequest() {
+        return SimpleHTTPResponse.BAD_REQUEST(StaticContentsManager.DEFAULT_BAD_REQUEST);
+    }
+
     public abstract void configure(ConfigurationStore properties) throws ConfigurationNotValidException;
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/MapResult.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/MapResult.java
@@ -49,6 +49,10 @@ public class MapResult {
          */
         MAINTENANCE_MODE,
         /**
+         * Bad request
+         */
+        BAD_REQUEST,
+        /**
          * Custom static message
          */
         STATIC,
@@ -101,5 +105,12 @@ public class MapResult {
                 .routeId(routeId)
                 .build();
     }
+
+    public static MapResult badRequest() {
+        return MapResult.builder()
+                .action(Action.BAD_REQUEST)
+                .build();
+    }
+
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -24,7 +24,9 @@ import static org.carapaceproxy.core.StaticContentsManager.DEFAULT_MAINTENANCE_M
 import static org.carapaceproxy.core.StaticContentsManager.DEFAULT_NOT_FOUND;
 import static org.carapaceproxy.core.StaticContentsManager.IN_MEMORY_RESOURCE;
 import static org.carapaceproxy.server.config.DirectorConfiguration.ALL_BACKENDS;
+
 import io.netty.handler.codec.http.HttpResponseStatus;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,6 +37,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.carapaceproxy.SimpleHTTPResponse;
 import org.carapaceproxy.configstore.ConfigurationStore;
 import org.carapaceproxy.core.ProxyRequest;
@@ -70,6 +73,7 @@ public class StandardEndpointMapper extends EndpointMapper {
     private String forceDirectorParameter = "x-director";
     private String forceBackendParameter = "x-backend";
     private String defaultMaintenanceAction = "maintenance";
+    private String defaultBadRequestAction = "bad-request";
 
     private static final Logger LOG = Logger.getLogger(StandardEndpointMapper.class.getName());
     private static final String ACME_CHALLENGE_URI_PATTERN = "/\\.well-known/acme-challenge/";
@@ -113,6 +117,14 @@ public class StandardEndpointMapper extends EndpointMapper {
 
     @Override
     public MapResult map(ProxyRequest request) {
+        //If header host is null return bad request
+        if (request.getRequestHostname() == null) {
+            if (LOG.isLoggable(Level.FINER)) {
+                LOG.log(Level.FINER, "Request " + request.getUri() + " header host is null");
+            }
+            return MapResult.badRequest();
+        }
+
         for (RouteConfiguration route : routes) {
             if (!route.isEnabled()) {
                 continue;
@@ -122,10 +134,11 @@ public class StandardEndpointMapper extends EndpointMapper {
             if (LOG.isLoggable(Level.FINER)) {
                 LOG.log(Level.FINER, "route {0}, map {1} -> {2}", new Object[]{route.getId(), request.getUri(), matchResult});
             }
+
             if (matchResult) {
-                if(parent.getCurrentConfiguration().isMaintenanceModeEnabled()) {
-                    if(LOG.isLoggable(Level.FINER)) {
-                        LOG.log(Level.FINER, "Maintenance mode is enable: request uri: {0}",request.getUri());
+                if (parent.getCurrentConfiguration().isMaintenanceModeEnabled()) {
+                    if (LOG.isLoggable(Level.FINER)) {
+                        LOG.log(Level.FINER, "Maintenance mode is enable: request uri: {0}", request.getUri());
                     }
                     return MapResult.maintenanceMode(route.getId());
                 }
@@ -254,10 +267,10 @@ public class StandardEndpointMapper extends EndpointMapper {
     }
 
     @Override
-    public SimpleHTTPResponse mapMaintenanceMode(String routeid) {
+    public SimpleHTTPResponse mapMaintenanceMode(String routeId) {
         ActionConfiguration maintenanceAction = null;
         // custom for route
-        Optional<RouteConfiguration> config = routes.stream().filter(r -> r.getId().equalsIgnoreCase(routeid)).findFirst();
+        Optional<RouteConfiguration> config = routes.stream().filter(r -> r.getId().equalsIgnoreCase(routeId)).findFirst();
         if (config.isPresent()) {
             String action = config.get().getMaintenanceModeAction();
             if (action != null) {
@@ -272,11 +285,24 @@ public class StandardEndpointMapper extends EndpointMapper {
             return new SimpleHTTPResponse(maintenanceAction.getErrorCode(), maintenanceAction.getFile(), maintenanceAction.getCustomHeaders());
         }
         // fallback
-        return super.mapMaintenanceMode(routeid);
+        return super.mapMaintenanceMode(routeId);
     }
 
     @Override
-    public SimpleHTTPResponse mapPageNotFound(String routeid) {
+    public SimpleHTTPResponse mapBadRequest() {
+        // custom global
+        if (defaultBadRequestAction != null) {
+            ActionConfiguration errorAction = actions.get(defaultBadRequestAction);
+            if (errorAction != null) {
+                return new SimpleHTTPResponse(errorAction.getErrorCode(), errorAction.getFile(), errorAction.getCustomHeaders());
+            }
+        }
+        // fallback
+        return super.mapBadRequest();
+    }
+
+    @Override
+    public SimpleHTTPResponse mapPageNotFound(String routeId) {
         // custom global
         if (defaultNotFoundAction != null) {
             ActionConfiguration errorAction = actions.get(defaultNotFoundAction);
@@ -285,7 +311,7 @@ public class StandardEndpointMapper extends EndpointMapper {
             }
         }
         // fallback
-        return super.mapPageNotFound(routeid);
+        return super.mapPageNotFound(routeId);
     }
 
     @Override
@@ -313,6 +339,8 @@ public class StandardEndpointMapper extends EndpointMapper {
         LOG.log(Level.INFO, "configured default.action.internalerror={0}", defaultInternalErrorAction);
         this.defaultMaintenanceAction = properties.getString("default.action.maintenance", "maintenance");
         LOG.log(Level.INFO, "configured default.action.maintenance={0}", defaultMaintenanceAction);
+        this.defaultBadRequestAction = properties.getString("default.action.badrequest", "bad-request");
+        LOG.log(Level.INFO, "configured default.action.badrequest={0}", defaultBadRequestAction);
         this.forceDirectorParameter = properties.getString("mapper.forcedirector.parameter", forceDirectorParameter);
         LOG.log(Level.INFO, "configured mapper.forcedirector.parameter={0}", forceDirectorParameter);
         this.forceBackendParameter = properties.getString("mapper.forcebackend.parameter", forceBackendParameter);
@@ -466,9 +494,9 @@ public class StandardEndpointMapper extends EndpointMapper {
                 config.setErrorAction(errorAction);
                 //Maintenance action
                 String maintenanceAction = properties.getString(prefix + "maintenanceaction", "");
-                if(!maintenanceAction.isEmpty()) {
+                if (!maintenanceAction.isEmpty()) {
                     ActionConfiguration defined = actions.get(maintenanceAction);
-                    if(defined == null || !ActionConfiguration.TYPE_STATIC.equals(defined.getType())) {
+                    if (defined == null || !ActionConfiguration.TYPE_STATIC.equals(defined.getType())) {
                         throw new ConfigurationNotValidException("Maintenance action for route " + id + " has to be defined and has to be type STATIC");
                     }
                 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -27,7 +27,6 @@ import static org.carapaceproxy.server.config.DirectorConfiguration.ALL_BACKENDS
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 
-import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -39,7 +38,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.curator.shaded.com.google.common.net.InternetDomainName;
 import org.carapaceproxy.SimpleHTTPResponse;
 import org.carapaceproxy.configstore.ConfigurationStore;
 import org.carapaceproxy.core.ProxyRequest;
@@ -121,15 +119,15 @@ public class StandardEndpointMapper extends EndpointMapper {
     public MapResult map(ProxyRequest request) {
         //If header host is null return bad request
         //https://www.rfc-editor.org/rfc/rfc2616#page-38
-        if (request.getRequestHostname() == null) {
+        if (request.getRequestHostname() == null ||
+            request.getRequestHostname().isBlank()) {
             if (LOG.isLoggable(Level.FINER)) {
-                LOG.log(Level.FINER, "Request " + request.getUri() + " header host is null");
+                LOG.log(Level.FINER, "Request " + request.getUri() + " header host is null or empty");
             }
             return MapResult.badRequest();
-        } else if (!request.isValidIPAddress(request.getHostname()) &&
-                !InternetDomainName.isValid(request.getHostname())) {  //Invalid header host
+        } else if (!request.isValidHostAndPort(request.getRequestHostname())) {  //Invalid header host
             if (LOG.isLoggable(Level.FINER)) {
-                LOG.log(Level.FINER, "Invalid header host {0} for request {1}", new Object[]{request.getHostname(), request.getUri()});
+                LOG.log(Level.FINER, "Invalid header host {0} for request {1}", new Object[]{request.getRequestHostname(), request.getUri()});
             }
             return MapResult.badRequest();
         }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -27,6 +27,7 @@ import static org.carapaceproxy.server.config.DirectorConfiguration.ALL_BACKENDS
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,6 +39,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.apache.curator.shaded.com.google.common.net.InternetDomainName;
 import org.carapaceproxy.SimpleHTTPResponse;
 import org.carapaceproxy.configstore.ConfigurationStore;
 import org.carapaceproxy.core.ProxyRequest;
@@ -118,9 +120,16 @@ public class StandardEndpointMapper extends EndpointMapper {
     @Override
     public MapResult map(ProxyRequest request) {
         //If header host is null return bad request
+        //https://www.rfc-editor.org/rfc/rfc2616#page-38
         if (request.getRequestHostname() == null) {
             if (LOG.isLoggable(Level.FINER)) {
                 LOG.log(Level.FINER, "Request " + request.getUri() + " header host is null");
+            }
+            return MapResult.badRequest();
+        } else if (!request.isValidIPAddress(request.getHostname()) &&
+                !InternetDomainName.isValid(request.getHostname())) {  //Invalid header host
+            if (LOG.isLoggable(Level.FINER)) {
+                LOG.log(Level.FINER, "Invalid header host {0} for request {1}", new Object[]{request.getHostname(), request.getUri()});
             }
             return MapResult.badRequest();
         }

--- a/carapace-server/src/main/resources/default-error-pages/400_badrequest.html
+++ b/carapace-server/src/main/resources/default-error-pages/400_badrequest.html
@@ -1,0 +1,5 @@
+<html>
+    <body>
+        Bad request
+    </body>
+</html>

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/ConnectionPoolTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/ConnectionPoolTest.java
@@ -177,9 +177,7 @@ public class ConnectionPoolTest extends UseAdminServer {
 
         //No Http header host
         String response = sendRequest(false, hostname, port, path);
-        // no response because NullPointerException occurred before.
-        // java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null
-        assertFalse(response.contains("it <b>works</b> !!"));
+        assertTrue(response.contains("Bad request"));
 
         //Add Http header host
         String response2 = sendRequest(true, hostname, port, path);

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/ConnectionPoolTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/ConnectionPoolTest.java
@@ -175,7 +175,7 @@ public class ConnectionPoolTest extends UseAdminServer {
         assertTrue(response.contains("Bad request"));
 
         //Add Http header host
-        String response2 = sendRequest(true, hostname, port, path, "localhost3");
+        String response2 = sendRequest(true, hostname, port, path, "localhost");
         assertTrue(response2.contains("it <b>works</b> !!"));
 
         //Empty header host
@@ -213,6 +213,14 @@ public class ConnectionPoolTest extends UseAdminServer {
         //Hostname as host header with port
         String response11 = sendRequest(true, hostname, port, path, "localhost:8080&");
         assertTrue(response11.contains("Bad request"));
+
+        //Invalid hostname
+        String response12 = sendRequest(true, hostname, port, path, "::::8080::9999");
+        assertTrue(response12.contains("Bad request"));
+
+        //Add Http header host
+        String response13 = sendRequest(true, hostname, port, path, "localhost3");
+        assertTrue(response13.contains("it <b>works</b> !!"));
     }
 
     public String sendRequest(boolean addHeaderHost, String hostname, int port, String path, String headerHost) throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <libs.jaxws.jaxb-impl>3.0.2</libs.jaxws.jaxb-impl>
         <libs.javaxactivation-api>1.2.0</libs.javaxactivation-api>
         <libs.slf4j>1.7.33</libs.slf4j>
-        <libs.guava>31.0.1-jre</libs.guava>
+        <libs.guava>31.1-jre</libs.guava>
         <libs.lombok>1.18.22</libs.lombok>
         <libs.spotbugsannotations>4.5.3</libs.spotbugsannotations>
 


### PR DESCRIPTION
#412
As per RFC, if host header is missing or wrong the response must be 400 Bad request.
See https://www.rfc-editor.org/rfc/rfc2616#page-38
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host


the error page can be customized by setting:
`default.action.badrequest=custom_action`