### PR TITLE
Converge dependency versions

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -75,22 +75,19 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
-            <version>${libs.prometheus}</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_hotspot</artifactId>
-            <version>${libs.prometheus}</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_servlet</artifactId>
-            <version>${libs.prometheus}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.bookkeeper.stats</groupId>
             <artifactId>prometheus-metrics-provider</artifactId>
-            <version>${libs.prometheus.metrics}</version>
+            <version>${libs.bookkeeper}</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -36,15 +36,31 @@
             <groupId>org.shredzone.acme4j</groupId>
             <artifactId>acme4j-client</artifactId>
             <version>${libs.acme4j}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.shredzone.acme4j</groupId>
             <artifactId>acme4j-utils</artifactId>
             <version>${libs.acme4j}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -186,21 +186,6 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>${libs.jaxws.jaxb-api}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-            <version>${libs.jaxws.jaxb-impl}</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
-            <version>${libs.javaxactivation-api}</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -51,6 +51,7 @@
             <artifactId>caffeine</artifactId>
             <version>${libs.caffeine}</version>
             <exclusions>
+                <!-- Excluding unnecessary annotations that are bundled in multiple versions by libraries -->
                 <exclusion>
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
@@ -65,7 +66,6 @@
             <groupId>org.antlr</groupId>
             <artifactId>ST4</artifactId>
             <version>${libs.antlr}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
@@ -102,10 +102,7 @@
             <artifactId>herddb-jdbc</artifactId>
             <version>${libs.herddb}</version>
             <exclusions>
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bc-fips</artifactId>
-                </exclusion>
+                <!-- Excluding unnecessary annotations that are bundled in multiple versions by libraries -->
                 <exclusion>
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
@@ -113,6 +110,11 @@
                 <exclusion>
                     <groupId>com.google.errorprone</groupId>
                     <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <!-- BouncyCastle FIPS clashes with other BouncyCastle modules -->
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bc-fips</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -150,27 +152,22 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>${libs.jersey}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
-            <version>${libs.jersey}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet</artifactId>
-            <version>${libs.jersey}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-jetty-http</artifactId>
-            <version>${libs.jersey}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>${libs.jersey}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -199,6 +196,7 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <exclusions>
+                <!-- Excluding unnecessary annotations that are bundled in multiple versions by libraries -->
                 <exclusion>
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
@@ -247,6 +245,7 @@
             <version>${libs.junit}</version>
             <scope>test</scope>
             <exclusions>
+                <!-- Clashes with org.hamcrest:hamcrest -->
                 <exclusion>
                     <groupId>org.hamcrest</groupId>
                     <artifactId>hamcrest-core</artifactId>
@@ -265,6 +264,7 @@
             <version>${libs.wiremock}</version>
             <scope>test</scope>
             <exclusions>
+                <!-- Clashes with org.hamcrest:hamcrest -->
                 <exclusion>
                     <groupId>org.hamcrest</groupId>
                     <artifactId>hamcrest-core</artifactId>
@@ -277,6 +277,7 @@
             <version>${libs.powermock}</version>
             <scope>test</scope>
             <exclusions>
+                <!-- Clashes with org.hamcrest:hamcrest -->
                 <exclusion>
                     <groupId>org.hamcrest</groupId>
                     <artifactId>hamcrest-core</artifactId>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -197,12 +198,12 @@
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.google.errorprone</groupId>
-                    <artifactId>error_prone_annotations</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.google.code.findbugs</groupId>
                     <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -166,22 +166,18 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>${libs.jetty}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <version>${libs.jetty}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>${libs.jetty}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>${libs.jetty}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -116,19 +116,17 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>${libs.commons.lang3}</version>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-pool2</artifactId>
-            <version>${libs.commons-pool2}</version>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
-            <version>${libs.commons-net}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -71,6 +71,16 @@
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
             <version>${libs.caffeine}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>
@@ -155,6 +165,14 @@
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -266,6 +284,20 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${libs.guava}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -31,29 +31,15 @@
             <groupId>org.shredzone.acme4j</groupId>
             <artifactId>acme4j-client</artifactId>
             <version>${libs.acme4j}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.shredzone.acme4j</groupId>
             <artifactId>acme4j-utils</artifactId>
             <version>${libs.acme4j}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>${libs.bouncycastle}</version>
-            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -118,7 +104,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>
-                    <artifactId>*</artifactId>
+                    <artifactId>bc-fips</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.checkerframework</groupId>
@@ -287,7 +273,6 @@
             <groupId>pl.pragmatists</groupId>
             <artifactId>JUnitParams</artifactId>
             <version>${libs.junitparams}</version>
