### PR TITLE
Implement CRUD APIs for connection pools

### DIFF
--- a/.github/workflows/pr-validation-report.yml
+++ b/.github/workflows/pr-validation-report.yml
@@ -13,7 +13,7 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-      - uses: dorny/test-reporter@v1
+      - uses: dorny/test-reporter@v1.9.1
         with:
           artifact: test-results # as named in pr-validation workflow
           name: Maven Tests

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -29,7 +29,7 @@ env:
     -Dsurefire.rerunFailingTestsCount=3
     --update-snapshots
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 jobs:
   build:
@@ -43,8 +43,8 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: 'Build and test with Maven'
-        run: mvn verify
-      - uses: actions/upload-artifact@v3
+        run: ./mvnw verify
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-results # as expected by pr-validation-report workflow

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: 'Set up JDK 17'
+      - name: 'Set up JDK 21'
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
       - name: 'Build and test with Maven'

--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+public final class MavenWrapperDownloader
+{
+    private static final String WRAPPER_VERSION = "3.2.0";
+
+    private static final boolean VERBOSE = Boolean.parseBoolean( System.getenv( "MVNW_VERBOSE" ) );
+
+    public static void main( String[] args )
+    {
+        log( "Apache Maven Wrapper Downloader " + WRAPPER_VERSION );
+
+        if ( args.length != 2 )
+        {
+            System.err.println( " - ERROR wrapperUrl or wrapperJarPath parameter missing" );
+            System.exit( 1 );
+        }
+
+        try
+        {
+            log( " - Downloader started" );
+            final URL wrapperUrl = new URL( args[0] );
+            final String jarPath = args[1].replace( "..", "" ); // Sanitize path
+            final Path wrapperJarPath = Paths.get( jarPath ).toAbsolutePath().normalize();
+            downloadFileFromURL( wrapperUrl, wrapperJarPath );
+            log( "Done" );
+        }
+        catch ( IOException e )
+        {
+            System.err.println( "- Error downloading: " + e.getMessage() );
+            if ( VERBOSE )
+            {
+                e.printStackTrace();
+            }
+            System.exit( 1 );
+        }
+    }
+
+    private static void downloadFileFromURL( URL wrapperUrl, Path wrapperJarPath )
+        throws IOException
+    {
+        log( " - Downloading to: " + wrapperJarPath );
+        if ( System.getenv( "MVNW_USERNAME" ) != null && System.getenv( "MVNW_PASSWORD" ) != null )
+        {
+            final String username = System.getenv( "MVNW_USERNAME" );
+            final char[] password = System.getenv( "MVNW_PASSWORD" ).toCharArray();
+            Authenticator.setDefault( new Authenticator()
+            {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication()
+                {
+                    return new PasswordAuthentication( username, password );
+                }
+            } );
+        }
+        try ( InputStream inStream = wrapperUrl.openStream() )
+        {
+            Files.copy( inStream, wrapperJarPath, StandardCopyOption.REPLACE_EXISTING );
+        }
+        log( " - Downloader complete" );
+    }
+
+    private static void log( String msg )
+    {
+        if ( VERBOSE )
+        {
+            System.out.println( msg );
+        }
+    }
+
+}

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.5/apache-maven-3.9.5-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -5,7 +5,7 @@
         <groupId>org.carapaceproxy</groupId>
         <artifactId>carapace-parent</artifactId>
         <version>1.11.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Carapace :: Server</name>
     <artifactId>carapace-server</artifactId>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -356,7 +356,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.1</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -343,6 +343,17 @@
             <artifactId>curator-test</artifactId>
             <version>${libs.curator}</version>
             <scope>test</scope>
