### PR TITLE
feat: fix URL deprecation warnings

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/HerdDBConfigurationStore.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/HerdDBConfigurationStore.java
@@ -32,7 +32,7 @@ import herddb.jdbc.HerdDBEmbeddedDataSource;
 import herddb.security.SimpleSingleUserManager;
 import herddb.server.ServerConfiguration;
 import java.io.File;
-import java.net.URL;
+import java.net.URI;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -434,7 +434,7 @@ public class HerdDBConfigurationStore implements ConfigurationStore {
                                 subjectAltNames != null && !subjectAltNames.isBlank() ? Set.of(subjectAltNames.split(",")) : Set.of(),
                                 chain,
                                 state,
-                                pendingOrder != null ? new URL(pendingOrder) : null,
+                                pendingOrder != null ? URI.create(pendingOrder).toURL() : null,
                                 pendingChallenges,
                                 attemptCount,
                                 message

--- a/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthCheck.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthCheck.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
@@ -35,9 +37,9 @@ import org.carapaceproxy.utils.IOUtils;
  */
 public class BackendHealthCheck {
 
-    public final static int RESULT_SUCCESS = 1;
-    public final static int RESULT_FAILURE_CONNECTION = 2;
-    public final static int RESULT_FAILURE_STATUS = 3;
+    public static final int RESULT_SUCCESS = 1;
+    public static final int RESULT_FAILURE_CONNECTION = 2;
+    public static final int RESULT_FAILURE_STATUS = 3;
 
     private final String path;
     private final long startTs;
@@ -102,7 +104,7 @@ public class BackendHealthCheck {
             URL url;
             HttpURLConnection httpConn = null;
             try {
-                url = new URL("http", host, port, path);
+                url = new URI("http", null, host, port, path, null, null).toURL();
                 URLConnection conn = url.openConnection();
                 conn.setConnectTimeout(timeoutMillis);
                 conn.setReadTimeout(timeoutMillis);
@@ -129,7 +131,7 @@ public class BackendHealthCheck {
                     );
                 }
 
-            } catch (MalformedURLException ex) {
+            } catch (MalformedURLException | URISyntaxException ex) {
                 throw new RuntimeException(ex);
 
             } catch (IOException | RuntimeException ex) {

--- a/carapace-server/src/test/java/org/carapaceproxy/ApplyConfigurationTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/ApplyConfigurationTest.java
@@ -23,10 +23,15 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import org.apache.commons.io.IOUtils;
@@ -41,11 +46,6 @@ import org.carapaceproxy.user.SimpleUserRealm;
 import org.carapaceproxy.user.UserRealm;
 import org.carapaceproxy.utils.TestEndpointMapper;
 import org.carapaceproxy.utils.TestUserRealm;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -405,7 +405,7 @@ public class ApplyConfigurationTest {
     private void testIt(int port, boolean ok) throws URISyntaxException, IOException {
         try {
             String url = "http://localhost:" + port + "/index.html?redir";
-            String s = IOUtils.toString(new URL(url).toURI(), StandardCharsets.UTF_8);
+            String s = IOUtils.toString(URI.create(url), StandardCharsets.UTF_8);
             System.out.println("RES FOR: " + url + " -> " + s);
             assertEquals("it <b>works</b> !!", s);
             if (!ok) {

--- a/carapace-server/src/test/java/org/carapaceproxy/BigUploadTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/BigUploadTest.java
@@ -19,6 +19,8 @@
  */
 package org.carapaceproxy;
 
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -26,6 +28,7 @@ import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutorService;
@@ -37,8 +40,6 @@ import org.apache.commons.io.IOUtils;
 import org.carapaceproxy.client.EndpointKey;
 import org.carapaceproxy.core.HttpProxyServer;
 import org.carapaceproxy.utils.TestEndpointMapper;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -178,7 +179,7 @@ public class BigUploadTest {
             try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
                 server.start();
                 int port = server.getLocalPort();
-                URL url = new URL("http://localhost:" + port + "/index.html");
+                URL url = URI.create("http://localhost:" + port + "/index.html").toURL();
                 HttpURLConnection con = (HttpURLConnection) url.openConnection();
                 con.setDoOutput(true);
 
@@ -216,7 +217,7 @@ public class BigUploadTest {
             try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder());) {
                 server.start();
                 int port = server.getLocalPort();
-                URL url = new URL("http://localhost:" + port + "/index.html");
+                URL url = URI.create("http://localhost:" + port + "/index.html").toURL();
                 HttpURLConnection con = (HttpURLConnection) url.openConnection();
 
                 try (InputStream in = con.getInputStream()) {

--- a/carapace-server/src/test/java/org/carapaceproxy/ConcurrentClientsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/ConcurrentClientsTest.java
@@ -23,8 +23,12 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import java.net.URL;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -34,9 +38,6 @@ import org.apache.commons.io.IOUtils;
 import org.carapaceproxy.client.EndpointKey;
 import org.carapaceproxy.core.HttpProxyServer;
 import org.carapaceproxy.utils.TestEndpointMapper;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -79,7 +80,7 @@ public class ConcurrentClientsTest {
                     @Override
                     public void run() {
                         try {
-                            String s = IOUtils.toString(new URL("http://localhost:" + port + "/index.html").toURI(), "utf-8");
+                            String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index.html"), StandardCharsets.UTF_8);
                             assertEquals("it <b>works</b> !!", s);
                         } catch (Throwable t) {
                             t.printStackTrace();

--- a/carapace-server/src/test/java/org/carapaceproxy/SimpleHTTPProxyTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/SimpleHTTPProxyTest.java
@@ -33,7 +33,7 @@ import static reactor.netty.http.HttpProtocol.HTTP11;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
-import java.net.URL;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Set;
@@ -79,7 +79,7 @@ public class SimpleHTTPProxyTest {
 
             // not found
             try {
-                String s = IOUtils.toString(new URL("http://localhost:" + port + "/index.html?not-found").toURI(), StandardCharsets.UTF_8);
+                String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index.html?not-found"), StandardCharsets.UTF_8);
                 System.out.println("s:" + s);
                 fail();
             } catch (FileNotFoundException ok) {
@@ -87,7 +87,7 @@ public class SimpleHTTPProxyTest {
 
             // proxy
             {
-                String s = IOUtils.toString(new URL("http://localhost:" + port + "/index.html?redir").toURI(), StandardCharsets.UTF_8);
+                String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index.html?redir"), StandardCharsets.UTF_8);
                 System.out.println("s:" + s);
                 assertEquals("it <b>works</b> !!", s);
             }
@@ -119,7 +119,7 @@ public class SimpleHTTPProxyTest {
 
             // not found
             try {
-                String s = IOUtils.toString(new URL("https://localhost:" + port + "/index.html?not-found").toURI(), StandardCharsets.UTF_8);
+                String s = IOUtils.toString(URI.create("https://localhost:" + port + "/index.html?not-found"), StandardCharsets.UTF_8);
                 System.out.println("s:" + s);
                 fail();
             } catch (FileNotFoundException ok) {
@@ -127,7 +127,7 @@ public class SimpleHTTPProxyTest {
 
             // proxy
             {
-                String s = IOUtils.toString(new URL("https://localhost:" + port + "/index.html?redir").toURI(), StandardCharsets.UTF_8);
+                String s = IOUtils.toString(URI.create("https://localhost:" + port + "/index.html?redir"), StandardCharsets.UTF_8);
                 System.out.println("s:" + s);
                 assertEquals("it <b>works</b> !!", s);
             }
@@ -146,7 +146,7 @@ public class SimpleHTTPProxyTest {
             server.start();
             int port = server.getLocalPort();
 
-            HttpTestUtils.ResourceInfos result = HttpTestUtils.downloadFromUrl(new URL("http://localhost:" + port + "/index.html"),
+            HttpTestUtils.ResourceInfos result = HttpTestUtils.downloadFromUrl(URI.create("http://localhost:" + port + "/index.html").toURL(),
                     new ByteArrayOutputStream(), Collections.singletonMap("return_errors", "true"));
             assertEquals(503, result.responseCode);
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/RestartEndpointTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/RestartEndpointTest.java
@@ -26,18 +26,18 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
-import java.net.URL;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 import org.carapaceproxy.core.HttpProxyServer;
+import org.carapaceproxy.utils.CarapaceLogger;
 import org.carapaceproxy.utils.RawHttpClient;
 import org.carapaceproxy.utils.TestEndpointMapper;
-import static org.junit.Assert.assertEquals;
-import org.carapaceproxy.utils.CarapaceLogger;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -91,7 +91,7 @@ public class RestartEndpointTest {
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 wireMockRule.start();
                 // ensure that wiremock started again
-                IOUtils.toByteArray(new URL("http://localhost:" + wireMockRule.port() + "/index.html"));
+                IOUtils.toByteArray(URI.create("http://localhost:" + wireMockRule.port() + "/index.html").toURL());
                 System.out.println("Server at " + "http://localhost:" + wireMockRule.port() + "/index.html" + " is UP an running !");
 
                 assertEquals("it <b>works</b> !!", client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString());
@@ -131,7 +131,7 @@ public class RestartEndpointTest {
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 wireMockRule.start();
                 // ensure that wiremock started again
-                IOUtils.toByteArray(new URL("http://localhost:" + wireMockRule.port() + "/index.html"));
+                IOUtils.toByteArray(URI.create("http://localhost:" + wireMockRule.port() + "/index.html").toURL());
                 System.out.println("Server at " + "http://localhost:" + wireMockRule.port() + "/index.html" + " is UP an running !");
 
                 assertEquals("it <b>works</b> !!", client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString());
@@ -163,7 +163,7 @@ public class RestartEndpointTest {
                 wireMockRule.start();
                 System.out.println("*********************************************************");
                 // ensure that wiremock started again
-                IOUtils.toByteArray(new URL("http://localhost:" + wireMockRule.port() + "/index.html"));
+                IOUtils.toByteArray(URI.create("http://localhost:" + wireMockRule.port() + "/index.html").toURL());
                 assertEquals("it <b>works</b> !!", client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString());
             }
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreTest.java
@@ -26,7 +26,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import java.net.URL;
+import java.net.URI;
 import java.security.KeyPair;
 import java.util.Collections;
 import java.util.Map;
@@ -263,7 +263,7 @@ public class ConfigurationStoreTest {
                 Collections.emptySet(),
                 "encodedChain1",
                 DynamicCertificateState.AVAILABLE,
-                new URL("http://locallhost/order"),
+                URI.create("http://locallhost/order").toURL(),
                 Map.of(d1, JSON.parse("{\"challenge\": \"data\"}"))
         );
         store.saveCertificate(cert1);
@@ -279,7 +279,7 @@ public class ConfigurationStoreTest {
 
         // Cert Updating
         cert1.setState(DynamicCertificateState.WAITING);
-        cert1.setPendingOrderLocation(new URL("http://locallhost/updatedorder"));
+        cert1.setPendingOrderLocation(URI.create("http://locallhost/updatedorder").toURL());
         cert1.setPendingChallengesData(Map.of(cert1.getDomain(), JSON.parse("{\"challenge\": \"updateddata\"}")));
         store.saveCertificate(cert1);
         assertEquals(cert1, store.loadCertificateForDomain(d1));

--- a/carapace-server/src/test/java/org/carapaceproxy/core/JettyHttpTraceMethodTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/JettyHttpTraceMethodTest.java
@@ -1,14 +1,13 @@
 package org.carapaceproxy.core;
 
+import static org.junit.Assert.assertEquals;
 import io.netty.handler.codec.http.HttpMethod;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import javax.servlet.http.HttpServletResponse;
 import org.carapaceproxy.api.UseAdminServer;
 import org.junit.Test;
-
-import javax.servlet.http.HttpServletResponse;
-import java.net.HttpURLConnection;
-import java.net.URL;
-
-import static org.junit.Assert.assertEquals;
 
 public class JettyHttpTraceMethodTest extends UseAdminServer {
 
@@ -16,7 +15,7 @@ public class JettyHttpTraceMethodTest extends UseAdminServer {
     public void httpTraceMethodTest() throws Exception {
         startAdmin();
         String URL = "http://localhost:8761";
-        URL url = new URL(URL);
+        URL url = URI.create(URL).toURL();
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.setRequestMethod(String.valueOf(HttpMethod.TRACE));
         int code = conn.getResponseCode();

--- a/carapace-server/src/test/java/org/carapaceproxy/listeners/MultiListeningEndpointTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/listeners/MultiListeningEndpointTest.java
@@ -19,17 +19,19 @@ package org.carapaceproxy.listeners;
  under the License.
 
  */
+
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.Assert.assertEquals;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import java.net.URL;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 import org.carapaceproxy.core.HttpProxyServer;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.carapaceproxy.utils.TestEndpointMapper;
-import static org.junit.Assert.assertEquals;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -65,13 +67,13 @@ public class MultiListeningEndpointTest {
 
             // proxy
             {
-                String s = IOUtils.toString(new URL("http://localhost:" + port + "/index.html?redir").toURI(), "utf-8");
+                String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index.html?redir"), StandardCharsets.UTF_8);
                 System.out.println("s:" + s);
                 assertEquals("it <b>works</b> !!", s);
             }
 
             {
-                String s = IOUtils.toString(new URL("http://localhost:" + port2 + "/index.html?redir").toURI(), "utf-8");
+                String s = IOUtils.toString(URI.create("http://localhost:" + port2 + "/index.html?redir"), StandardCharsets.UTF_8);
                 System.out.println("s:" + s);
                 assertEquals("it <b>works</b> !!", s);
             }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesTest.java
@@ -45,7 +45,7 @@ import static org.shredzone.acme4j.Status.VALID;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.File;
 import java.io.StringWriter;
-import java.net.URL;
+import java.net.URI;
 import java.nio.file.Files;
 import java.security.KeyPair;
 import java.security.cert.Certificate;
@@ -514,7 +514,7 @@ public class CertificatesTest extends UseAdminServer {
         store.saveKeyPairForDomain(keyPair, "localhost", false);
         CertificateData cert = dcMan.getCertificateDataForDomain("localhost");
         cert.setState(DynamicCertificateState.ORDERING);
-        cert.setPendingOrderLocation(new URL("https://localhost/orderlocation"));
+        cert.setPendingOrderLocation(URI.create("https://localhost/orderlocation").toURL());
         store.saveCertificate(cert);
         assertEquals(DynamicCertificateState.ORDERING, dcMan.getStateOfCertificate("localhost"));
 
@@ -616,7 +616,7 @@ public class CertificatesTest extends UseAdminServer {
         store.saveKeyPairForDomain(keyPair, "localhost", false);
         CertificateData cert = dcMan.getCertificateDataForDomain("localhost");
         cert.setState(DynamicCertificateState.ORDERING);
-        cert.setPendingOrderLocation(new URL("https://localhost/orderlocation"));
+        cert.setPendingOrderLocation(URI.create("https://localhost/orderlocation").toURL());
         store.saveCertificate(cert);
         assertEquals(DynamicCertificateState.ORDERING, dcMan.getStateOfCertificate("localhost"));
 
@@ -656,7 +656,7 @@ public class CertificatesTest extends UseAdminServer {
 
         cert = dcMan.getCertificateDataForDomain("localhost");
         cert.setState(DynamicCertificateState.ORDERING);
-        cert.setPendingOrderLocation(new URL("https://localhost/orderlocation"));
+        cert.setPendingOrderLocation(URI.create("https://localhost/orderlocation").toURL());
         store.saveCertificate(cert);
         assertEquals(DynamicCertificateState.ORDERING, dcMan.getStateOfCertificate("localhost"));
         server.getCurrentConfiguration().setLocalCertificatesStorePeersIds(Set.of(server.getPeerId()));
@@ -703,7 +703,7 @@ public class CertificatesTest extends UseAdminServer {
         store.saveKeyPairForDomain(keyPair, "localhost", true);
         cert = dcMan.getCertificateDataForDomain("localhost");
         cert.setState(DynamicCertificateState.ORDERING);
-        cert.setPendingOrderLocation(new URL("https://localhost/orderlocation"));
+        cert.setPendingOrderLocation(URI.create("https://localhost/orderlocation").toURL());
         store.saveCertificate(cert);
         assertEquals(DynamicCertificateState.ORDERING, dcMan.getStateOfCertificate("localhost"));
         renewed = Arrays.asList((X509Certificate[]) generateSampleChain(keyPair, false));
@@ -780,7 +780,7 @@ public class CertificatesTest extends UseAdminServer {
         store.saveKeyPairForDomain(keyPair, "localhost2", false);
         cert = dcMan.getCertificateDataForDomain("localhost2");
         cert.setState(DynamicCertificateState.ORDERING);
-        cert.setPendingOrderLocation(new URL("https://localhost/orderlocation"));
+        cert.setPendingOrderLocation(URI.create("https://localhost/orderlocation").toURL());
         store.saveCertificate(cert);
         assertEquals(DynamicCertificateState.ORDERING, dcMan.getStateOfCertificate("localhost2"));
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.shredzone.acme4j.Status.INVALID;
 import static org.shredzone.acme4j.Status.VALID;
-import java.net.URL;
+import java.net.URI;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
@@ -107,7 +107,7 @@ public class DynamicCertificatesManagerTest {
         // ACME mocking
         ACMEClient ac = mock(ACMEClient.class);
         Order o = mock(Order.class);
-        when(o.getLocation()).thenReturn(new URL("https://localhost/index"));
+        when(o.getLocation()).thenReturn(URI.create("https://localhost/index").toURL());
         if (runCase.equals("order_already_valid")) {
             when(o.getStatus()).thenReturn(Status.VALID);
         }
@@ -300,7 +300,7 @@ public class DynamicCertificatesManagerTest {
         // ACME mocking
         ACMEClient ac = mock(ACMEClient.class);
         Order o = mock(Order.class);
-        when(o.getLocation()).thenReturn(new URL("https://localhost/index"));
+        when(o.getLocation()).thenReturn(URI.create("https://localhost/index").toURL());
         Login login = mock(Login.class);
         when(login.bindOrder(any())).thenReturn(o);
         when(ac.getLogin()).thenReturn(login);
@@ -427,7 +427,7 @@ public class DynamicCertificatesManagerTest {
         // ACME mocking
         ACMEClient ac = mock(ACMEClient.class);
         Order o = mock(Order.class);
-        when(o.getLocation()).thenReturn(new URL("https://localhost/index"));
+        when(o.getLocation()).thenReturn(URI.create("https://localhost/index").toURL());
         Login login = mock(Login.class);
         when(login.bindOrder(any())).thenReturn(o);
         when(ac.getLogin()).thenReturn(login);
@@ -558,7 +558,7 @@ public class DynamicCertificatesManagerTest {
         // ACME mocking
         ACMEClient ac = mock(ACMEClient.class);
         Order o = mock(Order.class);
-        when(o.getLocation()).thenReturn(new URL("https://localhost/index"));
+        when(o.getLocation()).thenReturn(URI.create("https://localhost/index").toURL());
         Login login = mock(Login.class);
         when(login.bindOrder(any())).thenReturn(o);
         when(ac.getLogin()).thenReturn(login);

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
@@ -40,7 +40,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
-import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
@@ -118,45 +117,45 @@ public class BasicStandardEndpointMapperTest {
             int port = server.getLocalPort();
             {
                 // proxy on director 1
-                String s = IOUtils.toString(new URL("http://localhost:" + port + "/index.html").toURI(), StandardCharsets.UTF_8);
+                String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index.html"), StandardCharsets.UTF_8);
                 assertEquals("it <b>works</b> !!", s);
             }
 
             {
                 // cache on director 2
-                String s = IOUtils.toString(new URL("http://localhost:" + port + "/index2.html").toURI(), StandardCharsets.UTF_8);
+                String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index2.html"), StandardCharsets.UTF_8);
                 assertEquals("it <b>works</b> !!", s);
             }
 
             {
                 // director "all"
-                String s = IOUtils.toString(new URL("http://localhost:" + port + "/index3.html").toURI(), StandardCharsets.UTF_8);
+                String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index3.html"), StandardCharsets.UTF_8);
                 assertEquals("it <b>works</b> !!", s);
             }
 
             try {
-                IOUtils.toString(new URL("http://localhost:" + port + "/notfound.html").toURI(), StandardCharsets.UTF_8);
+                IOUtils.toString(URI.create("http://localhost:" + port + "/notfound.html"), StandardCharsets.UTF_8);
                 fail("expected 404");
             } catch (FileNotFoundException ok) {
             }
 
             {
-                String staticContent = IOUtils.toString(new URL("http://localhost:" + port + "/static.html").toURI(), StandardCharsets.UTF_8);
+                String staticContent = IOUtils.toString(URI.create("http://localhost:" + port + "/static.html"), StandardCharsets.UTF_8);
                 assertEquals("Test static page", staticContent);
             }
             {
-                String staticContent = IOUtils.toString(new URL("http://localhost:" + port + "/static.html").toURI(), StandardCharsets.UTF_8);
+                String staticContent = IOUtils.toString(URI.create("http://localhost:" + port + "/static.html"), StandardCharsets.UTF_8);
                 assertEquals("Test static page", staticContent);
             }
 
             try {
-                IOUtils.toString(new URL("http://localhost:" + port + "/error.html").toURI(), StandardCharsets.UTF_8);
+                IOUtils.toString(URI.create("http://localhost:" + port + "/error.html"), StandardCharsets.UTF_8);
                 fail("expected 500");
             } catch (IOException ok) {
             }
 
             try {
-                IOUtils.toString(new URL("http://localhost:" + port + "/notmapped.html").toURI(), StandardCharsets.UTF_8);
+                IOUtils.toString(URI.create("http://localhost:" + port + "/notmapped.html"), StandardCharsets.UTF_8);
                 fail("expected 404");
             } catch (FileNotFoundException ok) {
             }
@@ -265,7 +264,7 @@ public class BasicStandardEndpointMapperTest {
 
             // route-custom error (Internal Errror)
             {
-                HttpURLConnection conn = (HttpURLConnection) new URL("http://localhost:" + server.getLocalPort() + "/custom-error.html").openConnection();
+                HttpURLConnection conn = (HttpURLConnection) URI.create("http://localhost:" + server.getLocalPort() + "/custom-error.html").toURL().openConnection();
                 System.out.println("response core " +  conn.getResponseCode());
                 assertEquals("h-custom-error-value; h-custom-error-value2;h-custom-error-value3", conn.getHeaderField("h-custom-error"));
                 assertEquals(555, conn.getResponseCode());
@@ -273,14 +272,14 @@ public class BasicStandardEndpointMapperTest {
 
             // working one
             {
-                HttpURLConnection conn = (HttpURLConnection) new URL("http://localhost:" + server.getLocalPort() + "/index.html").openConnection();
+                HttpURLConnection conn = (HttpURLConnection) URI.create("http://localhost:" + server.getLocalPort() + "/index.html").toURL().openConnection();
                 assertEquals("h-working-one-value; h-working-one-value2;h-working-one-value3", conn.getHeaderField("h-working-one"));
                 assertEquals(200, conn.getResponseCode());
             }
 
             // global-custom error (Not Found)
             {
-                HttpURLConnection conn = (HttpURLConnection) new URL("http://localhost:" + server.getLocalPort() + "/index2.html").openConnection();
+                HttpURLConnection conn = (HttpURLConnection) URI.create("http://localhost:" + server.getLocalPort() + "/index2.html").toURL().openConnection();
                 assertEquals("h-custom-global-error-value; h-custom-global-error-value2;h-custom-global-error-value3", conn.getHeaderField("h-custom-global-error"));
                 assertEquals(444, conn.getResponseCode());
             }
@@ -330,17 +329,17 @@ public class BasicStandardEndpointMapperTest {
             int port = server.getLocalPort();
             // index.html matches with route
             {
-                String s = IOUtils.toString(new URL("http://localhost:" + port + "/index.html").toURI(), StandardCharsets.UTF_8);
+                String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index.html"), StandardCharsets.UTF_8);
                 assertEquals("it <b>works</b> !!", s);
             }
             // notmapped.html matches with route-default
             {
-                String s = IOUtils.toString(new URL("http://localhost:" + port + "/notmapped.html").toURI(), StandardCharsets.UTF_8);
+                String s = IOUtils.toString(URI.create("http://localhost:" + port + "/notmapped.html"), StandardCharsets.UTF_8);
                 assertEquals("it <b>works</b> !!", s);
             }
             // down.html (request to unreachable backend) has NOT to match to route-deafult BUT get internal-error
             try {
-                IOUtils.toString(new URL("http://localhost:" + port + "/down.html").toURI(), StandardCharsets.UTF_8);
+                IOUtils.toString(URI.create("http://localhost:" + port + "/down.html"), StandardCharsets.UTF_8);
                 fail("expected 500");
             } catch (IOException ok) {
             }
@@ -597,7 +596,7 @@ public class BasicStandardEndpointMapperTest {
 
             int port = server.getLocalPort();
             {
-                URLConnection conn = new URL("http://localhost:" + port + "/index.html").openConnection();
+                URLConnection conn = URI.create("http://localhost:" + port + "/index.html").toURL().openConnection();
                 assertEquals("header-1-value; header-1-value2;header-1-value3", conn.getHeaderField("custom-header-1"));
                 assertEquals("header-2-value", conn.getHeaderField("custom-header-2"));
                 // header mode-set
@@ -610,7 +609,7 @@ public class BasicStandardEndpointMapperTest {
                 assertEquals("r1;addHeaders;d1;b1", conn.getHeaderField("DebugHeaderCustomName"));
             }
             {
-                URLConnection conn = new URL("http://localhost:" + port + "/index2.html").openConnection();
+                URLConnection conn = URI.create("http://localhost:" + port + "/index2.html").toURL().openConnection();
                 assertNull(conn.getHeaderField("custom-header-1"));
                 assertEquals("header-2-value", conn.getHeaderField("custom-header-2"));
                 // in this action is text/html as normal
@@ -625,7 +624,7 @@ public class BasicStandardEndpointMapperTest {
                 assertEquals("r2;addHeader2;d2;b2", conn.getHeaderField("DebugHeaderCustomName"));
             }
             {
-                URLConnection conn = new URL("http://localhost:" + port + "/index3.html").openConnection();
+                URLConnection conn = URI.create("http://localhost:" + port + "/index3.html").toURL().openConnection();
                 assertEquals("header-1-value; header-1-value2;header-1-value3", conn.getHeaderField("custom-header-1"));
             }
         }
@@ -695,28 +694,28 @@ public class BasicStandardEndpointMapperTest {
 
             {
                 // redirect to same host/uri but with https (default port)
-                HttpURLConnection conn = (HttpURLConnection) new URL("http://localhost:" + port + "/index.html").openConnection();
+                HttpURLConnection conn = (HttpURLConnection) URI.create("http://localhost:" + port + "/index.html").toURL().openConnection();
                 conn.setInstanceFollowRedirects(false);
                 assertEquals("https://localhost/index.html", conn.getHeaderField("Location"));
                 assertTrue(conn.getHeaderFields().toString().contains("301 Moved Permanently"));
             }
             {
                 // redirect to absolute host:port/uri
-                HttpURLConnection conn = (HttpURLConnection) new URL("http://localhost:" + port + "/index2.html").openConnection();
+                HttpURLConnection conn = (HttpURLConnection) URI.create("http://localhost:" + port + "/index2.html").toURL().openConnection();
                 conn.setInstanceFollowRedirects(false);
                 assertEquals("http://foo/index0.html", conn.getHeaderField("Location"));
                 assertTrue(conn.getHeaderFields().toString().contains("302 Found"));
             }
             {
                 // relative redirect (same host:port, different uri)
-                HttpURLConnection conn = (HttpURLConnection) new URL("http://localhost:" + port + "/index3.html").openConnection();
+                HttpURLConnection conn = (HttpURLConnection) URI.create("http://localhost:" + port + "/index3.html").toURL().openConnection();
                 conn.setInstanceFollowRedirects(false);
                 assertEquals("http://localhost:" + port + "/index0.html", conn.getHeaderField("Location"));
                 assertTrue(conn.getHeaderFields().toString().contains("303 See Other"));
             }
             {
                 // redirect custom
-                HttpURLConnection conn = (HttpURLConnection) new URL("http://localhost:" + port + "/index4.html").openConnection();
+                HttpURLConnection conn = (HttpURLConnection) URI.create("http://localhost:" + port + "/index4.html").toURL().openConnection();
                 conn.setInstanceFollowRedirects(false);
                 assertEquals("https://192.0.0.1:1234/indexX.html", conn.getHeaderField("Location"));
                 assertTrue(conn.getHeaderFields().toString().contains("307 Temporary Redirect"));

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperTest.java
@@ -39,6 +39,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
@@ -406,19 +407,19 @@ public class BasicStandardEndpointMapperTest {
 
             {
                 String url = "http://localhost:" + server.getLocalPort() + "/index.html";
-                String s = IOUtils.toString(new URL(url).toURI(), StandardCharsets.UTF_8);
+                String s = IOUtils.toString(URI.create(url), StandardCharsets.UTF_8);
                 assertEquals("Test static page", s);
             }
             {
 
                 String url = "http://localhost:" + server.getLocalPort() + "/seconda.html";
-                String s = IOUtils.toString(new URL(url).toURI(), StandardCharsets.UTF_8);
+                String s = IOUtils.toString(URI.create(url), StandardCharsets.UTF_8);
                 assertEquals("it <b>works</b> !!", s);
             }
             // resource not esists > Not Found
             try {
                 String url = "http://localhost:" + server.getLocalPort() + "/not-exists.html";
-                String s = IOUtils.toString(new URL(url).toURI(), StandardCharsets.UTF_8);
+                String s = IOUtils.toString(URI.create(url), StandardCharsets.UTF_8);
                 fail("Expected Not Found, received " + s + " instead");
             } catch (Exception ex) {
                 assertTrue(ex instanceof FileNotFoundException);
@@ -473,13 +474,13 @@ public class BasicStandardEndpointMapperTest {
 
             // Test existent token
             String url = "http://localhost:" + server.getLocalPort() + "/.well-known/acme-challenge/" + tokenName;
-            String s = IOUtils.toString(new URL(url).toURI(), StandardCharsets.UTF_8);
+            String s = IOUtils.toString(URI.create(url), StandardCharsets.UTF_8);
             assertEquals(tokenData, s);
 
             // Test not existent token
             try {
                 url = "http://localhost:" + server.getLocalPort() + "/.well-known/acme-challenge/not-existent-token";
-                IOUtils.toString(new URL(url).toURI(), StandardCharsets.UTF_8);
+                IOUtils.toString(URI.create(url), StandardCharsets.UTF_8);
                 fail();
             } catch (Throwable t) {
                 assertTrue(t instanceof FileNotFoundException);

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/ForceBackendTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/ForceBackendTest.java
@@ -27,7 +27,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.carapaceproxy.core.ProxyRequest.PROPERTY_URI;
 import static org.junit.Assert.assertEquals;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import java.net.URL;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import org.apache.commons.io.IOUtils;
 import org.carapaceproxy.configstore.PropertiesConfigurationStore;
@@ -90,12 +91,12 @@ public class ForceBackendTest {
             int port = server.getLocalPort();
             {
                 // proxy on director 2
-                String s = IOUtils.toString(new URL("http://localhost:" + port + "/index.html?thedirector=director-2").toURI(), "utf-8");
+                String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index.html?thedirector=director-2"), StandardCharsets.UTF_8);
                 assertEquals("it <b>works</b> !!", s);
             }
             {
                 // proxy on backend 2
-                String s = IOUtils.toString(new URL("http://localhost:" + port + "/index.html?thebackend=backend-b").toURI(), "utf-8");
+                String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index.html?thebackend=backend-b"), StandardCharsets.UTF_8);
                 assertEquals("it <b>works</b> !!", s);
             }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/HttpTestUtils.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/HttpTestUtils.java
@@ -19,6 +19,7 @@ package org.carapaceproxy.utils;
  under the License.
 
  */
+
 import java.io.BufferedInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -29,6 +30,7 @@ import java.io.Reader;
 import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.net.Proxy;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
@@ -235,7 +237,7 @@ public class HttpTestUtils {
                     responseMessage = httpCon.getResponseMessage();
                     location = httpCon.getHeaderField("Location");
                     if (instance_follow_redirects && httpCode >= 300 && httpCode < 400 && location != null && !location.isEmpty()) {
-                        redirectTo = new URL(url, location);
+                        redirectTo = url.toURI().resolve(location).toURL();
                     }
                     String errorHeader = httpCon.getHeaderField("x-mn-error");
                     if (errorHeader != null && errorHeader.equals("notfound")) {
@@ -274,6 +276,8 @@ public class HttpTestUtils {
                 } else {
                     throw ex;
                 }
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
             }
         } catch (IOException | RuntimeException ex) {
             Exception finalError = ex;


### PR DESCRIPTION
`new URL` constructor is deprecated since Java 20: <https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/net/URL.html>

closes #509 