### PR TITLE
feat(server): Trust `X-Forwarded-For` header for some IPs

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -165,7 +165,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
@@ -180,6 +179,11 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>${libs.commons-io}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+            <version>${libs.commons-net}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/carapace-server/src/main/java/org/carapaceproxy/api/RequestFiltersResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/RequestFiltersResource.java
@@ -27,9 +27,14 @@ import javax.servlet.ServletContext;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import org.carapaceproxy.core.HttpProxyServer;
 import org.carapaceproxy.core.RequestFilter;
-import org.carapaceproxy.server.filters.*;
+import org.carapaceproxy.server.filters.RegexpMapSessionIdFilter;
+import org.carapaceproxy.server.filters.RegexpMapUserIdFilter;
+import org.carapaceproxy.server.filters.XForwardedForRequestFilter;
+import org.carapaceproxy.server.filters.XTlsCipherRequestFilter;
+import org.carapaceproxy.server.filters.XTlsProtocolRequestFilter;
 
 /**
  * Access to request filters
@@ -40,8 +45,8 @@ import org.carapaceproxy.server.filters.*;
 @Produces("application/json")
 public class RequestFiltersResource {
 
-    @javax.ws.rs.core.Context
-    ServletContext context;
+    @Context
+    private ServletContext context;
 
     public static final class RequestFilterBean {
 
@@ -68,6 +73,7 @@ public class RequestFiltersResource {
 
     @GET
     @Path("/")
+    @SuppressWarnings("deprecation")
     public List<RequestFilterBean> getAllRequestFilters() {
         HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
 
@@ -77,20 +83,18 @@ public class RequestFiltersResource {
             if (f instanceof XForwardedForRequestFilter) {
                 filterBean.setType(XForwardedForRequestFilter.TYPE);
                 res.add(filterBean);
-            } else if(f instanceof XTlsCipherRequestFilter){
+            } else if (f instanceof XTlsCipherRequestFilter) {
                 filterBean.setType(XTlsCipherRequestFilter.TYPE);
                 res.add(filterBean);
-            } else if(f instanceof XTlsProtocolRequestFilter){
+            } else if (f instanceof XTlsProtocolRequestFilter) {
                 filterBean.setType(XTlsProtocolRequestFilter.TYPE);
                 res.add(filterBean);
-            } else if (f instanceof RegexpMapUserIdFilter) {
-                RegexpMapUserIdFilter filter = (RegexpMapUserIdFilter) f;
+            } else if (f instanceof final RegexpMapUserIdFilter filter) {
                 filterBean.setType(RegexpMapUserIdFilter.TYPE);
                 filterBean.addValue("parameterName", filter.getParameterName());
                 filterBean.addValue("compiledPattern", filter.getCompiledPattern());
                 res.add(filterBean);
-            } else if (f instanceof RegexpMapSessionIdFilter) {
-                RegexpMapSessionIdFilter filter = (RegexpMapSessionIdFilter) f;
+            } else if (f instanceof final RegexpMapSessionIdFilter filter) {
                 filterBean.setType(RegexpMapSessionIdFilter.TYPE);
                 filterBean.addValue("parameterName", filter.getParameterName());
                 filterBean.addValue("compiledPattern", filter.getCompiledPattern());

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ForwardedStrategies.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ForwardedStrategies.java
@@ -78,7 +78,7 @@ public final class ForwardedStrategies {
 
     record IfTrusted(Set<String> trustedIps) implements ForwardedStrategy {
 
-        static final String NAME = "if-trusted";
+        static final String NAME = "IF_TRUSTED";
 
         @Override
         public ConnectionInfo apply(final ConnectionInfo connectionInfo, final HttpRequest request) {

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ForwardedStrategies.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ForwardedStrategies.java
@@ -1,0 +1,113 @@
+package org.carapaceproxy.core;
+
+import com.google.common.net.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import java.util.Set;
+import org.apache.commons.net.util.SubnetUtils;
+import reactor.netty.http.server.ConnectionInfo;
+
+public final class ForwardedStrategies {
+    private ForwardedStrategies() {
+        throw new AssertionError();
+    }
+
+    /**
+     * Always drop the {@link HttpHeaders#X_FORWARDED_FOR} header.
+     *
+     * @return the strategy
+     */
+    public static ForwardedStrategy drop() {
+        return StaticStrategies.DROP;
+    }
+
+    /**
+     * Act like {@link #preserve()} if host address is one of the trusted ones, else act like {@link #rewrite()}.
+     *
+     * @return the strategy
+     */
+    public static ForwardedStrategy ifTrusted(final Set<String> trustedIps) {
+        return new IfTrusted(trustedIps);
+    }
+
+    /**
+     * Always preserve the {@link HttpHeaders#X_FORWARDED_FOR} header.
+     *
+     * @return the strategy
+     */
+    public static ForwardedStrategy preserve() {
+        return StaticStrategies.PRESERVE;
+    }
+
+    /**
+     * Always rewrite the {@link HttpHeaders#X_FORWARDED_FOR} header with the current IP.
+     *
+     * @return the strategy
+     */
+    public static ForwardedStrategy rewrite() {
+        return StaticStrategies.REWRITE;
+    }
+
+    enum StaticStrategies implements ForwardedStrategy {
+        DROP {
+            @Override
+            public ConnectionInfo apply(final ConnectionInfo connectionInfo, final HttpRequest request) {
+                request.headers().remove(HttpHeaders.X_FORWARDED_FOR);
+                return connectionInfo;
+            }
+        },
+
+        PRESERVE {
+            @Override
+            public ConnectionInfo apply(final ConnectionInfo connectionInfo, final HttpRequest httpRequest) {
+                return connectionInfo;
+            }
+        },
+
+        REWRITE {
+            @Override
+            public ConnectionInfo apply(final ConnectionInfo connectionInfo, final HttpRequest request) {
+                request.headers().remove(HttpHeaders.X_FORWARDED_FOR);
+                final var remoteAddress = connectionInfo.getRemoteAddress();
+                if (remoteAddress != null) {
+                    request.headers().add(HttpHeaders.X_FORWARDED_FOR, remoteAddress.getAddress().getHostAddress());
+                }
+                return connectionInfo;
+            }
+        }
+    }
+
+    record IfTrusted(Set<String> trustedIps) implements ForwardedStrategy {
+
+        static final String NAME = "if-trusted";
+
+        @Override
+        public ConnectionInfo apply(final ConnectionInfo connectionInfo, final HttpRequest request) {
+            if (validate(connectionInfo)) {
+                return preserve().apply(connectionInfo, request);
+            }
+            return rewrite().apply(connectionInfo, request);
+        }
+
+        private boolean validate(final ConnectionInfo connectionInfo) {
+            if (trustedIps == null) {
+                return false;
+            }
+            final var address = connectionInfo.getRemoteAddress();
+            if (address == null) {
+                return false;
+            }
+            for (final var cidr : trustedIps) {
+                final var subnetInfo = new SubnetUtils(cidr).getInfo();
+                if (subnetInfo.isInRange(address.getAddress().getHostAddress())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public String name() {
+            return NAME;
+        }
+    }
+}

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ForwardedStrategy.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ForwardedStrategy.java
@@ -1,0 +1,44 @@
+package org.carapaceproxy.core;
+
+import static org.carapaceproxy.core.ForwardedStrategies.StaticStrategies;
+import com.google.common.net.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import java.util.Set;
+import java.util.function.BiFunction;
+import org.carapaceproxy.configstore.ConfigurationStore;
+import org.carapaceproxy.core.ForwardedStrategies.IfTrusted;
+import reactor.netty.http.server.ConnectionInfo;
+
+public sealed interface ForwardedStrategy extends BiFunction<ConnectionInfo, HttpRequest, ConnectionInfo> permits StaticStrategies, IfTrusted {
+
+    /**
+     * Choose a strategy to handle {@value HttpHeaders#X_FORWARDED_FOR} header given and optional set of trusted IPs.
+     *
+     * @param name       the name of the strategy from the {@link ConfigurationStore config}
+     * @param trustedIps an optional set of trusted IPs from the {@link ConfigurationStore config}
+     * @return the appropriate strategy object
+     */
+    static ForwardedStrategy of(final String name, final Set<String> trustedIps) {
+        if (StaticStrategies.DROP.name().equals(name)) {
+            return ForwardedStrategies.drop();
+        }
+        if (StaticStrategies.PRESERVE.name().equals(name)) {
+            return ForwardedStrategies.preserve();
+        }
+        if (StaticStrategies.REWRITE.name().equals(name)) {
+            return ForwardedStrategies.rewrite();
+        }
+        if (IfTrusted.NAME.equals(name)) {
+            return ForwardedStrategies.ifTrusted(trustedIps);
+        }
+        throw new IllegalArgumentException("Unexpected forwarded strategy: " + name);
+    }
+
+    /**
+     * Get a name for the strategy.
+     *
+     * @return the name
+     * @see Enum#name()
+     */
+    String name();
+}

--- a/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
@@ -21,6 +21,7 @@ package org.carapaceproxy.core;
 
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_DAYS_BEFORE_RENEWAL;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_FORWARDED_STRATEGY;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
 import static org.carapaceproxy.server.filters.RequestFilterFactory.buildRequestFilter;
 import java.io.File;
@@ -326,8 +327,9 @@ public class RuntimeServerConfiguration {
                         properties.getInt(prefix + "keepaliveidle", keepaliveIdle),
                         properties.getInt(prefix + "keepaliveinterval", keepaliveInterval),
                         properties.getInt(prefix + "keepalivecount", keepaliveCount),
-                        properties.getInt(prefix + "maxkeepaliverequests", maxKeepAliveRequests)
-
+                        properties.getInt(prefix + "maxkeepaliverequests", maxKeepAliveRequests),
+                        properties.getString(prefix + "forwarded", DEFAULT_FORWARDED_STRATEGY),
+                        properties.getValues(prefix + "trustedips", Set.of())
                 ));
             }
         }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/NetworkListenerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/NetworkListenerConfiguration.java
