### PR TITLE
Upgrade reactor netty to laster version

### DIFF
--- a/carapace-server/src/test/java/org/carapaceproxy/core/MaxHeaderSizeTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/MaxHeaderSizeTest.java
@@ -99,6 +99,7 @@ public class MaxHeaderSizeTest extends UseAdminServer {
 
         HttpResponse<String> response2 = httpClient2.send(request, HttpResponse.BodyHandlers.ofString());
 
-        assertEquals(413, response2.statusCode());
+        // https://github.com/reactor/reactor-netty/pull/2534
+        assertEquals(431, response2.statusCode());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -108,8 +108,8 @@
         <maven.compiler.target>17</maven.compiler.target>
         <javacc-maven-plugin.version>2.4</javacc-maven-plugin.version>
 
-        <libs.projectreactor>2020.0.23</libs.projectreactor>
-        <libs.netty.ssl>2.0.54.Final</libs.netty.ssl>
+        <libs.projectreactor>2022.0.3</libs.projectreactor>
+        <libs.netty.ssl>2.0.56.Final</libs.netty.ssl>
         <libs.acme4j>2.12</libs.acme4j>
         <libs.bouncycastle>1.70</libs.bouncycastle>
         <libs.awssdk>2.17.113</libs.awssdk>
@@ -120,7 +120,7 @@
         <libs.curator>5.2.0</libs.curator>
         <libs.prometheus>0.14.1</libs.prometheus>
         <libs.prometheus.metrics>4.14.4</libs.prometheus.metrics>
-        <libs.micrometer>1.8.2</libs.micrometer>
+        <libs.micrometer>1.10.6</libs.micrometer>
         <libs.herddb>0.26.1</libs.herddb>
 
         <libs.commons.lang3>3.12.0</libs.commons.lang3>


### PR DESCRIPTION
Motivation

- Latest version of reactor netty include netty 4.1.89.Final
-  Current reactor netty version use 4.1.81.Final that include a potential memory leak bug fixed in 4.1.85.Final.
   https://netty.io/news/2022/11/09/4-1-85-Final.html

