### PR TITLE
Fix PR validation permissions by splitting in two workflows

### DIFF
--- a/.github/workflows/pr-validation-report.yml
+++ b/.github/workflows/pr-validation-report.yml
@@ -1,0 +1,21 @@
+name: Java CI - Test report
+on:
+  workflow_run:
+    workflows:
+      - 'Java CI - Code tests'
+    types:
+      - completed
+permissions:
+  contents: read
+  actions: read
+  checks: write
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/test-reporter@v1
+        with:
+          artifact: test-results # as named in pr-validation workflow
+          name: Maven Tests
+          path: carapace-*/target/surefire-reports/*.xml # (inside artifact .zip)
+          reporter: java-junit

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,10 +16,6 @@
 name: Java CI - Code tests
 on:
   pull_request:
-permissions:
-  contents: read
-  actions: read
-  checks: write
 env:
   MAVEN_OPTS: >-
     -Dmaven.artifact.threads=4 
@@ -48,11 +44,9 @@ jobs:
           cache: 'maven'
       - name: 'Build and test with Maven'
         run: mvn verify
-      - name: 'Report test results'
-        uses: dorny/test-reporter@v1
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: Maven Tests
+          name: test-results # as expected by pr-validation-report workflow
           path: carapace-*/target/surefire-reports/*.xml
-          reporter: java-junit
-          fail-on-error: true
+          retention-days: 1


### PR DESCRIPTION
Splitting PR validation workflow in two, one doing the actual validation, and the other publishing checks with the right permissions

See:

* https://github.com/marketplace/actions/junit-report-action#pr-run-permissions
* https://github.com/marketplace/actions/publish-test-results#permissions
* https://github.com/marketplace/actions/test-reporter#recommended-setup-for-public-repositories