@@ -19,83 +19,85 @@
  */
 package org.carapaceproxy.server.config;
 
-import java.util.Collections;
-import java.util.Set;
-
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.util.concurrent.DefaultEventExecutor;
-import lombok.Data;
+import java.util.Set;
+import lombok.Getter;
+import org.carapaceproxy.core.ForwardedStrategies;
 
 /**
  * Listens for connections on the network
  */
-@Data
+@Getter
 public class NetworkListenerConfiguration {
 
     public static final Set<String> DEFAULT_SSL_PROTOCOLS = Set.of("TLSv1.2", "TLSv1.3");
+    public static final int DEFAULT_SO_BACKLOG = 128;
+    public static final int DEFAULT_KEEP_ALIVE_IDLE = 300;
+    public static final int DEFAULT_KEEP_ALIVE_INTERVAL = 60;
+    public static final int DEFAULT_KEEP_ALIVE_COUNT = 8;
+    public static final int DEFAULT_MAX_KEEP_ALIVE_REQUESTS = 1000;
+    public static final String DEFAULT_FORWARDED_STRATEGY = ForwardedStrategies.preserve().name();
 
     private final String host;
     private final int port;
     private final boolean ssl;
     private final String sslCiphers;
     private final String defaultCertificate;
-    private Set<String> sslProtocols = Collections.emptySet();
-    private int soBacklog;
-    private boolean keepAlive;
-    private int keepAliveIdle;
-    private int keepAliveInterval;
-    private int keepAliveCount;
-    private int maxKeepAliveRequests;
+    private final String forwardedStrategy;
+    private final Set<String> trustedIps;
+    private final Set<String> sslProtocols;
+    private final int soBacklog;
+    private final boolean keepAlive;
+    private final int keepAliveIdle;
+    private final int keepAliveInterval;
+    private final int keepAliveCount;
+    private final int maxKeepAliveRequests;
+    private final ChannelGroup group;
 
-    private ChannelGroup group;
-
-    public HostPort getKey() {
-        return new HostPort(host, port);
+    public NetworkListenerConfiguration(final String host, final int port) {
+        this(
+                host,
+                port,
+                false,
+                null,
+                null,
+                DEFAULT_SSL_PROTOCOLS,
+                DEFAULT_SO_BACKLOG,
+                true,
+                DEFAULT_KEEP_ALIVE_IDLE,
+                DEFAULT_KEEP_ALIVE_INTERVAL,
+                DEFAULT_KEEP_ALIVE_COUNT,
+                DEFAULT_MAX_KEEP_ALIVE_REQUESTS,
+                DEFAULT_FORWARDED_STRATEGY,
+                Set.of()
+        );
     }
 
-    public record HostPort(String host, int port) {}
-
-    public NetworkListenerConfiguration(String host, int port) {
-        this(host, port, false, null, null, Collections.emptySet(),
-                128,true, 300, 60, 8, 1000);
-    }
-
-    public NetworkListenerConfiguration(String host,
-                                        int port,
-                                        boolean ssl,
-                                        String sslCiphers,
-                                        String defaultCertificate,
-                                        int soBacklog,
-                                        boolean keepAlive,
-                                        int keepAliveIdle,
-                                        int keepAliveInterval,
-                                        int keepAliveCount,
-                                        int maxKeepAliveRequests) {
-        this(host, port, ssl, sslCiphers, defaultCertificate, DEFAULT_SSL_PROTOCOLS,
-                soBacklog, keepAlive, keepAliveIdle, keepAliveInterval, keepAliveCount, maxKeepAliveRequests);
-    }
-
-    public NetworkListenerConfiguration(String host,
-                                        int port,
-                                        boolean ssl,
-                                        String sslCiphers,
-                                        String defaultCertificate,
-                                        Set<String> sslProtocols,
-                                        int soBacklog,
-                                        boolean keepAlive,
-                                        int keepAliveIdle,
-                                        int keepAliveInterval,
-                                        int keepAliveCount,
-                                        int maxKeepAliveRequests) {
+    public NetworkListenerConfiguration(
+            final String host,
+            final int port,
+            final boolean ssl,
+            final String sslCiphers,
+            final String defaultCertificate,
+            final Set<String> sslProtocols,
+            final int soBacklog,
+            final boolean keepAlive,
+            final int keepAliveIdle,
+            final int keepAliveInterval,
+            final int keepAliveCount,
+            final int maxKeepAliveRequests,
+            final String forwardedStrategy,
+            final Set<String> trustedIps) {
         this.host = host;
         this.port = port;
         this.ssl = ssl;
         this.sslCiphers = sslCiphers;
         this.defaultCertificate = defaultCertificate;
-        if (ssl) {
-            this.sslProtocols = sslProtocols;
-        }
+        this.forwardedStrategy = forwardedStrategy;
+        this.trustedIps = trustedIps;
+        this.sslProtocols = ssl ? sslProtocols : Set.of();
         this.soBacklog = soBacklog;
         this.keepAlive = keepAlive;
         this.keepAliveIdle = keepAliveIdle;
@@ -103,6 +105,13 @@ public class NetworkListenerConfiguration {
         this.keepAliveCount = keepAliveCount;
         this.maxKeepAliveRequests = maxKeepAliveRequests;
         this.group = new DefaultChannelGroup(new DefaultEventExecutor());
+    }
+
+    public HostPort getKey() {
+        return new HostPort(host, port);
+    }
+
+    public record HostPort(String host, int port) {
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/filters/RequestFilterFactory.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/filters/RequestFilterFactory.java
@@ -34,6 +34,7 @@ import org.carapaceproxy.server.mapper.requestmatcher.parser.RequestMatchParser;
  */
 public class RequestFilterFactory {
 
+    @SuppressWarnings("deprecation")
     public static RequestFilter buildRequestFilter(RequestFilterConfiguration config) throws ConfigurationNotValidException {
         String type = config.getType();
         Map<String, String> filterConfig = config.getFilterConfig();

--- a/carapace-server/src/main/java/org/carapaceproxy/server/filters/XForwardedForRequestFilter.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/filters/XForwardedForRequestFilter.java
@@ -26,8 +26,10 @@ import org.carapaceproxy.server.mapper.requestmatcher.RequestMatcher;
 /**
  * Add a X-Forwarded-For Header
  */
+@Deprecated
 public class XForwardedForRequestFilter extends BasicRequestFilter {
 
+    @Deprecated
     public static final String TYPE = "add-x-forwarded-for";
 
     public XForwardedForRequestFilter(RequestMatcher matcher) {

--- a/carapace-server/src/test/java/org/carapaceproxy/ApplyConfigurationTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/ApplyConfigurationTest.java
@@ -331,6 +331,7 @@ public class ApplyConfigurationTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testChangeFiltersConfiguration() throws Exception {
 

--- a/carapace-server/src/test/java/org/carapaceproxy/DatabaseConfigurationTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/DatabaseConfigurationTest.java
@@ -63,6 +63,7 @@ public class DatabaseConfigurationTest {
 
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     @Ignore
     public void testChangeFiltersConfiguration() throws Exception {

--- a/carapace-server/src/test/java/org/carapaceproxy/RawClientTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/RawClientTest.java
@@ -29,6 +29,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_FORWARDED_STRATEGY;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
 import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.STATIC;
 import static org.carapaceproxy.utils.RawHttpClient.consumeHttpResponseInput;
 import static org.hamcrest.CoreMatchers.is;
@@ -73,6 +75,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -747,8 +750,7 @@ public class RawClientTest {
         EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot());) {
             server.addCertificate(new SSLCertificateConfiguration("localhost", null, "localhost.p12", "testproxy", STATIC));
-            server.addListener(new NetworkListenerConfiguration("localhost", 0, scheme.equals("https"), null, "localhost", 128,
-                    true, 300, 60, 8, 100));
+            server.addListener(new NetworkListenerConfiguration("localhost", 0, scheme.equals("https"), null, "localhost", DEFAULT_SSL_PROTOCOLS, 128, true, 300, 60, 8, 100, DEFAULT_FORWARDED_STRATEGY, Set.of()));
 
             server.start();
             int port = server.getLocalPort();

--- a/carapace-server/src/test/java/org/carapaceproxy/SimpleHTTPProxyTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/SimpleHTTPProxyTest.java
@@ -24,6 +24,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_FORWARDED_STRATEGY;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
 import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.STATIC;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -32,6 +34,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.net.URL;
 import java.util.Collections;
+import java.util.Set;
 import org.apache.commons.io.IOUtils;
 import org.carapaceproxy.client.EndpointKey;
 import org.carapaceproxy.core.HttpProxyServer;
@@ -108,7 +111,7 @@ public class SimpleHTTPProxyTest {
 
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot());) {
             server.addCertificate(new SSLCertificateConfiguration("localhost", null, certificate, "changeit", STATIC));
-            server.addListener(new NetworkListenerConfiguration("localhost", 0, true, null, "localhost", 128, true, 300, 60, 8, 1000));
+            server.addListener(new NetworkListenerConfiguration("localhost", 0, true, null, "localhost", DEFAULT_SSL_PROTOCOLS, 128, true, 300, 60, 8, 1000, DEFAULT_FORWARDED_STRATEGY, Set.of()));
             server.start();
             int port = server.getLocalPort();
 

--- a/carapace-server/src/test/java/org/carapaceproxy/api/StartAPIServerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/StartAPIServerTest.java
@@ -522,6 +522,7 @@ public class StartAPIServerTest extends UseAdminServer {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testResourcesFilter() throws Exception {
         Properties properties = new Properties(HTTP_ADMIN_SERVER_CONFIG);

--- a/carapace-server/src/test/java/org/carapaceproxy/core/ForwardedStrategyTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/ForwardedStrategyTest.java
@@ -1,0 +1,199 @@
+package org.carapaceproxy.core;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_KEEP_ALIVE_COUNT;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_KEEP_ALIVE_IDLE;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_KEEP_ALIVE_INTERVAL;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_MAX_KEEP_ALIVE_REQUESTS;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SO_BACKLOG;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.io.IOException;
+import java.util.Set;
+import org.carapaceproxy.server.config.ConfigurationNotValidException;
+import org.carapaceproxy.server.config.NetworkListenerConfiguration;
+import org.carapaceproxy.utils.RawHttpClient;
+import org.carapaceproxy.utils.TestEndpointMapper;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ForwardedStrategyTest {
+    public static final String REAL_IP_ADDRESS = "127.0.0.1";
+    public static final String FORWARDED_IP_ADDRESS = "1.2.3.4";
+    public static final String HEADER_PRESENT = "Header present!";
+    public static final String HEADER_REWRITTEN = "Header rewritten!";
+    public static final String NO_HEADER = "No header!";
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(0);
+
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
+
+    @Before
+    public void setupWireMock() {
+        stubFor(get(urlEqualTo("/index.html"))
+                .withHeader("X-Forwarded-For", equalTo(FORWARDED_IP_ADDRESS))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/html")
+                        .withBody(HEADER_PRESENT)));
+        stubFor(get(urlEqualTo("/index.html"))
+                .withHeader("X-Forwarded-For", equalTo(REAL_IP_ADDRESS))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/html")
+                        .withBody(HEADER_REWRITTEN)));
+        stubFor(get(urlEqualTo("/index.html"))
+                .withHeader("X-Forwarded-For", absent())
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/html")
+                        .withBody(NO_HEADER)));
+    }
+
+    @Test
+    public void testDropStrategy() throws IOException, ConfigurationNotValidException, InterruptedException {
+        final var mapper = new TestEndpointMapper("localhost", wireMockRule.port());
+        try (final var server = new HttpProxyServer(mapper, tmpDir.newFolder())) {
+            server.addListener(getConfiguration(ForwardedStrategies.drop(), Set.of()));
+            server.start();
+            int port = server.getLocalPort();
+            assertTrue(port > 0);
+            try (final var client = new RawHttpClient("localhost", port)) {
+                final var response = requestWithoutHeader(client);
+                assertThat(response, containsString(NO_HEADER));
+            }
+            try (final var client = new RawHttpClient("localhost", port)) {
+                final var response = requestWithHeader(client);
+                assertThat(response, containsString(NO_HEADER));
+            }
+        }
+    }
+
+    @Test
+    public void testPreserveStrategy() throws IOException, ConfigurationNotValidException, InterruptedException {
+        final var mapper = new TestEndpointMapper("localhost", wireMockRule.port());
+        try (final var server = new HttpProxyServer(mapper, tmpDir.newFolder())) {
+            server.addListener(getConfiguration(ForwardedStrategies.preserve(), Set.of()));
+            server.start();
+            int port = server.getLocalPort();
+            assertTrue(port > 0);
+            try (final var client = new RawHttpClient("localhost", port)) {
+                final var response = requestWithoutHeader(client);
+                assertThat(response, containsString(NO_HEADER));
+            }
+            try (final var client = new RawHttpClient("localhost", port)) {
+                final var response = requestWithHeader(client);
+                assertThat(response, containsString(HEADER_PRESENT));
+            }
+        }
+    }
+
+    @Test
+    public void testRewriteStrategy() throws IOException, ConfigurationNotValidException, InterruptedException {
+        final var mapper = new TestEndpointMapper("localhost", wireMockRule.port());
+        try (final var server = new HttpProxyServer(mapper, tmpDir.newFolder())) {
+            server.addListener(getConfiguration(ForwardedStrategies.rewrite(), Set.of()));
+            server.start();
+            int port = server.getLocalPort();
+            assertTrue(port > 0);
+            try (final var client = new RawHttpClient("localhost", port)) {
+                final var response = requestWithoutHeader(client);
+                assertThat(response, containsString(HEADER_REWRITTEN));
+            }
+            try (final var client = new RawHttpClient("localhost", port)) {
+                final var response = requestWithHeader(client);
+                assertThat(response, containsString(HEADER_REWRITTEN));
+            }
+        }
+    }
+
+    @Test
+    public void testIfTrustedStrategy() throws IOException, ConfigurationNotValidException, InterruptedException {
+        final var mapper = new TestEndpointMapper("localhost", wireMockRule.port());
+        try (final var server = new HttpProxyServer(mapper, tmpDir.newFolder())) {
+            final var trustedIps = Set.of(REAL_IP_ADDRESS + "/24");
+            server.addListener(getConfiguration(ForwardedStrategies.ifTrusted(trustedIps), trustedIps));
+            server.start();
+            int port = server.getLocalPort();
+            assertTrue(port > 0);
+            try (final var client = new RawHttpClient("localhost", port)) {
+                final var response = requestWithoutHeader(client);
+                assertThat(response, containsString(NO_HEADER));
+            }
+            try (final var client = new RawHttpClient("localhost", port)) {
+                final var response = requestWithHeader(client);
+                assertThat(response, containsString(HEADER_PRESENT));
+            }
+        }
+    }
+
+    @Test
+    public void testIfNotTrustedStrategy() throws IOException, ConfigurationNotValidException, InterruptedException {
+        final var mapper = new TestEndpointMapper("localhost", wireMockRule.port());
+        try (final var server = new HttpProxyServer(mapper, tmpDir.newFolder())) {
+            final var trustedIps = Set.of(FORWARDED_IP_ADDRESS + "/24");
+            server.addListener(getConfiguration(ForwardedStrategies.ifTrusted(trustedIps), trustedIps));
+            server.start();
+            int port = server.getLocalPort();
+            assertTrue(port > 0);
+            try (final var client = new RawHttpClient("localhost", port)) {
+                final var response = requestWithoutHeader(client);
+                assertThat(response, containsString(HEADER_REWRITTEN));
+            }
+            try (final var client = new RawHttpClient("localhost", port)) {
+                final var response = requestWithHeader(client);
+                assertThat(response, containsString(HEADER_REWRITTEN));
+            }
+        }
+    }
+
+    private static NetworkListenerConfiguration getConfiguration(final ForwardedStrategy strategy, final Set<String> trustedIps) {
+        return new NetworkListenerConfiguration(
+                "localhost",
+                0,
+                false,
+                null,
+                null,
+                DEFAULT_SSL_PROTOCOLS,
+                DEFAULT_SO_BACKLOG,
+                true,
+                DEFAULT_KEEP_ALIVE_IDLE,
+                DEFAULT_KEEP_ALIVE_INTERVAL,
+                DEFAULT_KEEP_ALIVE_COUNT,
+                DEFAULT_MAX_KEEP_ALIVE_REQUESTS,
+                strategy.name(),
+                trustedIps
+        );
+    }
+
+    private static String requestWithHeader(final RawHttpClient client) throws IOException {
+        return client.executeRequest("""
+                GET /index.html HTTP/1.1\r
+                Host: localhost\r
+                X-Forwarded-For: %s\r
+                Connection: close\r
+                \r
+                """.formatted(FORWARDED_IP_ADDRESS)).toString();
+    }
+
+    private static String requestWithoutHeader(final RawHttpClient client) throws IOException {
+        return client.executeRequest("""
+                GET /index.html HTTP/1.1\r
+                Host: localhost\r
+                Connection: close\r
+                \r
+                """).toString();
+    }
+}

--- a/carapace-server/src/test/java/org/carapaceproxy/listeners/ListenerConfigurationTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/listeners/ListenerConfigurationTest.java
@@ -1,5 +1,9 @@
 package org.carapaceproxy.listeners;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.util.Map;
+import java.util.Properties;
 import org.carapaceproxy.configstore.PropertiesConfigurationStore;
 import org.carapaceproxy.core.HttpProxyServer;
 import org.carapaceproxy.core.Listeners;
@@ -8,12 +12,6 @@ import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import java.util.Map;
-import java.util.Properties;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class ListenerConfigurationTest {
 

--- a/carapace-server/src/test/java/org/carapaceproxy/listeners/SSLSNITest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/listeners/SSLSNITest.java
@@ -23,6 +23,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_FORWARDED_STRATEGY;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
 import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.STATIC;
 import static org.junit.Assert.assertEquals;
@@ -72,9 +73,7 @@ public class SSLSNITest {
         
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot());) {
             server.addCertificate(new SSLCertificateConfiguration(nonLocalhost, null, certificate, "testproxy", STATIC));
-            server.addListener(new NetworkListenerConfiguration(nonLocalhost, 0, true, null, nonLocalhost /*
-                     * default
-                     */, 128, true, 300, 60, 8, 1000));
+            server.addListener(new NetworkListenerConfiguration(nonLocalhost, 0, true, null, nonLocalhost /* default */, DEFAULT_SSL_PROTOCOLS, 128, true, 300, 60, 8, 1000, DEFAULT_FORWARDED_STRATEGY, Set.of()));
             server.start();
             int port = server.getLocalPort();
 
@@ -166,7 +165,7 @@ public class SSLSNITest {
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot())) {
             server.addCertificate(new SSLCertificateConfiguration(nonLocalhost, null, certificate, "testproxy", STATIC));
             server.addListener(new NetworkListenerConfiguration(nonLocalhost, 0, true, null, nonLocalhost, Set.of("TLSv1.3"),
-                    128, true, 300, 60, 8, 1000));
+                    128, true, 300, 60, 8, 1000, DEFAULT_FORWARDED_STRATEGY, Set.of()));
             server.start();
             int port = server.getLocalPort();
             try (RawHttpClient client = new RawHttpClient(nonLocalhost, port, true, nonLocalhost)) {
@@ -182,7 +181,7 @@ public class SSLSNITest {
             try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot())) {
                 server.addCertificate(new SSLCertificateConfiguration(nonLocalhost, null, certificate, "testproxy", STATIC));
                 server.addListener(new NetworkListenerConfiguration(nonLocalhost, 0, true, null, nonLocalhost, Set.of(proto),
-                        128, true, 300, 60, 8, 1000));
+                        128, true, 300, 60, 8, 1000, DEFAULT_FORWARDED_STRATEGY, Set.of()));
                 server.start();
                 int port = server.getLocalPort();
                 try (RawHttpClient client = new RawHttpClient(nonLocalhost, port, true, nonLocalhost)) {
@@ -196,7 +195,8 @@ public class SSLSNITest {
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot())) {
             server.addCertificate(new SSLCertificateConfiguration(nonLocalhost, null, certificate, "testproxy", STATIC));
             server.addListener(new NetworkListenerConfiguration(nonLocalhost, 0, true, null, nonLocalhost,
-                    128, true, 300, 60, 8, 1000));
+                    DEFAULT_SSL_PROTOCOLS,
+                    128, true, 300, 60, 8, 1000, DEFAULT_FORWARDED_STRATEGY, Set.of()));
             server.start();
             int port = server.getLocalPort();
             try (RawHttpClient client = new RawHttpClient(nonLocalhost, port, true, nonLocalhost)) {
@@ -212,7 +212,7 @@ public class SSLSNITest {
             try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot())) {
                 server.addCertificate(new SSLCertificateConfiguration(nonLocalhost, null, certificate, "testproxy", STATIC));
                 server.addListener(new NetworkListenerConfiguration(nonLocalhost, 0, true, null, nonLocalhost, Set.of("TLSvWRONG"),
-                        128, true, 300, 60, 8, 1000));
+                        128, true, 300, 60, 8, 1000, DEFAULT_FORWARDED_STRATEGY, Set.of()));
             }
         });
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheTest.java
@@ -24,6 +24,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.carapaceproxy.server.cache.ContentsCache.CACHE_CONTROL_CACHE_DISABLED_VALUES;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_FORWARDED_STRATEGY;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
 import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.STATIC;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -36,6 +38,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.carapaceproxy.EndpointStats;
@@ -205,7 +208,8 @@ public class CacheTest {
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot());) {
             server.addCertificate(new SSLCertificateConfiguration("localhost", null, "localhost.p12", "testproxy", STATIC));
             server.addListener(new NetworkListenerConfiguration("localhost", 0, true, null, "localhost",
-                    128, true, 300, 60, 8, 1000));
+                    DEFAULT_SSL_PROTOCOLS,
+                    128, true, 300, 60, 8, 1000, DEFAULT_FORWARDED_STRATEGY, Set.of()));
             server.start();
         }
     }
