### PR TITLE
fix(server): add default identifier if not specified by the user

### DIFF
--- a/carapace-server/src/test/java/org/carapaceproxy/core/ForwardedStrategyTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/ForwardedStrategyTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertTrue;
 import static reactor.netty.http.HttpProtocol.HTTP11;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
@@ -27,13 +28,22 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class ForwardedStrategyTest {
     public static final String REAL_IP_ADDRESS = "127.0.0.1";
     public static final String FORWARDED_IP_ADDRESS = "1.2.3.4";
     public static final String HEADER_PRESENT = "Header present!";
     public static final String HEADER_REWRITTEN = "Header rewritten!";
     public static final String NO_HEADER = "No header!";
+    public static final String SUBNET = "/24";
+
+    @Parameterized.Parameters(name = "Use actual CIDR? {0}")
+    public static Iterable<?> data() {
+        return List.of(true, false);
+    }
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(0);
@@ -62,6 +72,9 @@ public class ForwardedStrategyTest {
                         .withHeader("Content-Type", "text/html")
                         .withBody(NO_HEADER)));
     }
+
+    @Parameterized.Parameter
+    public boolean useCidr;
 
     @Test
     public void testDropStrategy() throws IOException, ConfigurationNotValidException, InterruptedException {
@@ -124,7 +137,7 @@ public class ForwardedStrategyTest {
     public void testIfTrustedStrategy() throws IOException, ConfigurationNotValidException, InterruptedException {
         final var mapper = new TestEndpointMapper("localhost", wireMockRule.port());
         try (final var server = new HttpProxyServer(mapper, tmpDir.newFolder())) {
-            final var trustedIps = Set.of(REAL_IP_ADDRESS + "/24");
+            final var trustedIps = Set.of(REAL_IP_ADDRESS + (useCidr ? SUBNET : ""));
             server.addListener(getConfiguration(ForwardedStrategies.ifTrusted(trustedIps), trustedIps));
             server.start();
             int port = server.getLocalPort();
@@ -144,7 +157,7 @@ public class ForwardedStrategyTest {
     public void testIfNotTrustedStrategy() throws IOException, ConfigurationNotValidException, InterruptedException {
         final var mapper = new TestEndpointMapper("localhost", wireMockRule.port());
         try (final var server = new HttpProxyServer(mapper, tmpDir.newFolder())) {
-            final var trustedIps = Set.of(FORWARDED_IP_ADDRESS + "/24");
+            final var trustedIps = Set.of(FORWARDED_IP_ADDRESS + (useCidr ? SUBNET : ""));
             server.addListener(getConfiguration(ForwardedStrategies.ifTrusted(trustedIps), trustedIps));
             server.start();
             int port = server.getLocalPort();


### PR DESCRIPTION
Follow-up of #477, closes #492 