-            <type>jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -238,15 +238,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${libs.junit}</version>
             <scope>test</scope>
-            <exclusions>
-                <!-- Clashes with org.hamcrest:hamcrest -->
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>pl.pragmatists</groupId>
@@ -287,12 +279,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${libs.mockito}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
             <version>${libs.curator}</version>
@@ -304,11 +290,12 @@
                      messes up with Intellij IDEA test run of whole project.
                 -->
                 <exclusion>
-                    <groupId>ch.qos.logback</groupId>
+                    <groupId>org.junit.jupiter</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <!-- We want a single SLF4J backend in our classpath! -->
                 <exclusion>
-                    <groupId>org.junit.jupiter</groupId>
+                    <groupId>ch.qos.logback</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -95,14 +95,6 @@
             <version>${libs.zookkeeper}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>commons-cli</groupId>
                     <artifactId>commons-cli</artifactId>
                 </exclusion>
@@ -272,7 +264,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${libs.slf4j}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -44,17 +44,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.shredzone.acme4j</groupId>
-            <artifactId>acme4j-utils</artifactId>
-            <version>${libs.acme4j}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -17,6 +17,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-tools</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty-core</artifactId>
         </dependency>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -227,17 +227,14 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${libs.jackson}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${libs.jackson}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${libs.jackson}</version>
         </dependency>
         <dependency>
             <groupId>javax.xml.bind</groupId>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -213,7 +213,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>${libs.guava}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.checkerframework</groupId>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>${libs.netty.ssl}</version>
         </dependency>
         <dependency>
             <groupId>org.shredzone.acme4j</groupId>
@@ -60,12 +59,6 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>route53</artifactId>
             <version>${libs.awssdk}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
@@ -112,13 +105,6 @@
             <groupId>org.apache.bookkeeper.stats</groupId>
             <artifactId>prometheus-metrics-provider</artifactId>
             <version>${libs.prometheus.metrics}</version>
-            <type>jar</type>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
@@ -130,10 +116,6 @@
             <artifactId>herddb-jdbc</artifactId>
             <version>${libs.herddb}</version>
             <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>*</artifactId>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -88,26 +88,6 @@
             <version>${libs.antlr}</version>
             <scope>compile</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
-            <version>${libs.zookkeeper}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-cli</groupId>
-                    <artifactId>commons-cli</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.yetus</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
@@ -177,11 +157,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>
             <version>${libs.commons-pool2}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>${libs.commons-io}</version>
         </dependency>
         <dependency>
             <groupId>commons-net</groupId>
