### PR TITLE
Service unavailable page customization

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/SimpleHTTPResponse.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/SimpleHTTPResponse.java
@@ -68,6 +68,10 @@ public class SimpleHTTPResponse {
         return new SimpleHTTPResponse(400, res, null);
     }
 
+    public static final SimpleHTTPResponse SERVICE_UNAVAILABLE(String res) {
+        return new SimpleHTTPResponse(503, res, null);
+    }
+
     @Override
     public String toString() {
         return "SimpleHTTPResponse{" + "errorcode=" + errorcode + ", resource=" + resource + ", customHeaders=" + customHeaders + '}';

--- a/carapace-server/src/main/java/org/carapaceproxy/core/StaticContentsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/StaticContentsManager.java
@@ -21,10 +21,8 @@ package org.carapaceproxy.core;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.http.DefaultFullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.*;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -49,6 +47,7 @@ public class StaticContentsManager {
     public static final String DEFAULT_INTERNAL_SERVER_ERROR = CLASSPATH_RESOURCE + "/default-error-pages/500_internalservererror.html";
     public static final String DEFAULT_MAINTENANCE_MODE_ERROR =  CLASSPATH_RESOURCE + "/default-error-pages/500_maintenance.html";
     public static final String DEFAULT_BAD_REQUEST =  CLASSPATH_RESOURCE + "/default-error-pages/400_badrequest.html";
+    public static final String DEFAULT_SERVICE_UNAVAILABLE_ERROR =  CLASSPATH_RESOURCE + "/default-error-pages/503_serviceunavailable.html";
 
     private static final Logger LOG = Logger.getLogger(StaticContentsManager.class.getName());
 
@@ -57,10 +56,6 @@ public class StaticContentsManager {
     public void close() {
         contents.values().forEach(ByteBuf::release);
         contents.clear();
-    }
-
-    public DefaultFullHttpResponse buildServiceNotAvailableResponse() {
-        return buildResponse(500, DEFAULT_INTERNAL_SERVER_ERROR);
     }
 
     public DefaultFullHttpResponse buildResponse(int code, String resource) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/EndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/EndpointMapper.java
@@ -65,6 +65,9 @@ public abstract class EndpointMapper {
         return SimpleHTTPResponse.INTERNAL_ERROR(StaticContentsManager.DEFAULT_INTERNAL_SERVER_ERROR);
     }
 
+    public SimpleHTTPResponse mapServiceUnavailableError(String routeId) {
+        return SimpleHTTPResponse.SERVICE_UNAVAILABLE(StaticContentsManager.DEFAULT_SERVICE_UNAVAILABLE_ERROR);
+    }
     public SimpleHTTPResponse mapMaintenanceMode(String routeId) {
         return SimpleHTTPResponse.MAINTENANCE_MODE(StaticContentsManager.DEFAULT_MAINTENANCE_MODE_ERROR);
     }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/MapResult.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/MapResult.java
@@ -45,6 +45,10 @@ public class MapResult {
          */
         INTERNAL_ERROR,
         /**
+         * Service not available
+         */
+        SERVICE_UNAVAILABLE,
+        /**
          * Maintenance mode
          */
         MAINTENANCE_MODE,

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -74,6 +74,7 @@ public class StandardEndpointMapper extends EndpointMapper {
     private String forceBackendParameter = "x-backend";
     private String defaultMaintenanceAction = "maintenance";
     private String defaultBadRequestAction = "bad-request";
+    private String defaultServiceUnavailable = "service-unavailable";
 
     private static final Logger LOG = Logger.getLogger(StandardEndpointMapper.class.getName());
     private static final String ACME_CHALLENGE_URI_PATTERN = "/\\.well-known/acme-challenge/";
@@ -274,6 +275,19 @@ public class StandardEndpointMapper extends EndpointMapper {
     }
 
     @Override
+    public SimpleHTTPResponse mapServiceUnavailableError(String routeId) {
+        // custom global
+        if (defaultServiceUnavailable != null) {
+            ActionConfiguration errorAction = actions.get(defaultServiceUnavailable);
+            if (errorAction != null) {
+                return new SimpleHTTPResponse(errorAction.getErrorCode(), errorAction.getFile(), errorAction.getCustomHeaders());
+            }
+        }
+        // fallback
+        return super.mapServiceUnavailableError(routeId);
+    }
+
+    @Override
     public SimpleHTTPResponse mapMaintenanceMode(String routeId) {
         ActionConfiguration maintenanceAction = null;
         // custom for route
@@ -348,6 +362,8 @@ public class StandardEndpointMapper extends EndpointMapper {
         LOG.log(Level.INFO, "configured default.action.maintenance={0}", defaultMaintenanceAction);
         this.defaultBadRequestAction = properties.getString("default.action.badrequest", "bad-request");
         LOG.log(Level.INFO, "configured default.action.badrequest={0}", defaultBadRequestAction);
+        this.defaultServiceUnavailable = properties.getString("default.action.serviceunavailable", "service-unavailable");
+        LOG.log(Level.INFO, "configured default.action.serviceunavailable={0}", defaultServiceUnavailable);
         this.forceDirectorParameter = properties.getString("mapper.forcedirector.parameter", forceDirectorParameter);
         LOG.log(Level.INFO, "configured mapper.forcedirector.parameter={0}", forceDirectorParameter);
         this.forceBackendParameter = properties.getString("mapper.forcebackend.parameter", forceBackendParameter);

--- a/carapace-server/src/main/resources/default-error-pages/503_serviceunavailable.html
+++ b/carapace-server/src/main/resources/default-error-pages/503_serviceunavailable.html
@@ -1,0 +1,5 @@
+<html>
+    <body>
+        Service Unavailable
+    </body>
+</html>

--- a/carapace-server/src/test/java/org/carapaceproxy/RawClientTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/RawClientTest.java
@@ -679,7 +679,7 @@ public class RawClientTest {
                             try (RawHttpClient client2 = new RawHttpClient("localhost", port, 300_000)) {
                                 String resp = client2.get("/index.html").getBodyString();
                                 System.out.println("### RESP client2: " + resp);
-                                if (!resp.contains("An internal error occurred")) { // borrow timeout
+                                if (!resp.contains("Service Unavailable")) { // borrow timeout
                                     failed.set(true);
                                     return;
                                 }

--- a/carapace-server/src/test/java/org/carapaceproxy/SimpleHTTPProxyTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/SimpleHTTPProxyTest.java
@@ -143,7 +143,7 @@ public class SimpleHTTPProxyTest {
 
             HttpTestUtils.ResourceInfos result = HttpTestUtils.downloadFromUrl(new URL("http://localhost:" + port + "/index.html"),
                     new ByteArrayOutputStream(), Collections.singletonMap("return_errors", "true"));
-            assertEquals(500, result.responseCode);
+            assertEquals(503, result.responseCode);
         }
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/RestartEndpointTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/RestartEndpointTest.java
@@ -85,7 +85,7 @@ public class RestartEndpointTest {
                 wireMockRule.stop();
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 System.out.println("statusline:" + resp.getStatusLine());
-                assertEquals("HTTP/1.1 500 Internal Server Error\r\n", resp.getStatusLine());
+                assertEquals("HTTP/1.1 503 Service Unavailable\r\n", resp.getStatusLine());
                 assertThat(resp.getHeaderLines(), hasItems("cache-control: no-cache\r\n", "connection: keep-alive\r\n"));
             }
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
@@ -125,7 +125,7 @@ public class RestartEndpointTest {
 
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 System.out.println("statusline:" + resp.getStatusLine());
-                assertEquals("HTTP/1.1 500 Internal Server Error\r\n", resp.getStatusLine());
+                assertEquals("HTTP/1.1 503 Service Unavailable\r\n", resp.getStatusLine());
                 assertThat(resp.getHeaderLines(), hasItems("cache-control: no-cache\r\n", "connection: keep-alive\r\n"));
             }
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendTest.java
@@ -95,11 +95,11 @@ public class UnreachableBackendTest {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertEquals("HTTP/1.1 500 Internal Server Error\r\n", resp.getStatusLine());
+                assertEquals("HTTP/1.1 503 Service Unavailable\r\n", resp.getStatusLine());
                 assertEquals("<html>\n"
                         + "    <body>\n"
-                        + "        An internal error occurred\n"
-                        + "    </body>        \n"
+                        + "        Service Unavailable\n"
+                        + "    </body>\n"
                         + "</html>\n", resp.getBodyString());
             }
             assertFalse(server.getBackendHealthManager().isAvailable(key.getHostPort()));
@@ -131,11 +131,11 @@ public class UnreachableBackendTest {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertEquals("HTTP/1.1 500 Internal Server Error\r\n", resp.getStatusLine());
+                assertEquals("HTTP/1.1 503 Service Unavailable\r\n", resp.getStatusLine());
                 assertEquals("<html>\n"
                         + "    <body>\n"
-                        + "        An internal error occurred\n"
-                        + "    </body>        \n"
+                        + "        Service Unavailable\n"
+                        + "    </body>\n"
                         + "</html>\n", resp.getBodyString());
             }
             assertTrue(server.getBackendHealthManager().isAvailable(key.getHostPort())); // no troubles for new connections
@@ -161,11 +161,11 @@ public class UnreachableBackendTest {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertEquals("HTTP/1.1 500 Internal Server Error\r\n", resp.getStatusLine());
+                assertEquals("HTTP/1.1 503 Service Unavailable\r\n", resp.getStatusLine());
                 assertEquals("<html>\n"
                         + "    <body>\n"
-                        + "        An internal error occurred\n"
-                        + "    </body>        \n"
+                        + "        Service Unavailable\n"
+                        + "    </body>\n"
                         + "</html>\n", resp.getBodyString());
             }
             assertTrue(server.getBackendHealthManager().isAvailable(key.getHostPort())); // no troubles for new connections
@@ -195,11 +195,11 @@ public class UnreachableBackendTest {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertEquals("HTTP/1.1 500 Internal Server Error\r\n", resp.getStatusLine());
+                assertEquals("HTTP/1.1 503 Service Unavailable\r\n", resp.getStatusLine());
                 assertEquals("<html>\n"
                         + "    <body>\n"
-                        + "        An internal error occurred\n"
-                        + "    </body>        \n"
+                        + "        Service Unavailable\n"
+                        + "    </body>\n"
                         + "</html>\n", resp.getBodyString());
             }
             assertTrue(server.getBackendHealthManager().isAvailable(key.getHostPort()));


### PR DESCRIPTION
In the current implementation, in case of problems during a request from Carapace to the server, we return the error page `"500 An internal error occured" ` via the `Publisher<Void> serveServiceNotAvailable(ProxyRequest request) `function.
The error page returned is the default one and cannot be customized.

Changes:
- In case of problems, the default error code` 503 service unavailable` is returned
- Added dynamic sys prop **default.action.serviceunavailable** to set up your own custom error page