@@ -229,7 +233,7 @@ public class CacheTest {
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot());) {
             server.addCertificate(new SSLCertificateConfiguration("localhost", null, "localhost.p12", "testproxy", STATIC));
             server.addListener(new NetworkListenerConfiguration("localhost", 0, true, null, "localhost",
-                    128, true, 300, 60, 8, 1000));
+                    DEFAULT_SSL_PROTOCOLS, 128, true, 300, 60, 8, 1000, DEFAULT_FORWARDED_STRATEGY, Set.of()));
 
             RuntimeServerConfiguration currentConfiguration = server.getCurrentConfiguration();
             currentConfiguration.setCacheDisabledForSecureRequestsWithoutPublic(cacheDisabledForSecureRequestsWithoutPublic);
@@ -361,7 +365,7 @@ public class CacheTest {
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir.getRoot());) {
             server.addCertificate(new SSLCertificateConfiguration("localhost", null, "localhost.p12", "testproxy", STATIC));
             server.addListener(new NetworkListenerConfiguration("localhost", httpsPort, true, null, "localhost",
-                    128, true, 300, 60, 8, 1000));
+                    DEFAULT_SSL_PROTOCOLS, 128, true, 300, 60, 8, 1000, DEFAULT_FORWARDED_STRATEGY, Set.of()));
             server.addListener(new NetworkListenerConfiguration("localhost", httpPort));
             server.start();
             server.getCache().getStats().resetCacheMetrics();