@@ -384,6 +359,10 @@
                     and the old-fashioned JUnit (in particular a version which is strictly not 4.12 and 4.13)
                      messes up with Intellij IDEA test run of whole project.
                 -->
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.junit.jupiter</groupId>
                     <artifactId>*</artifactId>

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/ACMEClient.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/ACMEClient.java
@@ -66,10 +66,6 @@ public class ACMEClient {
     private final boolean testingModeOn;
     private final KeyPair userKey;
 
-    public enum ChallengeType {
-        HTTP
-    }
-
     public ACMEClient(KeyPair userKey, boolean testingMode) {
         Security.addProvider(new BouncyCastleProvider());
         this.userKey = userKey;
@@ -140,10 +136,9 @@ public class ACMEClient {
      * @return {@link Http01Challenge} to verify
      */
     private Http01Challenge httpChallenge(Authorization auth) throws AcmeException {
-        Http01Challenge challenge = auth.findChallenge(Http01Challenge.TYPE);
-        if (challenge == null) {
-            throw new AcmeException("Found no " + Http01Challenge.TYPE + " challenge, don't know what to do...");
-        }
+        Http01Challenge challenge = auth.findChallenge(Http01Challenge.TYPE)
+                .map(Http01Challenge.class::cast)
+                .orElseThrow(() -> new AcmeException("Found no " + Http01Challenge.TYPE + " challenge, don't know what to do..."));
         LOG.debug("It must be reachable at: http://{}/.well-known/acme-challenge/{}",
                 auth.getIdentifier().getDomain(), challenge.getToken()
         );
@@ -161,10 +156,10 @@ public class ACMEClient {
      * @throws org.shredzone.acme4j.exception.AcmeException
      */
     public Challenge dnsChallenge(Authorization auth) throws AcmeException {
-        Dns01Challenge challenge = auth.findChallenge(Dns01Challenge.TYPE);
-        if (challenge == null) {
-            throw new AcmeException("Found no " + Dns01Challenge.TYPE + " challenge, don't know what to do...");
-        }
+        Dns01Challenge challenge = auth
+                .findChallenge(Dns01Challenge.TYPE)
+                .map(Dns01Challenge.class::cast)
+                .orElseThrow(() -> new AcmeException("Found no " + Dns01Challenge.TYPE + " challenge, don't know what to do..."));
         LOG.info("DNS-challenge _acme-challenge.{}. to save as TXT-record with content {}", auth.getIdentifier().getDomain(), challenge.getDigest());
         return challenge;
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/RawClientTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/RawClientTest.java
@@ -762,7 +762,7 @@ public class RawClientTest {
                                 .withHeader("Content-Type", "text/html")
                                 .withHeader("Content-Length", "it <b>works</b> !!".length() + "")
                                 .withBody("it <b>works</b> !!")));
-                String s = client.executeRequest("GET " + scheme + "://yahoo.com/index.html?p1=v1&p2=https://localhost/index.html?p=1 HTTP/1.1 \r\nHost: localhost\r\n\r\n").getBodyString();
+                String s = client.executeRequest("GET " + scheme + "://yahoo.com/index.html?p1=v1&p2=https://localhost/index.html?p=1 HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString();
                 assertEquals("it <b>works</b> !!", s);
                 s = client.get("/index.html?p1=v1&p2=https://localhost/index.html?p=1").getBodyString();
                 assertEquals("it <b>works</b> !!", s);
@@ -773,7 +773,7 @@ public class RawClientTest {
                                 .withHeader("Content-Type", "text/html")
                                 .withHeader("Content-Length", "it <b>works</b> !!".length() + "")
                                 .withBody("it <b>works</b> !!")));
-                s = client.executeRequest("GET " + scheme + "://yahoo.com/index.html HTTP/1.1 \r\nHost: localhost\r\n\r\n").getBodyString();
+                s = client.executeRequest("GET " + scheme + "://yahoo.com/index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString();
                 assertEquals("it <b>works</b> !!", s);
                 s = client.get("/index.html").getBodyString();
                 assertEquals("it <b>works</b> !!", s);
@@ -785,11 +785,11 @@ public class RawClientTest {
                                 .withHeader("Content-Type", "text/html")
                                 .withHeader("Content-Length", "it <b>works</b> !!".length() + "")
                                 .withBody("it <b>works</b> !!")));
-                s = client.executeRequest("GET " + scheme + "://yahoo.com/?p1=v1&p2=https://localhost/index.html?p=1 HTTP/1.1 \r\nHost: localhost\r\n\r\n").getBodyString();
+                s = client.executeRequest("GET " + scheme + "://yahoo.com/?p1=v1&p2=https://localhost/index.html?p=1 HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString();
                 assertEquals("it <b>works</b> !!", s);
                 s = client.get("/?p1=v1&p2=https://localhost/index.html?p=1").getBodyString();
                 assertEquals("it <b>works</b> !!", s);
-                s = client.executeRequest("GET " + scheme + "://yahoo.com?p1=v1&p2=https://localhost/index.html?p=1 HTTP/1.1 \r\nHost: localhost\r\n\r\n").getBodyString();
+                s = client.executeRequest("GET " + scheme + "://yahoo.com?p1=v1&p2=https://localhost/index.html?p=1 HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString();
                 assertEquals("it <b>works</b> !!", s);
                 s = client.get("?p1=v1&p2=https://localhost/index.html?p=1").getBodyString();
                 assertEquals("it <b>works</b> !!", s);
@@ -800,11 +800,11 @@ public class RawClientTest {
                                 .withHeader("Content-Type", "text/html")
                                 .withHeader("Content-Length", "it <b>works</b> !!".length() + "")
                                 .withBody("it <b>works</b> !!")));
-                s = client.executeRequest("GET " + scheme + "://yahoo.com/ HTTP/1.1 \r\nHost: localhost\r\n\r\n").getBodyString();
+                s = client.executeRequest("GET " + scheme + "://yahoo.com/ HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString();
                 assertEquals("it <b>works</b> !!", s);
                 s = client.get("/").getBodyString();
                 assertEquals("it <b>works</b> !!", s);
-                s = client.executeRequest("GET " + scheme + "://yahoo.com HTTP/1.1 \r\nHost: localhost\r\n\r\n").getBodyString();
+                s = client.executeRequest("GET " + scheme + "://yahoo.com HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString();
                 assertEquals("it <b>works</b> !!", s);
             }
         }

--- a/carapace-ui/pom.xml
+++ b/carapace-ui/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>

--- a/carapace-ui/pom.xml
+++ b/carapace-ui/pom.xml
@@ -23,27 +23,9 @@
         <carapace.ui.dir>src/main/webapp</carapace.ui.dir>
     </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-web-api</artifactId>
-            <version>7.0</version>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
-
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration>
-                        <compilerArgs>
-                            <endorseddirs>${endorsed.dir}</endorseddirs>
-                        </compilerArgs>
-                    </configuration>
-                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
@@ -51,29 +33,6 @@
                         <packagingIncludes>ui/**</packagingIncludes>
                         <failOnMissingWebXml>false</failOnMissingWebXml>
                     </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <phase>validate</phase>
-                            <goals>
-                                <goal>copy</goal>
-                            </goals>
-                            <configuration>
-                                <outputDirectory>${endorsed.dir}</outputDirectory>
-                                <silent>true</silent>
-                                <artifactItems>
-                                    <artifactItem>
-                                        <groupId>javax</groupId>
-                                        <artifactId>javaee-endorsed-api</artifactId>
-                                        <version>7.0</version>
-                                    </artifactItem>
-                                </artifactItems>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/carapace-ui/pom.xml
+++ b/carapace-ui/pom.xml
@@ -69,7 +69,6 @@
                                         <groupId>javax</groupId>
                                         <artifactId>javaee-endorsed-api</artifactId>
                                         <version>7.0</version>
-                                        <type>jar</type>
                                     </artifactItem>
                                 </artifactItems>
                             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,16 @@
                 <artifactId>zookeeper-jute</artifactId>
                 <version>${libs.zookkeeper}</version>
             </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk15on</artifactId>
+                <version>${libs.bouncycastle}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk15on</artifactId>
+                <version>${libs.bouncycastle}</version>
+            </dependency>
             <!-- Individual test dependencies -->
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <libs.jackson>2.14.1</libs.jackson>
         <libs.javassist>3.27.0-GA</libs.javassist>
         <libs.slf4j>1.7.35</libs.slf4j>
-        <libs.guava>31.1-jre</libs.guava>
+        <libs.guava>33.3.1-jre</libs.guava>
         <libs.lombok>1.18.32</libs.lombok>
         <libs.spotbugsannotations>4.5.3</libs.spotbugsannotations>
         <libs.protobuf>3.17.1</libs.protobuf>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
         <libs.guava>31.1-jre</libs.guava>
         <libs.lombok>1.18.32</libs.lombok>
         <libs.spotbugsannotations>4.5.3</libs.spotbugsannotations>
+        <libs.protobuf>3.17.1</libs.protobuf>
 
         <!-- test dependecies -->
         <libs.junit>4.13.2</libs.junit>
@@ -212,6 +213,11 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk15on</artifactId>
                 <version>${libs.bouncycastle}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${libs.protobuf}</version>
             </dependency>
             <!-- Individual test dependencies -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,13 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava-bom</artifactId>
+                <version>${libs.guava}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
             <!-- Individual dependencies -->
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
 
         <libs.projectreactor>2023.0.11</libs.projectreactor>
         <libs.netty>4.1.114.Final</libs.netty>
-        <libs.acme4j>2.12</libs.acme4j>
+        <libs.acme4j>3.4.0</libs.acme4j>
         <libs.bouncycastle>1.78.1</libs.bouncycastle>
         <libs.awssdk>2.17.113</libs.awssdk>
         <libs.caffeine>3.0.5</libs.caffeine>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <libs.caffeine>3.0.5</libs.caffeine>
         <libs.antlr>4.3.1</libs.antlr>
 
-        <libs.zookkeeper>3.7.0</libs.zookkeeper>
+        <libs.zookkeeper>3.7.2</libs.zookkeeper>
         <libs.curator>5.2.0</libs.curator>
         <libs.prometheus>0.14.1</libs.prometheus>
         <libs.prometheus.metrics>4.14.4</libs.prometheus.metrics>
@@ -117,7 +117,7 @@
         <libs.jaxws.jaxb-api>2.3.1</libs.jaxws.jaxb-api>
         <libs.jaxws.jaxb-impl>3.0.2</libs.jaxws.jaxb-impl>
         <libs.javaxactivation-api>1.2.0</libs.javaxactivation-api>
-        <libs.slf4j>1.7.33</libs.slf4j>
+        <libs.slf4j>1.7.35</libs.slf4j>
         <libs.guava>31.1-jre</libs.guava>
         <libs.lombok>1.18.32</libs.lombok>
         <libs.spotbugsannotations>4.5.3</libs.spotbugsannotations>
@@ -153,6 +153,7 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- BOMs -->
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
@@ -167,6 +168,13 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <!-- Individual dependencies -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${libs.slf4j}</version>
+            </dependency>
+            <!-- Individual test dependencies -->
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <libs.projectreactor>2023.0.11</libs.projectreactor>
         <libs.netty>4.1.114.Final</libs.netty>
         <libs.acme4j>2.12</libs.acme4j>
-        <libs.bouncycastle>1.70</libs.bouncycastle>
+        <libs.bouncycastle>1.78.1</libs.bouncycastle>
         <libs.awssdk>2.17.113</libs.awssdk>
         <libs.caffeine>3.0.5</libs.caffeine>
         <libs.antlr>4.3.1</libs.antlr>
@@ -246,12 +246,12 @@
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
+                <artifactId>bcpkix-jdk18on</artifactId>
                 <version>${libs.bouncycastle}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
+                <artifactId>bcprov-jdk18on</artifactId>
                 <version>${libs.bouncycastle}</version>
             </dependency>
             <dependency>
@@ -468,7 +468,7 @@
                                         <exclusion>org.hamcrest:hamcrest-core</exclusion>
                                     </excludes>
                                     <includes>
-                                        <include>org.bouncycastle:*-jdk15on</include>
+                                        <include>org.bouncycastle:*-jdk18on</include>
                                     </includes>
                                 </bannedDependencies>
                                 <dependencyConvergence/>

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,13 @@
                 <type>pom</type>
             </dependency>
             <dependency>
+                <groupId>org.glassfish.jersey</groupId>
+                <artifactId>jersey-bom</artifactId>
+                <version>${libs.jersey}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${libs.jackson}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,13 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>${libs.jetty}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${libs.jackson}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.carapaceproxy</groupId>
@@ -106,10 +107,11 @@
         <libs.micrometer>1.11.0</libs.micrometer>
         <libs.herddb>0.26.1</libs.herddb>
 
+        <libs.commons.codec>1.15</libs.commons.codec>
         <libs.commons.lang3>3.12.0</libs.commons.lang3>
-        <libs.commons-pool2>2.11.1</libs.commons-pool2>
-        <libs.commons-io>2.11.0</libs.commons-io>
-        <libs.commons-net>3.11.0</libs.commons-net>
+        <libs.commons.logging>1.2</libs.commons.logging>
+        <libs.commons.io>2.11.0</libs.commons.io>
+        <libs.commons.net>3.11.0</libs.commons.net>
 
         <libs.jetty>9.4.44.v20210927</libs.jetty>
         <libs.jersey>2.35</libs.jersey>
@@ -208,9 +210,29 @@
                 <version>${libs.slf4j}</version>
             </dependency>
             <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${libs.commons.codec}</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>${libs.commons-io}</version>
+                <version>${libs.commons.io}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>${libs.commons.logging}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-net</groupId>
+                <artifactId>commons-net</artifactId>
+                <version>${libs.commons.net}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${libs.commons.lang3}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
         <libs.jetty>9.4.44.v20210927</libs.jetty>
         <libs.jersey>2.35</libs.jersey>
         <libs.jackson>2.14.1</libs.jackson>
+        <libs.javassist>3.27.0-GA</libs.javassist>
         <libs.slf4j>1.7.35</libs.slf4j>
         <libs.guava>31.1-jre</libs.guava>
         <libs.lombok>1.18.32</libs.lombok>
@@ -127,7 +128,7 @@
         <libs.junitparams>1.1.1</libs.junitparams>
         <libs.wiremock>2.35.0</libs.wiremock>
         <libs.powermock>2.0.9</libs.powermock>
-        <libs.mockito>3.12.4</libs.mockito>
+        <libs.objenesis>3.0.1</libs.objenesis>
         <libs.hamcrest>2.2</libs.hamcrest>
 
         <libs.asm>9.2</libs.asm>
@@ -268,6 +269,28 @@
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>
                 <version>${libs.hamcrest}</version>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${libs.junit}</version>
+                <exclusions>
+                    <!-- Clashes with org.hamcrest:hamcrest -->
+                    <exclusion>
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>hamcrest-core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.objenesis</groupId>
+                <artifactId>objenesis</artifactId>
+                <version>${libs.objenesis}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.javassist</groupId>
+                <artifactId>javassist</artifactId>
+                <version>${libs.javassist}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -442,6 +465,7 @@
                                         <exclude>com.google.code.findbugs</exclude>
                                         <exclude>org.bouncycastle:*</exclude>
                                         <exclude>org.checkerframework</exclude>
+                                        <exclusion>org.hamcrest:hamcrest-core</exclusion>
                                     </excludes>
                                     <includes>
                                         <include>org.bouncycastle:*-jdk15on</include>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <javacc-maven-plugin.version>2.4</javacc-maven-plugin.version>
 
         <libs.projectreactor>2022.0.7</libs.projectreactor>
-        <libs.netty.ssl>2.0.61.Final</libs.netty.ssl>
+        <libs.netty>4.1.92.Final</libs.netty>
         <libs.acme4j>2.12</libs.acme4j>
         <libs.bouncycastle>1.70</libs.bouncycastle>
         <libs.awssdk>2.17.113</libs.awssdk>
@@ -160,6 +160,13 @@
                 <version>${libs.projectreactor}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${libs.netty}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,6 @@
         <libs.mockito>3.12.4</libs.mockito>
         <libs.hamcrest>2.2</libs.hamcrest>
 
-        <plugins.spotbugsmaven>4.5.3.0</plugins.spotbugsmaven>
         <libs.asm>9.2</libs.asm>
     </properties>
 
@@ -299,7 +298,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>${plugins.spotbugsmaven}</version>
+                    <version>4.8.6.4</version>
                     <configuration>
                         <effort>Max</effort>
                         <maxHeap>4096</maxHeap>
@@ -316,7 +315,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>3.5.1</version>
                     <configuration>
                         <reuseForks>false</reuseForks>
                         <trimStackTrace>false</trimStackTrace>
@@ -352,7 +351,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.6.1</version>
+                    <version>3.8.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -362,7 +361,37 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.7.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.4.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.1.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.20.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.1.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.3.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.4.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -375,7 +404,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <preparationProfiles>production</preparationProfiles>
                     <releaseProfiles>production</releaseProfiles>
@@ -401,12 +430,12 @@
                         <configuration>
                             <rules>
                                 <banDependencyManagementScope/>
+                                <banDuplicatePomDependencyVersions/>
                                 <banDynamicVersions>
                                     <ignores>
                                         <ignore>${project.groupId}</ignore>
                                     </ignores>
                                 </banDynamicVersions>
-                                <banDuplicatePomDependencyVersions/>
                                 <bannedDependencies>
                                     <excludes>
                                         <exclude>com.google.errorprone</exclude>
@@ -418,6 +447,11 @@
                                         <include>org.bouncycastle:*-jdk15on</include>
                                     </includes>
                                 </bannedDependencies>
+                                <dependencyConvergence/>
+                                <requireMavenVersion>
+                                    <version>3.9</version>
+                                </requireMavenVersion>
+                                <requirePluginVersions/>
                             </rules>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
 
         <libs.jetty>9.4.44.v20210927</libs.jetty>
         <libs.jersey>2.35</libs.jersey>
-        <libs.jackson>2.13.1</libs.jackson>
+        <libs.jackson>2.14.1</libs.jackson>
         <libs.jaxws.jaxb-api>2.3.1</libs.jaxws.jaxb-api>
         <libs.jaxws.jaxb-impl>3.0.2</libs.jaxws.jaxb-impl>
         <libs.javaxactivation-api>1.2.0</libs.javaxactivation-api>
@@ -159,6 +159,13 @@
                 <version>${libs.projectreactor}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${libs.jackson}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,8 +92,8 @@
         <maven.compiler.release>${toolchain.java.version}</maven.compiler.release>
         <javacc-maven-plugin.version>2.4</javacc-maven-plugin.version>
 
-        <libs.projectreactor>2022.0.7</libs.projectreactor>
-        <libs.netty>4.1.92.Final</libs.netty>
+        <libs.projectreactor>2023.0.11</libs.projectreactor>
+        <libs.netty>4.1.114.Final</libs.netty>
         <libs.acme4j>2.12</libs.acme4j>
         <libs.bouncycastle>1.70</libs.bouncycastle>
         <libs.awssdk>2.17.113</libs.awssdk>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <libs.caffeine>3.0.5</libs.caffeine>
         <libs.antlr>4.3.1</libs.antlr>
 
-        <libs.bookkeeper>4.14.4</libs.bookkeeper>
+        <libs.bookkeeper>4.14.8</libs.bookkeeper>
         <libs.zookkeeper>3.8.4</libs.zookkeeper>
         <libs.curator>5.2.0</libs.curator>
         <libs.prometheus>0.16.0</libs.prometheus>
@@ -110,12 +110,12 @@
         <libs.commons.codec>1.15</libs.commons.codec>
         <libs.commons.lang3>3.12.0</libs.commons.lang3>
         <libs.commons.logging>1.2</libs.commons.logging>
-        <libs.commons.io>2.11.0</libs.commons.io>
+        <libs.commons.io>2.14.0</libs.commons.io>
         <libs.commons.net>3.11.0</libs.commons.net>
 
-        <libs.jetty>9.4.44.v20210927</libs.jetty>
+        <libs.jetty>9.4.52.v20230823</libs.jetty>
         <libs.jersey>2.35</libs.jersey>
-        <libs.jackson>2.14.1</libs.jackson>
+        <libs.jackson>2.14.3</libs.jackson>
         <libs.javassist>3.27.0-GA</libs.javassist>
         <libs.slf4j>1.7.35</libs.slf4j>
         <libs.guava>33.3.1-jre</libs.guava>
@@ -126,7 +126,7 @@
         <!-- test dependecies -->
         <libs.junit>4.13.2</libs.junit>
         <libs.junitparams>1.1.1</libs.junitparams>
-        <libs.wiremock>2.35.0</libs.wiremock>
+        <libs.wiremock>2.35.2</libs.wiremock>
         <libs.powermock>2.0.9</libs.powermock>
         <libs.objenesis>3.0.1</libs.objenesis>
         <libs.hamcrest>2.2</libs.hamcrest>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <libs.caffeine>3.0.5</libs.caffeine>
         <libs.antlr>4.3.1</libs.antlr>
 
-        <libs.zookkeeper>3.7.2</libs.zookkeeper>
+        <libs.zookkeeper>3.8.4</libs.zookkeeper>
         <libs.curator>5.2.0</libs.curator>
         <libs.prometheus>0.14.1</libs.prometheus>
         <libs.prometheus.metrics>4.14.4</libs.prometheus.metrics>
@@ -173,6 +173,21 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${libs.slf4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${libs.commons-io}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>${libs.zookkeeper}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper-jute</artifactId>
+                <version>${libs.zookkeeper}</version>
             </dependency>
             <!-- Individual test dependencies -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -99,10 +99,10 @@
         <libs.caffeine>3.0.5</libs.caffeine>
         <libs.antlr>4.3.1</libs.antlr>
 
+        <libs.bookkeeper>4.14.4</libs.bookkeeper>
         <libs.zookkeeper>3.8.4</libs.zookkeeper>
         <libs.curator>5.2.0</libs.curator>
-        <libs.prometheus>0.14.1</libs.prometheus>
-        <libs.prometheus.metrics>4.14.4</libs.prometheus.metrics>
+        <libs.prometheus>0.16.0</libs.prometheus>
         <libs.micrometer>1.11.0</libs.micrometer>
         <libs.herddb>0.26.1</libs.herddb>
 
@@ -194,6 +194,13 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>io.prometheus</groupId>
+                <artifactId>simpleclient_bom</artifactId>
+                <version>${libs.prometheus}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
             <!-- Individual dependencies -->
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -229,6 +236,11 @@
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
                 <version>${libs.protobuf}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.bookkeeper.stats</groupId>
+                <artifactId>bookkeeper-stats-api</artifactId>
+                <version>${libs.bookkeeper}</version>
             </dependency>
             <!-- Individual test dependencies -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -114,9 +114,6 @@
         <libs.jetty>9.4.44.v20210927</libs.jetty>
         <libs.jersey>2.35</libs.jersey>
         <libs.jackson>2.14.1</libs.jackson>
-        <libs.jaxws.jaxb-api>2.3.1</libs.jaxws.jaxb-api>
-        <libs.jaxws.jaxb-impl>3.0.2</libs.jaxws.jaxb-impl>
-        <libs.javaxactivation-api>1.2.0</libs.javaxactivation-api>
         <libs.slf4j>1.7.35</libs.slf4j>
         <libs.guava>31.1-jre</libs.guava>
         <libs.lombok>1.18.32</libs.lombok>

--- a/pom.xml
+++ b/pom.xml
@@ -158,8 +158,8 @@
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
                 <version>${libs.projectreactor}</version>
-                <type>pom</type>
                 <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
@@ -172,8 +172,8 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
                 <version>${libs.jetty}</version>
-                <type>pom</type>
                 <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
@@ -336,6 +336,41 @@
                     <updateWorkingCopyVersions>true</updateWorkingCopyVersions>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-dependency-convergence</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <banDependencyManagementScope/>
+                                <banDynamicVersions>
+                                    <ignores>
+                                        <ignore>${project.groupId}</ignore>
+                                    </ignores>
+                                </banDynamicVersions>
+                                <banDuplicatePomDependencyVersions/>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>com.google.errorprone</exclude>
+                                        <exclude>com.google.code.findbugs</exclude>
+                                        <exclude>org.bouncycastle:*</exclude>
+                                        <exclude>org.checkerframework</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <include>org.bouncycastle:*-jdk15on</include>
+                                    </includes>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Closes #476 

* upgrade [Maven Wrapper](https://maven.apache.org/wrapper/) to Maven **3.9.9**;
* add [Reactor Tools](https://projectreactor.io/docs/core/release/reference/index.html#reactor-tools-debug) to improve debug capabilities;
* upgrade [Reactor Netty BOM](https://projectreactor.io/docs/netty/release/reference/index.html#getting) to version **2023.0.11**; 
  - this bumps Project Reactor dependencies to **3.6.11**
  - this bumps Reactor Netty dependencies to **1.1.23**;
* use [Netty BOM](https://github.com/netty/netty/issues/5994) to ensure that Netty-related dependencies outside of Reactor Netty BOM are aligned to version **4.1.114.Final**;
  - this includes [`io.netty:netty-tcnative-boringssl-static`](https://netty.io/wiki/forked-tomcat-native.html), now on version **2.0.66.Final**;
* update [acme4j](https://acme4j.shredzone.org/) to version **3.4.0**;
  - this was a major update that required some small fixes because of some breaking changes;
  - only `acme4j-client` was kept, `acme4j-utils` doesn't exist anymore, see <https://shredzone.org/maven/acme4j/migration.html> for details;
* update [Bouncy Castle](https://www.bouncycastle.org/documentation/documentation-java/) to version **1.78.1**;
* update [Apache BookKeeper](https://bookkeeper.apache.org/docs/overview/) used by [HerdDB](https://github.com/diennea/herddb) to version **4.14.8**;
  - we can't bump it any further without messing with HerdDB
* update [Apache ZooKeeper](https://zookeeper.apache.org/) to version **3.8.4**;
  - this was required to drop safely the dependency to [log4j 1.2](https://logging.apache.org/log4j/1.x/), which we previously excluded from the dependency tree without actually being sure that logs were routed correctly to Java logger;
* introduce BOM for [Prometheus Java client library](https://prometheus.github.io/client_java/) to version **0.16.0**;
  - we probably could have done a step forward here, using the [Simpleclient Bridge](https://prometheus.github.io/client_java/migration/simpleclient/) with the [Prometheus Java Client **1.0.0**](https://grafana.com/blog/2023/09/27/introducing-the-prometheus-java-client-1.0.0/), but I think we need a dedicated issue to revamp Carapace metrics;
* consolidate versions of various Apache Commons libraries, that mostly come as transitive dependencies:
  - bump [Apache Commons Codec](https://commons.apache.org/proper/commons-codec/) to version **1.15**;
  - bump [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/) to version **3.12.0**;
  - bump [Apache Commons Logging](https://commons.apache.org/proper/commons-logging/) to version **1.2**;
  - bump [Apache Commons IO](https://commons.apache.org/proper/commons-io/) to version **2.14.0**;
  - drop [Apache Commons Pool](https://commons.apache.org/proper/commons-pool/) 2.11.1 that was never used;
  - bump [Apache Commons Net](https://commons.apache.org/proper/commons-net/) to version 3.11.0
* introduce [Eclipse Jetty](https://jetty.org/index.html) BOM to consolidate dependencies to version **9.4.52.v20230823**;
* introduce [Eclipse Jersey](https://eclipse-ee4j.github.io/jersey/) BOM to consolidate dependencies to version **2.35**;
* introduce [Jackson BOM](https://github.com/FasterXML/jackson-bom) to consolidate dependencies to version **2.14.3**;
* drop unnecessary, explicit, dependency to JAX-B;
* consolidate [SLF4J](https://www.slf4j.org/) dependency to version **1.7.35**;
  - the backend of choice remains `slf4j-jdk14`, excluding transitive dependency to [Logback](https://logback.qos.ch/);
* introduce [Google Guava](https://github.com/google/guava) BOM to consolidate dependency to version **33.3.1** for JRE;
* consolidate [Google Protobuf](https://protobuf.dev/) version to **3.17.1**;
* upgrade [Wiremock](https://wiremock.org/2.x/docs/) to version **2.35.2**
  - waiting for #485 for a major bump
* drop explicit [Mockito](https://site.mockito.org/) as it conflicts with the version that comes with Powermock (see <https://github.com/powermock/powermock/wiki/Mockito>)
* consolidate [Objenesis](https://objenesis.org/) dependency version to **3.0.1**;
* upgrade built-in Maven plugins to the latest versions;
* exclude transitive dependencies to unused annotations;
* enforce dependency consistence through [Apache Maven Enforcer Plugin](https://maven.apache.org/enforcer/maven-enforcer-plugin/index.html)
