### PR TITLE
build: add MacOS native DNS bindings for ARM

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -31,6 +31,22 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <!-- https://netty.io/wiki/forked-tomcat-native.html#how-to-download-netty-tcnative-boringssl-uber-jar -->
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns-native-macos</artifactId>
+            <!-- Reactor Netty brings in this x86 version of the native DNS bindings for macOS... -->
+            <classifier>osx-x86_64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns-native-macos</artifactId>
+            <!-- ...but we also need the ARM version to fully support running on Apple devices -->
+            <classifier>osx-aarch_64</classifier>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.shredzone.acme4j</groupId>


### PR DESCRIPTION
When running on macOS with an ARM-based device, we get the following warning:

```
nov 04, 2024 11:46:57 AM io.netty.resolver.dns.DnsServerAddressStreamProviders <clinit>
GRAVE: Unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider, fallback to system defaults. This may result in incorrect DNS resolutions on MacOS. Check whether you have a dependency on 'io.netty:netty-resolver-dns-native-macos'. Use DEBUG level to see the full stack: java.lang.UnsatisfiedLinkError: failed to load the required native library
This is because Netty requires io.netty:netty-resolver-dns-native-macos in the classpath to leverage DNS resolution correctly.
```

Reactor Netty bundles the x86 version, but not the ARM one