--- a/carapace-server/src/test/java/org/carapaceproxy/server/filters/XForwardedForFilterTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/filters/XForwardedForFilterTest.java
@@ -19,12 +19,14 @@ package org.carapaceproxy.server.filters;
  under the License.
 
  */
+
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.absent;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.Assert.assertTrue;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.util.Collections;
 import org.carapaceproxy.client.EndpointKey;
@@ -32,7 +34,6 @@ import org.carapaceproxy.core.HttpProxyServer;
 import org.carapaceproxy.server.config.RequestFilterConfiguration;
 import org.carapaceproxy.utils.RawHttpClient;
 import org.carapaceproxy.utils.TestEndpointMapper;
-import static org.junit.Assert.assertTrue;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -60,7 +61,6 @@ public class XForwardedForFilterTest {
                         .withBody("it <b>works</b> !!")));
 
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.port());
-        EndpointKey key = new EndpointKey("localhost", wireMockRule.port());
 
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
             server.addRequestFilter(new RequestFilterConfiguration(XForwardedForRequestFilter.TYPE, Collections.emptyMap()));

--- a/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsCipherFilterTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsCipherFilterTest.java
@@ -7,6 +7,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_FORWARDED_STRATEGY;
 import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.STATIC;
 import static org.junit.Assert.assertTrue;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -58,7 +59,7 @@ public class XTlsCipherFilterTest {
             server.addRequestFilter(new RequestFilterConfiguration(XTlsCipherRequestFilter.TYPE, Collections.emptyMap()));
             server.addRequestFilter(new RequestFilterConfiguration(XTlsProtocolRequestFilter.TYPE, Collections.emptyMap()));
             server.addListener(new NetworkListenerConfiguration("0.0.0.0", 0, true, null, "*", Set.of("TLSv1.2"),
-                    128, true, 300, 60, 8, 1000));
+                    128, true, 300, 60, 8, 1000, DEFAULT_FORWARDED_STRATEGY, Set.of()));
             server.start();
             int port = server.getLocalPort();
 
