### PR TITLE
build(server): upgrade Lombok to 1.18.32

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -277,7 +277,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${libs.lombok}</version>
-            <type>jar</type>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/carapace-ui/pom.xml
+++ b/carapace-ui/pom.xml
@@ -37,13 +37,20 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.6.1</version>
                 <configuration>
                     <source>17</source>
                     <target>17</target>
                     <compilerArguments>
                         <endorseddirs>${endorsed.dir}</endorseddirs>
                     </compilerArguments>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${libs.lombok}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
             <name>Alessandro Luccaroni</name>
             <organization>Diennea</organization>
         </developer>
+        <developer>
+            <id>niccomlt</id>
+            <name>Niccolò Maltoni</name>
+            <organization>Diennea</organization>
+        </developer>
     </developers>
     <build>
         <plugins>
@@ -135,7 +140,7 @@
         <libs.javaxactivation-api>1.2.0</libs.javaxactivation-api>
         <libs.slf4j>1.7.33</libs.slf4j>
         <libs.guava>31.1-jre</libs.guava>
-        <libs.lombok>1.18.22</libs.lombok>
+        <libs.lombok>1.18.32</libs.lombok>
         <libs.spotbugsannotations>4.5.3</libs.spotbugsannotations>
 
         <!-- test dependecies -->


### PR DESCRIPTION
upgrade was needed to support building on JDK21 (closes #470)