+            <exclusions>
+                <!--
+                    The presence of both JUnit Jupiter APIs (in particular version 5.6.2)
+                    and the old-fashioned JUnit (in particular a version which is strictly not 4.12 and 4.13)
+                     messes up with Intellij IDEA test run of whole project.
+                -->
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/carapace-server/src/main/java/org/carapaceproxy/api/response/FormValidationResponse.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/response/FormValidationResponse.java
@@ -17,9 +17,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class FormValidationResponse extends SimpleResponse {
 
-    public final static String ERROR_FIELD_REQUIRED = "Value required";
-    public final static String ERROR_FIELD_INVALID = "Value invalid";
-    public final static String ERROR_FIELD_DUPLICATED = "Value already used";
+    public static final String ERROR_FIELD_REQUIRED = "Value required";
+    public static final String ERROR_FIELD_INVALID = "Value invalid";
+    public static final String ERROR_FIELD_DUPLICATED = "Value already used";
 
     private String field;
 

--- a/carapace-server/src/main/java/org/carapaceproxy/client/EndpointKey.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/client/EndpointKey.java
@@ -38,13 +38,12 @@ public final class EndpointKey {
 
     public static EndpointKey make(String hostAndPort) {
         int pos = hostAndPort.indexOf(':');
-        if (pos > 0) {
-            String host = hostAndPort.substring(0, pos);
-            int port = Integer.parseInt(hostAndPort.substring(pos + 1, hostAndPort.length()));
-            return new EndpointKey(host, port);
-        } else {
+        if (pos <= 0) {
             return new EndpointKey(hostAndPort, 0);
         }
+        String host = hostAndPort.substring(0, pos);
+        int port = Integer.parseInt(hostAndPort.substring(pos + 1));
+        return new EndpointKey(host, port);
     }
 
     public EndpointKey(String host, int port) {

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationConsumer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationConsumer.java
@@ -1,0 +1,7 @@
+package org.carapaceproxy.configstore;
+
+import java.util.function.Consumer;
+
+@FunctionalInterface
+public interface ConfigurationConsumer extends Consumer<PropertiesConfigurationStore> {
+}

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationStore.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationStore.java
@@ -138,7 +138,7 @@ public interface ConfigurationStore extends AutoCloseable {
                 if (split.length > 0) {
                     usedIndexes.add(Integer.parseInt(split[0]));
                 }
-            } catch (NumberFormatException e) {
+            } catch (NumberFormatException ignored) {
 
             }
         });
@@ -147,8 +147,9 @@ public interface ConfigurationStore extends AutoCloseable {
     }
 
     /**
+     * Check if any of the properties match a predicate.
      *
-     * @param predicate
+     * @param predicate the predicate to execute against all the properties
      * @return whether exist at least one property matching to passed predicate.
      */
     default boolean anyPropertyMatches(BiPredicate<String, String> predicate) {
@@ -168,7 +169,7 @@ public interface ConfigurationStore extends AutoCloseable {
     /**
      * Persist (if supported) the new configuration
      *
-     * @param newConfigurationStore
+     * @param newConfigurationStore the new configuration store to persist
      */
     default void commitConfiguration(ConfigurationStore newConfigurationStore) {
     }

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationStore.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationStore.java
@@ -202,5 +202,4 @@ public interface ConfigurationStore extends AutoCloseable {
     String loadAcmeChallengeToken(String id);
 
     void deleteAcmeChallengeToken(String id);
-
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationStore.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationStore.java
@@ -25,6 +25,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
@@ -37,6 +38,14 @@ import org.carapaceproxy.server.config.ConfigurationNotValidException;
 public interface ConfigurationStore extends AutoCloseable {
 
     String PROPERTY_VALUES_SEPARATOR = ",";
+
+    default String toStringConfiguration() {
+        Set<String> props = new TreeSet<>();
+        forEach((k, v) -> props.add(k + "=" + v));
+        StringBuilder builder = new StringBuilder();
+        props.forEach(p -> builder.append(p).append("\n"));
+        return builder.toString();
+    }
 
     String getProperty(String key, String defaultValue);
 

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/PropertiesConfigurationStore.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/PropertiesConfigurationStore.java
@@ -143,4 +143,28 @@ public class PropertiesConfigurationStore implements ConfigurationStore {
         properties.setProperty(prefix + "keepalive", String.valueOf(connectionPool.isKeepAlive()));
     }
 
+    public void deleteConnectionPool(final String id) {
+        final var max = findMaxIndexForPrefix("connectionpool");
+        for (int index = 0; index <= max; index++) {
+            String prefix = "connectionpool." + index + ".";
+            if (id.equals(properties.getProperty(prefix + "id"))) {
+                properties.remove(prefix + "id");
+                properties.remove(prefix + "domain");
+                properties.remove(prefix + "maxconnectionsperendpoint");
+                properties.remove(prefix + "borrowtimeout");
+                properties.remove(prefix + "connecttimeout");
+                properties.remove(prefix + "stuckrequesttimeout");
+                properties.remove(prefix + "idletimeout");
+                properties.remove(prefix + "maxlifetime");
+                properties.remove(prefix + "disposetimeout");
+                properties.remove(prefix + "keepaliveidle");
+                properties.remove(prefix + "keepaliveinterval");
+                properties.remove(prefix + "keepalivecount");
+                properties.remove(prefix + "enabled");
+                properties.remove(prefix + "keepalive");
+                // found
+                break;
+            }
+        }
+    }
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/PropertiesConfigurationStore.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/PropertiesConfigurationStore.java
@@ -118,15 +118,24 @@ public class PropertiesConfigurationStore implements ConfigurationStore {
         acmeChallengeTokens.remove(id);
     }
 
-    public void saveConnectionPool(final ConnectionPoolConfiguration connectionPool) {
+    public void addConnectionPool(final ConnectionPoolConfiguration connectionPool) {
+        saveConnectionPool(connectionPool, findMaxIndexForPrefix("connectionpool") + 1);
+    }
+
+    public void updateConnectionPool(final ConnectionPoolConfiguration connectionPool) {
         final var max = findMaxIndexForPrefix("connectionpool");
-        String prefix = "connectionpool.0.";
-        for (int index = 0; index <= max; prefix = "connectionpool." + ++index + '.') {
-            if (getProperty(prefix, null) != null) {
-                // found
-                break;
+        for (int index = 0; index <= max; index++) {
+            final var prefix = "connectionpool." + index + ".";
+            final var id = properties.getProperty(prefix + "id", null);
+            if (connectionPool.getId().equals(id)) {
+                saveConnectionPool(connectionPool, index);
+                return;
             }
         }
+    }
+
+    private void saveConnectionPool(final ConnectionPoolConfiguration connectionPool, final int index) {
+        final var prefix = "connectionpool." + index + ".";
         properties.setProperty(prefix + "id", connectionPool.getId());
         properties.setProperty(prefix + "domain", connectionPool.getDomain());
         properties.setProperty(prefix + "maxconnectionsperendpoint", String.valueOf(connectionPool.getMaxConnectionsPerEndpoint()));
@@ -162,8 +171,7 @@ public class PropertiesConfigurationStore implements ConfigurationStore {
                 properties.remove(prefix + "keepalivecount");
                 properties.remove(prefix + "enabled");
                 properties.remove(prefix + "keepalive");
-                // found
-                break;
+                return;
             }
         }
     }

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/PropertiesConfigurationStore.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/PropertiesConfigurationStore.java
@@ -48,9 +48,7 @@ public class PropertiesConfigurationStore implements ConfigurationStore {
 
     @Override
     public void forEach(BiConsumer<String, String> consumer) {
-        properties.forEach((k, v) -> {
-            consumer.accept(k.toString(), v.toString());
-        });
+        properties.forEach((k, v) -> consumer.accept(k.toString(), v.toString()));
     }
 
     @Override

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/PropertiesConfigurationStore.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/PropertiesConfigurationStore.java
@@ -23,6 +23,7 @@ import java.security.KeyPair;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
+import org.carapaceproxy.server.config.ConnectionPoolConfiguration;
 
 /**
  * Reads configuration from a Java properties file
@@ -115,6 +116,31 @@ public class PropertiesConfigurationStore implements ConfigurationStore {
     @Override
     public void deleteAcmeChallengeToken(String id) {
         acmeChallengeTokens.remove(id);
+    }
+
+    public void saveConnectionPool(final ConnectionPoolConfiguration connectionPool) {
+        final var max = findMaxIndexForPrefix("connectionpool");
+        String prefix = "connectionpool.0.";
+        for (int index = 0; index <= max; prefix = "connectionpool." + ++index + '.') {
+            if (getProperty(prefix, null) != null) {
+                // found
+                break;
+            }
+        }
+        properties.setProperty(prefix + "id", connectionPool.getId());
+        properties.setProperty(prefix + "domain", connectionPool.getDomain());
+        properties.setProperty(prefix + "maxconnectionsperendpoint", String.valueOf(connectionPool.getMaxConnectionsPerEndpoint()));
+        properties.setProperty(prefix + "borrowtimeout", String.valueOf(connectionPool.getBorrowTimeout()));
+        properties.setProperty(prefix + "connecttimeout", String.valueOf(connectionPool.getConnectTimeout()));
+        properties.setProperty(prefix + "stuckrequesttimeout", String.valueOf(connectionPool.getStuckRequestTimeout()));
+        properties.setProperty(prefix + "idletimeout", String.valueOf(connectionPool.getIdleTimeout()));
+        properties.setProperty(prefix + "maxlifetime", String.valueOf(connectionPool.getMaxLifeTime()));
+        properties.setProperty(prefix + "disposetimeout", String.valueOf(connectionPool.getDisposeTimeout()));
+        properties.setProperty(prefix + "keepaliveidle", String.valueOf(connectionPool.getKeepaliveIdle()));
+        properties.setProperty(prefix + "keepaliveinterval", String.valueOf(connectionPool.getKeepaliveInterval()));
+        properties.setProperty(prefix + "keepalivecount", String.valueOf(connectionPool.getKeepaliveCount()));
+        properties.setProperty(prefix + "enabled", String.valueOf(connectionPool.isEnabled()));
+        properties.setProperty(prefix + "keepalive", String.valueOf(connectionPool.isKeepAlive()));
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
@@ -863,7 +863,7 @@ public class HttpProxyServer implements AutoCloseable {
                 return;
             }
             EndpointKey key = EndpointKey.make(metric.getTag(REMOTE_ADDRESS));
-            Map<String, ConnectionPoolStats> pools = res.computeIfAbsent(key, k -> new HashMap<String, ConnectionPoolStats>());
+            Map<String, ConnectionPoolStats> pools = res.computeIfAbsent(key, k -> new HashMap<>());
             String poolName = metric.getTag(NAME);
             ConnectionPoolStats stats = pools.computeIfAbsent(poolName, k -> new ConnectionPoolStats());
             double value = 0;

--- a/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
@@ -59,7 +59,7 @@ public class RuntimeServerConfiguration {
     private final List<NetworkListenerConfiguration> listeners = new ArrayList<>();
     private final Map<String, SSLCertificateConfiguration> certificates = new HashMap<>();
     private final List<RequestFilterConfiguration> requestFilters = new ArrayList<>();
-    private final List<ConnectionPoolConfiguration> connectionPools = new ArrayList<>();
+    private final Map<String, ConnectionPoolConfiguration> connectionPools = new HashMap<>();
     private ConnectionPoolConfiguration defaultConnectionPool;
 
     private int maxConnectionsPerEndpoint = 10;
@@ -381,7 +381,8 @@ public class RuntimeServerConfiguration {
             boolean keepAlive = properties.getBoolean(prefix + "keepalive", true);
 
             ConnectionPoolConfiguration connectionPool = new ConnectionPoolConfiguration(
-                    id, domain,
+                    id,
+                    domain,
                     maxconnectionsperendpoint,
                     borrowtimeout,
                     connecttimeout,
@@ -395,7 +396,7 @@ public class RuntimeServerConfiguration {
                     keepAlive,
                     enabled
             );
-            connectionPools.add(connectionPool);
+            connectionPools.put(id, connectionPool);
             LOG.log(Level.INFO, "Configured connectionpool." + i + ": {0}", connectionPool);
         }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/api/ClusterReconfigTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/ClusterReconfigTest.java
@@ -20,7 +20,7 @@
 package org.carapaceproxy.api;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 import java.util.Properties;
 import org.apache.curator.test.TestingServer;
 import org.carapaceproxy.utils.RawHttpClient;

--- a/carapace-server/src/test/java/org/carapaceproxy/api/ConnectionPoolsResourceTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/ConnectionPoolsResourceTest.java
@@ -1,0 +1,225 @@
+package org.carapaceproxy.api;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import javax.ws.rs.core.Response;
+import org.carapaceproxy.utils.HttpTestUtils;
+import org.carapaceproxy.utils.RawHttpClient;
+import org.carapaceproxy.utils.TestUtils;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ConnectionPoolsResourceTest extends UseAdminServer {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String CONNECTION_POOLS_PATH = "/api/connectionpools";
+    private static final String CREATED = String.valueOf(Response.Status.CREATED.getStatusCode());
+    private static final String OK = String.valueOf(Response.Status.OK.getStatusCode());
+    private static final String DEFAULT_EXAMPLE_ORG = "example.org";
+    private static final String ALTERNATIVE_EXAMPLE_COM = "example.com";
+    private static final int MAX_CONNECTIONS_PER_ENDPOINT = 10;
+    private static final int BORROW_TIMEOUT = 5000;
+    private static final int CONNECT_TIMEOUT = 10000;
+    private static final int STUCK_REQUEST_TIMEOUT = 15000;
+    private static final int IDLE_TIMEOUT = 20000;
+    private static final int MAX_LIFE_TIME = 100000;
+    private static final int DISPOSE_TIMEOUT = 50000;
+    private static final int KEEPALIVE_IDLE = 500;
+    private static final int KEEPALIVE_INTERVAL = 50;
+    private static final int KEEPALIVE_COUNT = 5;
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(0);
+
+    private void configureAndStartServer() throws Exception {
+
+        HttpTestUtils.overrideJvmWideHttpsVerifier();
+
+        stubFor(get(urlEqualTo("/index.html"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/html")
+                        .withHeader("Content-Length", String.valueOf("it <b>works</b> !!".length()))
+                        .withBody("it <b>works</b> !!")));
+
+        final Properties config = new Properties(HTTP_ADMIN_SERVER_CONFIG);
+        config.put("config.type", "database");
+        config.put("db.jdbc.url", "jdbc:herddb:localhost");
+        config.put("db.server.base.dir", tmpDir.newFolder().getAbsolutePath());
+        config.put("aws.accesskey", "accesskey");
+        config.put("aws.secretkey", "secretkey");
+        startServer(config);
+
+        // Default certificate
+        String defaultCertificate = TestUtils.deployResource("ia.p12", tmpDir.getRoot());
+        config.put("certificate.1.hostname", "*");
+        config.put("certificate.1.file", defaultCertificate);
+        config.put("certificate.1.password", "changeit");
+
+        // Listeners
+        config.put("listener.1.host", "localhost");
+        config.put("listener.1.port", "8086");
+        config.put("listener.1.enabled", "true");
+        config.put("listener.1.defaultcertificate", "*");
+
+        // Backends
+        config.put("backend.1.id", "localhost");
+        config.put("backend.1.enabled", "true");
+        config.put("backend.1.host", "localhost");
+        config.put("backend.1.port", String.valueOf(wireMockRule.port()));
+
+        config.put("backend.2.id", "localhost2");
+        config.put("backend.2.enabled", "true");
+        config.put("backend.2.host", "localhost2");
+        config.put("backend.2.port", String.valueOf(wireMockRule.port()));
+
+        // Default director
+        config.put("director.1.id", "*");
+        config.put("director.1.backends", "localhost");
+        config.put("director.1.enabled", "true");
+
+        // Default route
+        config.put("route.100.id", "default");
+        config.put("route.100.enabled", "true");
+        config.put("route.100.match", "all");
+        config.put("route.100.action", "proxy-all");
+
+        // Default connection pool properties
+        config.put("connectionsmanager.maxconnectionsperendpoint", MAX_CONNECTIONS_PER_ENDPOINT);
+
+        // Custom connection pool (with defaults)
+        config.put("connectionpool.1.id", DEFAULT_EXAMPLE_ORG);
+        config.put("connectionpool.1.domain", DEFAULT_EXAMPLE_ORG);
+        config.put("connectionpool.1.maxconnectionsperendpoint", String.valueOf(MAX_CONNECTIONS_PER_ENDPOINT * 2));
+        config.put("connectionpool.1.enabled", "true");
+
+        changeDynamicConfiguration(config);
+    }
+
+    @Test
+    public void testGetSingle() throws Exception {
+        configureAndStartServer();
+        try (final var client = new RawHttpClient("localhost", 8761)) {
+            final var defaultResult = client.get(CONNECTION_POOLS_PATH + "/*", credentials);
+            final var defaultResultBean = MAPPER.readValue(defaultResult.getBodyString(), ConnectionPoolsResource.ConnectionPoolBean.class);
+            assertThat(defaultResultBean.getId(), is("*"));
+            assertThat(defaultResultBean.getDomain(), is("*"));
+            assertThat(defaultResultBean.getMaxConnectionsPerEndpoint(), is(MAX_CONNECTIONS_PER_ENDPOINT));
+
+            final var result = client.get(CONNECTION_POOLS_PATH + "/" + DEFAULT_EXAMPLE_ORG, credentials);
+            final var resultBean = MAPPER.readValue(result.getBodyString(), ConnectionPoolsResource.ConnectionPoolBean.class);
+            assertThat(resultBean.getId(), is(DEFAULT_EXAMPLE_ORG));
+            assertThat(resultBean.getDomain(), is(DEFAULT_EXAMPLE_ORG));
+            assertThat(resultBean.getMaxConnectionsPerEndpoint(), is(MAX_CONNECTIONS_PER_ENDPOINT * 2));
+        }
+    }
+
+    @Test
+    public void testGetAll() throws Exception {
+        configureAndStartServer();
+
+        try (final var client = new RawHttpClient("localhost", 8761)) {
+            final var result = client.get(CONNECTION_POOLS_PATH, credentials);
+            final var resultMap = MAPPER.readValue(result.getBodyString(), new MapTypeReference());
+            assertThat(resultMap.keySet(), is(Set.of("*", DEFAULT_EXAMPLE_ORG)));
+        }
+    }
+
+    @Test
+    public void testPostNewConnectionPool() throws Exception {
+        configureAndStartServer();
+        try (final var client = new RawHttpClient("localhost", 8761)) {
+            final var pool = buildConnectionPoolBean();
+            final var response = client.post(CONNECTION_POOLS_PATH, null, pool, credentials);
+            assertThat(response.getStatusLine(), containsString(CREATED));
+            final var config = server.getCurrentConfiguration();
+            assertThat(config.getConnectionPools().keySet(), is(Set.of(DEFAULT_EXAMPLE_ORG, ALTERNATIVE_EXAMPLE_COM)));
+            final var newConnectionPool = config.getConnectionPools().get(ALTERNATIVE_EXAMPLE_COM);
+            assertThat(newConnectionPool.getId(), is(ALTERNATIVE_EXAMPLE_COM));
+            assertThat(newConnectionPool.getDomain(), is(ALTERNATIVE_EXAMPLE_COM));
+            assertThat(newConnectionPool.getMaxConnectionsPerEndpoint(), is(MAX_CONNECTIONS_PER_ENDPOINT * 3));
+            assertThat(newConnectionPool.getBorrowTimeout(), is(BORROW_TIMEOUT));
+            assertThat(newConnectionPool.getConnectTimeout(), is(CONNECT_TIMEOUT));
+            assertThat(newConnectionPool.getStuckRequestTimeout(), is(STUCK_REQUEST_TIMEOUT));
+            assertThat(newConnectionPool.getIdleTimeout(), is(IDLE_TIMEOUT));
+            assertThat(newConnectionPool.getMaxLifeTime(), is(MAX_LIFE_TIME));
+            assertThat(newConnectionPool.getDisposeTimeout(), is(DISPOSE_TIMEOUT));
+            assertThat(newConnectionPool.getKeepaliveIdle(), is(KEEPALIVE_IDLE));
+            assertThat(newConnectionPool.getKeepaliveInterval(), is(KEEPALIVE_INTERVAL));
+            assertThat(newConnectionPool.getKeepaliveCount(), is(KEEPALIVE_COUNT));
+            assertThat(newConnectionPool.isKeepAlive(), is(true));
+            assertThat(newConnectionPool.isEnabled(), is(true));
+        }
+    }
+
+    @Test
+    public void testPutConnectionPoolModifications() throws Exception {
+        configureAndStartServer();
+        try (final var client = new RawHttpClient("localhost", 8761)) {
+            final var pool = buildConnectionPoolBean();
+            pool.setId(DEFAULT_EXAMPLE_ORG);
+            final var response = client.put(CONNECTION_POOLS_PATH + "/" + DEFAULT_EXAMPLE_ORG, null, pool, credentials);
+            assertThat(response.getStatusLine(), containsString(OK));
+            final var config = server.getCurrentConfiguration();
+            assertThat(config.getConnectionPools().keySet(), is(Set.of(DEFAULT_EXAMPLE_ORG)));
+            final var newConnectionPool = config.getConnectionPools().get(DEFAULT_EXAMPLE_ORG);
+            assertThat(newConnectionPool.getId(), is(DEFAULT_EXAMPLE_ORG));
+            assertThat(newConnectionPool.getDomain(), is(ALTERNATIVE_EXAMPLE_COM));
+            assertThat(newConnectionPool.getMaxConnectionsPerEndpoint(), is(MAX_CONNECTIONS_PER_ENDPOINT * 3));
+            assertThat(newConnectionPool.getBorrowTimeout(), is(BORROW_TIMEOUT));
+            assertThat(newConnectionPool.getConnectTimeout(), is(CONNECT_TIMEOUT));
+            assertThat(newConnectionPool.getStuckRequestTimeout(), is(STUCK_REQUEST_TIMEOUT));
+            assertThat(newConnectionPool.getIdleTimeout(), is(IDLE_TIMEOUT));
+            assertThat(newConnectionPool.getMaxLifeTime(), is(MAX_LIFE_TIME));
+            assertThat(newConnectionPool.getDisposeTimeout(), is(DISPOSE_TIMEOUT));
+            assertThat(newConnectionPool.getKeepaliveIdle(), is(KEEPALIVE_IDLE));
+            assertThat(newConnectionPool.getKeepaliveInterval(), is(KEEPALIVE_INTERVAL));
+            assertThat(newConnectionPool.getKeepaliveCount(), is(KEEPALIVE_COUNT));
+            assertThat(newConnectionPool.isKeepAlive(), is(true));
+            assertThat(newConnectionPool.isEnabled(), is(true));
+        }
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        configureAndStartServer();
+        try (final var client = new RawHttpClient("localhost", 8761)) {
+            final var response = client.delete(CONNECTION_POOLS_PATH + "/" + DEFAULT_EXAMPLE_ORG, credentials);
+            assertThat(response.getStatusLine(), containsString(OK));
+            final var config = server.getCurrentConfiguration();
+            assertThat(config.getConnectionPools().isEmpty(), is(true));
+        }
+    }
+
+    private static ConnectionPoolsResource.ConnectionPoolBean buildConnectionPoolBean() {
+        final var pool = new ConnectionPoolsResource.ConnectionPoolBean();
+        pool.setId(ALTERNATIVE_EXAMPLE_COM);
+        pool.setDomain(ALTERNATIVE_EXAMPLE_COM);
+        pool.setMaxConnectionsPerEndpoint(MAX_CONNECTIONS_PER_ENDPOINT * 3);
+        pool.setBorrowTimeout(BORROW_TIMEOUT);
+        pool.setConnectTimeout(CONNECT_TIMEOUT);
+        pool.setStuckRequestTimeout(STUCK_REQUEST_TIMEOUT);
+        pool.setIdleTimeout(IDLE_TIMEOUT);
+        pool.setMaxLifeTime(MAX_LIFE_TIME);
+        pool.setDisposeTimeout(DISPOSE_TIMEOUT);
+        pool.setKeepaliveIdle(KEEPALIVE_IDLE);
+        pool.setKeepaliveInterval(KEEPALIVE_INTERVAL);
+        pool.setKeepaliveCount(KEEPALIVE_COUNT);
+        pool.setKeepAlive(true);
+        pool.setEnabled(true);
+        return pool;
+    }
+
+    private static class MapTypeReference extends TypeReference<Map<String, ConnectionPoolsResource.ConnectionPoolBean>> {
+    }
+}

--- a/carapace-ui/pom.xml
+++ b/carapace-ui/pom.xml
@@ -37,7 +37,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
                 <configuration>
                     <source>17</source>
                     <target>17</target>
@@ -56,7 +55,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.2.1</version>
                 <configuration>
                     <packagingIncludes>ui/**</packagingIncludes>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -65,7 +63,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.6</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>

--- a/carapace-ui/pom.xml
+++ b/carapace-ui/pom.xml
@@ -6,7 +6,7 @@
         <groupId>org.carapaceproxy</groupId>
         <artifactId>carapace-parent</artifactId>
         <version>1.11.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>carapace-ui</artifactId>
     <packaging>war</packaging>

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,308 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.2.0
+#
+# Required ENV vars:
+# ------------------
+#   JAVA_HOME - location of a JDK home dir
+#
+# Optional ENV vars
+# -----------------
+#   MAVEN_OPTS - parameters passed to the Java VM when running Maven
+#     e.g. to debug Maven itself, use
+#       set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+#   MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+# ----------------------------------------------------------------------------
+
+if [ -z "$MAVEN_SKIP_RC" ] ; then
+
+  if [ -f /usr/local/etc/mavenrc ] ; then
+    . /usr/local/etc/mavenrc
+  fi
+
+  if [ -f /etc/mavenrc ] ; then
+    . /etc/mavenrc
+  fi
+
+  if [ -f "$HOME/.mavenrc" ] ; then
+    . "$HOME/.mavenrc"
+  fi
+
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+mingw=false
+case "$(uname)" in
+  CYGWIN*) cygwin=true ;;
+  MINGW*) mingw=true;;
+  Darwin*) darwin=true
+    # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
+    # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
+    if [ -z "$JAVA_HOME" ]; then
+      if [ -x "/usr/libexec/java_home" ]; then
+        JAVA_HOME="$(/usr/libexec/java_home)"; export JAVA_HOME
+      else
+        JAVA_HOME="/Library/Java/Home"; export JAVA_HOME
+      fi
+    fi
+    ;;
+esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if [ -r /etc/gentoo-release ] ; then
+    JAVA_HOME=$(java-config --jre-home)
+  fi
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=$(cygpath --path --unix "$CLASSPATH")
+fi
+
+# For Mingw, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$JAVA_HOME" ] && [ -d "$JAVA_HOME" ] &&
+    JAVA_HOME="$(cd "$JAVA_HOME" || (echo "cannot cd into $JAVA_HOME."; exit 1); pwd)"
+fi
+
+if [ -z "$JAVA_HOME" ]; then
+  javaExecutable="$(which javac)"
+  if [ -n "$javaExecutable" ] && ! [ "$(expr "\"$javaExecutable\"" : '\([^ ]*\)')" = "no" ]; then
+    # readlink(1) is not available as standard on Solaris 10.
+    readLink=$(which readlink)
+    if [ ! "$(expr "$readLink" : '\([^ ]*\)')" = "no" ]; then
+      if $darwin ; then
+        javaHome="$(dirname "\"$javaExecutable\"")"
+        javaExecutable="$(cd "\"$javaHome\"" && pwd -P)/javac"
+      else
+        javaExecutable="$(readlink -f "\"$javaExecutable\"")"
+      fi
+      javaHome="$(dirname "\"$javaExecutable\"")"
+      javaHome=$(expr "$javaHome" : '\(.*\)/bin')
+      JAVA_HOME="$javaHome"
+      export JAVA_HOME
+    fi
+  fi
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD="$(\unset -f command 2>/dev/null; \command -v java)"
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." >&2
+  echo "  We cannot execute $JAVACMD" >&2
+  exit 1
+fi
+
+if [ -z "$JAVA_HOME" ] ; then
+  echo "Warning: JAVA_HOME environment variable is not set."
+fi
+
+# traverses directory structure from process work directory to filesystem root
+# first directory with .mvn subdirectory is considered project base directory
+find_maven_basedir() {
+  if [ -z "$1" ]
+  then
+    echo "Path not specified to find_maven_basedir"
+    return 1
+  fi
+
+  basedir="$1"
+  wdir="$1"
+  while [ "$wdir" != '/' ] ; do
+    if [ -d "$wdir"/.mvn ] ; then
+      basedir=$wdir
+      break
+    fi
+    # workaround for JBEAP-8937 (on Solaris 10/Sparc)
+    if [ -d "${wdir}" ]; then
+      wdir=$(cd "$wdir/.." || exit 1; pwd)
+    fi
+    # end of workaround
+  done
+  printf '%s' "$(cd "$basedir" || exit 1; pwd)"
+}
+
+# concatenates all lines of a file
+concat_lines() {
+  if [ -f "$1" ]; then
+    # Remove \r in case we run on Windows within Git Bash
+    # and check out the repository with auto CRLF management
+    # enabled. Otherwise, we may read lines that are delimited with
+    # \r\n and produce $'-Xarg\r' rather than -Xarg due to word
+    # splitting rules.
+    tr -s '\r\n' ' ' < "$1"
+  fi
+}
+
+log() {
+  if [ "$MVNW_VERBOSE" = true ]; then
+    printf '%s\n' "$1"
+  fi
+}
+
+BASE_DIR=$(find_maven_basedir "$(dirname "$0")")
+if [ -z "$BASE_DIR" ]; then
+  exit 1;
+fi
+
+MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}; export MAVEN_PROJECTBASEDIR
+log "$MAVEN_PROJECTBASEDIR"
+
+##########################################################################################
+# Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+# This allows using the maven wrapper in projects that prohibit checking in binary data.
+##########################################################################################
+wrapperJarPath="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar"
+if [ -r "$wrapperJarPath" ]; then
+    log "Found $wrapperJarPath"
+else
+    log "Couldn't find $wrapperJarPath, downloading it ..."
+
+    if [ -n "$MVNW_REPOURL" ]; then
+      wrapperUrl="$MVNW_REPOURL/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+    else
+      wrapperUrl="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+    fi
+    while IFS="=" read -r key value; do
+      # Remove '\r' from value to allow usage on windows as IFS does not consider '\r' as a separator ( considers space, tab, new line ('\n'), and custom '=' )
+      safeValue=$(echo "$value" | tr -d '\r')
+      case "$key" in (wrapperUrl) wrapperUrl="$safeValue"; break ;;
+      esac
+    done < "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
+    log "Downloading from: $wrapperUrl"
+
+    if $cygwin; then
+      wrapperJarPath=$(cygpath --path --windows "$wrapperJarPath")
+    fi
+
+    if command -v wget > /dev/null; then
+        log "Found wget ... using wget"
+        [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--quiet"
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            wget $QUIET "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+        else
+            wget $QUIET --http-user="$MVNW_USERNAME" --http-password="$MVNW_PASSWORD" "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+        fi
+    elif command -v curl > /dev/null; then
+        log "Found curl ... using curl"
+        [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--silent"
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            curl $QUIET -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
+        else
+            curl $QUIET --user "$MVNW_USERNAME:$MVNW_PASSWORD" -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
+        fi
+    else
+        log "Falling back to using Java to download"
+        javaSource="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.java"
+        javaClass="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.class"
+        # For Cygwin, switch paths to Windows format before running javac
+        if $cygwin; then
+          javaSource=$(cygpath --path --windows "$javaSource")
+          javaClass=$(cygpath --path --windows "$javaClass")
+        fi
+        if [ -e "$javaSource" ]; then
+            if [ ! -e "$javaClass" ]; then
+                log " - Compiling MavenWrapperDownloader.java ..."
+                ("$JAVA_HOME/bin/javac" "$javaSource")
+            fi
+            if [ -e "$javaClass" ]; then
+                log " - Running MavenWrapperDownloader.java ..."
+                ("$JAVA_HOME/bin/java" -cp .mvn/wrapper MavenWrapperDownloader "$wrapperUrl" "$wrapperJarPath") || rm -f "$wrapperJarPath"
+            fi
+        fi
+    fi
+fi
+##########################################################################################
+# End of extension
+##########################################################################################
+
+# If specified, validate the SHA-256 sum of the Maven wrapper jar file
+wrapperSha256Sum=""
+while IFS="=" read -r key value; do
+  case "$key" in (wrapperSha256Sum) wrapperSha256Sum=$value; break ;;
+  esac
+done < "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
+if [ -n "$wrapperSha256Sum" ]; then
+  wrapperSha256Result=false
+  if command -v sha256sum > /dev/null; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | sha256sum -c > /dev/null 2>&1; then
+      wrapperSha256Result=true
+    fi
+  elif command -v shasum > /dev/null; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | shasum -a 256 -c > /dev/null 2>&1; then
+      wrapperSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available."
+    echo "Please install either command, or disable validation by removing 'wrapperSha256Sum' from your maven-wrapper.properties."
+    exit 1
+  fi
+  if [ $wrapperSha256Result = false ]; then
+    echo "Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised." >&2
+    echo "Investigate or delete $wrapperJarPath to attempt a clean download." >&2
+    echo "If you updated your Maven version, you need to update the specified wrapperSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=$(cygpath --path --windows "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=$(cygpath --path --windows "$CLASSPATH")
+  [ -n "$MAVEN_PROJECTBASEDIR" ] &&
+    MAVEN_PROJECTBASEDIR=$(cygpath --path --windows "$MAVEN_PROJECTBASEDIR")
+fi
+
+# Provide a "standardized" way to retrieve the CLI args that will
+# work with both Windows and non-Windows executions.
+MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $*"
+export MAVEN_CMD_LINE_ARGS
+
+WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+# shellcheck disable=SC2086 # safe args
+exec "$JAVACMD" \
+  $MAVEN_OPTS \
+  $MAVEN_DEBUG_OPTS \
+  -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
+  "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
+  ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,205 @@
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.2.0
+@REM
+@REM Required ENV vars:
+@REM JAVA_HOME - location of a JDK home dir
+@REM
+@REM Optional ENV vars
+@REM MAVEN_BATCH_ECHO - set to 'on' to enable the echoing of the batch commands
+@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a keystroke before ending
+@REM MAVEN_OPTS - parameters passed to the Java VM when running Maven
+@REM     e.g. to debug Maven itself, use
+@REM set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+@REM MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+@REM ----------------------------------------------------------------------------
+
+@REM Begin all REM lines with '@' in case MAVEN_BATCH_ECHO is 'on'
+@echo off
+@REM set title of command window
+title %0
+@REM enable echoing by setting MAVEN_BATCH_ECHO to 'on'
+@if "%MAVEN_BATCH_ECHO%" == "on"  echo %MAVEN_BATCH_ECHO%
+
+@REM set %HOME% to equivalent of $HOME
+if "%HOME%" == "" (set "HOME=%HOMEDRIVE%%HOMEPATH%")
+
+@REM Execute a user defined script before this one
+if not "%MAVEN_SKIP_RC%" == "" goto skipRcPre
+@REM check for pre script, once with legacy .bat ending and once with .cmd ending
+if exist "%USERPROFILE%\mavenrc_pre.bat" call "%USERPROFILE%\mavenrc_pre.bat" %*
+if exist "%USERPROFILE%\mavenrc_pre.cmd" call "%USERPROFILE%\mavenrc_pre.cmd" %*
+:skipRcPre
+
+@setlocal
+
+set ERROR_CODE=0
+
+@REM To isolate internal variables from possible post scripts, we use another setlocal
+@setlocal
+
+@REM ==== START VALIDATION ====
+if not "%JAVA_HOME%" == "" goto OkJHome
+
+echo.
+echo Error: JAVA_HOME not found in your environment. >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo.
+goto error
+
+:OkJHome
+if exist "%JAVA_HOME%\bin\java.exe" goto init
+
+echo.
+echo Error: JAVA_HOME is set to an invalid directory. >&2
+echo JAVA_HOME = "%JAVA_HOME%" >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo.
+goto error
+
+@REM ==== END VALIDATION ====
+
+:init
+
+@REM Find the project base dir, i.e. the directory that contains the folder ".mvn".
+@REM Fallback to current working directory if not found.
+
+set MAVEN_PROJECTBASEDIR=%MAVEN_BASEDIR%
+IF NOT "%MAVEN_PROJECTBASEDIR%"=="" goto endDetectBaseDir
+
+set EXEC_DIR=%CD%
+set WDIR=%EXEC_DIR%
+:findBaseDir
+IF EXIST "%WDIR%"\.mvn goto baseDirFound
+cd ..
+IF "%WDIR%"=="%CD%" goto baseDirNotFound
+set WDIR=%CD%
+goto findBaseDir
+
+:baseDirFound
+set MAVEN_PROJECTBASEDIR=%WDIR%
+cd "%EXEC_DIR%"
+goto endDetectBaseDir
+
+:baseDirNotFound
+set MAVEN_PROJECTBASEDIR=%EXEC_DIR%
+cd "%EXEC_DIR%"
+
+:endDetectBaseDir
+
+IF NOT EXIST "%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config" goto endReadAdditionalConfig
+
+@setlocal EnableExtensions EnableDelayedExpansion
+for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do set JVM_CONFIG_MAVEN_PROPS=!JVM_CONFIG_MAVEN_PROPS! %%a
+@endlocal & set JVM_CONFIG_MAVEN_PROPS=%JVM_CONFIG_MAVEN_PROPS%
+
+:endReadAdditionalConfig
+
+SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
+set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
+set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+set WRAPPER_URL="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+
+FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+    IF "%%A"=="wrapperUrl" SET WRAPPER_URL=%%B
+)
+
+@REM Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+@REM This allows using the maven wrapper in projects that prohibit checking in binary data.
+if exist %WRAPPER_JAR% (
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Found %WRAPPER_JAR%
+    )
+) else (
+    if not "%MVNW_REPOURL%" == "" (
+        SET WRAPPER_URL="%MVNW_REPOURL%/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+    )
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Couldn't find %WRAPPER_JAR%, downloading it ...
+        echo Downloading from: %WRAPPER_URL%
+    )
+
+    powershell -Command "&{"^
+		"$webclient = new-object System.Net.WebClient;"^
+		"if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
+		"$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
+		"}"^
+		"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%WRAPPER_URL%', '%WRAPPER_JAR%')"^
+		"}"
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Finished downloading %WRAPPER_JAR%
+    )
+)
+@REM End of extension
+
+@REM If specified, validate the SHA-256 sum of the Maven wrapper jar file
+SET WRAPPER_SHA_256_SUM=""
+FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+    IF "%%A"=="wrapperSha256Sum" SET WRAPPER_SHA_256_SUM=%%B
+)
+IF NOT %WRAPPER_SHA_256_SUM%=="" (
+    powershell -Command "&{"^
+       "$hash = (Get-FileHash \"%WRAPPER_JAR%\" -Algorithm SHA256).Hash.ToLower();"^
+       "If('%WRAPPER_SHA_256_SUM%' -ne $hash){"^
+       "  Write-Output 'Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised.';"^
+       "  Write-Output 'Investigate or delete %WRAPPER_JAR% to attempt a clean download.';"^
+       "  Write-Output 'If you updated your Maven version, you need to update the specified wrapperSha256Sum property.';"^
+       "  exit 1;"^
+       "}"^
+       "}"
+    if ERRORLEVEL 1 goto error
+)
+
+@REM Provide a "standardized" way to retrieve the CLI args that will
+@REM work with both Windows and non-Windows executions.
+set MAVEN_CMD_LINE_ARGS=%*
+
+%MAVEN_JAVA_EXE% ^
+  %JVM_CONFIG_MAVEN_PROPS% ^
+  %MAVEN_OPTS% ^
+  %MAVEN_DEBUG_OPTS% ^
+  -classpath %WRAPPER_JAR% ^
+  "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" ^
+  %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
+if ERRORLEVEL 1 goto error
+goto end
+
+:error
+set ERROR_CODE=1
+
+:end
+@endlocal & set ERROR_CODE=%ERROR_CODE%
+
+if not "%MAVEN_SKIP_RC%"=="" goto skipRcPost
+@REM check for post script, once with legacy .bat ending and once with .cmd ending
+if exist "%USERPROFILE%\mavenrc_post.bat" call "%USERPROFILE%\mavenrc_post.bat"
+if exist "%USERPROFILE%\mavenrc_post.cmd" call "%USERPROFILE%\mavenrc_post.cmd"
+:skipRcPost
+
+@REM pause the script if MAVEN_BATCH_PAUSE is set to 'on'
+if "%MAVEN_BATCH_PAUSE%"=="on" pause
+
+if "%MAVEN_TERMINATE_CMD%"=="on" exit %ERROR_CODE%
+
+cmd /C exit /B %ERROR_CODE%


### PR DESCRIPTION
See #419 

## Additional features and fixes

### Maven wrapper

During the CI pipeline, I experienced some problems between Java 21 and the version of the `maven-compiler-plugin` bundled with the version of maven provided with the GitHub Actions.

To pin a specific version of Maven, I decided to introduce the [wrapper](https://maven.apache.org/wrapper): like Gradle, it introduces a couple of shell scripts (plus a Java one) that handle the download and the execution of a specific version of the build system, in fact making it another dependency of the project.

This is good to control better how the build is done, both in CI and in development.

### GitHub Actions workflow

- Java version was updated to Java 21
- Now using Maven wrapper instead of Maven directly
- Updated dorny/test-reporter action to version v1.9.1, that allows to use v4 of actions/upload-artifact and actions/checkout, which were deprecated

### JUnit 5 Vintage dependency excluded

see https://github.com/diennea/carapaceproxy/issues/440