@@ -73,7 +74,7 @@ public class XTlsCipherFilterTest {
             server.addCertificate(new SSLCertificateConfiguration("*", null, certificate, "testproxy", STATIC));
             server.addRequestFilter(new RequestFilterConfiguration(XTlsProtocolRequestFilter.TYPE, Collections.emptyMap()));
             server.addListener(new NetworkListenerConfiguration("0.0.0.0", 0, true, null, "*", Set.of("TLSv1.2"),
-                    128, true, 300, 60, 8, 1000));
+                    128, true, 300, 60, 8, 1000, DEFAULT_FORWARDED_STRATEGY, Set.of()));
             server.start();
             int port = server.getLocalPort();
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsProtocolFilterTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsProtocolFilterTest.java
@@ -6,6 +6,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_FORWARDED_STRATEGY;
 import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.STATIC;
 import static org.junit.Assert.assertTrue;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -56,7 +57,7 @@ public class XTlsProtocolFilterTest {
             server.addCertificate(new SSLCertificateConfiguration("*", null, certificate, "testproxy", STATIC));
             server.addRequestFilter(new RequestFilterConfiguration(XTlsProtocolRequestFilter.TYPE, Collections.emptyMap()));
             server.addListener(new NetworkListenerConfiguration("0.0.0.0", 0, true, null, "*", Set.of("TLSv1.2"),
-                    128, true, 300, 60, 8, 1000));
+                    128, true, 300, 60, 8, 1000, DEFAULT_FORWARDED_STRATEGY, Set.of()));
             server.start();
             int port = server.getLocalPort();
 
@@ -70,7 +71,7 @@ public class XTlsProtocolFilterTest {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder())) {
             server.addCertificate(new SSLCertificateConfiguration("*", null, certificate, "testproxy", STATIC));
             server.addListener(new NetworkListenerConfiguration("0.0.0.0", 0, true, null, "*", Set.of("TLSv1.2"),
-                    128, true, 300, 60, 8, 1000));
+                    128, true, 300, 60, 8, 1000, DEFAULT_FORWARDED_STRATEGY, Set.of()));
             server.start();
             int port = server.getLocalPort();
 

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/RawHttpClient.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/RawHttpClient.java
@@ -313,10 +313,6 @@ public final class RawHttpClient implements AutoCloseable {
             throw new IOException("bad response, does not start with HTTP/1.1. Received: " + result.statusLine);
         }
 
-        if (!result.statusLine.startsWith("HTTP/1.1 ")) {
-            throw new IOException("bad response, does not start with HTTP/1.1. Received: " + result.statusLine);
-        }
-
         // header
         while (true) {
             BufferedStream counter = new BufferedStream(result.rawResponse);

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/TestEndpointMapper.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/TestEndpointMapper.java
@@ -39,10 +39,10 @@ public class TestEndpointMapper extends EndpointMapper {
     private final int port;
     private final boolean cacheAll;
     private final Map<String, BackendConfiguration> backends;
-    private final List<RouteConfiguration> routes = new ArrayList();
-    private final List<ActionConfiguration> actions = new ArrayList();
-    private final List<DirectorConfiguration> directors = new ArrayList();
-    private final List<CustomHeader> headers = new ArrayList();
+    private final List<RouteConfiguration> routes = new ArrayList<>();
+    private final List<ActionConfiguration> actions = new ArrayList<>();
+    private final List<DirectorConfiguration> directors = new ArrayList<>();
+    private final List<CustomHeader> headers = new ArrayList<>();
 
     public TestEndpointMapper(String host, int port) {
         this(host, port, false);

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
         <libs.commons.lang3>3.12.0</libs.commons.lang3>
         <libs.commons-pool2>2.11.1</libs.commons-pool2>
         <libs.commons-io>2.11.0</libs.commons-io>
+        <libs.commons-net>3.11.0</libs.commons-net>
 
         <libs.jetty>9.4.44.v20210927</libs.jetty>
         <libs.jersey>2.35</libs.jersey>


### PR DESCRIPTION
- Add [Apache `commons-net:commons-net:3.11.0`](https://commons.apache.org/proper/commons-net/) dependency
- Move [`X-Forwarded-For` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) management from `add-x-forwarded-for` filter to new listener options:
  - `add-x-forwarded-for` filter is now deprecated for removal
  - added `forwarded` = `DROP` | `PRESERVE` | `REWRITE` (default) | `IF_TRUSTED` listener option
  - added `trustedips` optional listener option, that accepts CIDR that should be considered trusted