### PR TITLE
feat: clean HTTP 1.1 to 2 upgrade headers

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/api/BackendsResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/BackendsResource.java
@@ -96,13 +96,13 @@ public class BackendsResource {
             }
             BackendHealthStatus bhs = backendsSnapshot.get(key);
             if (bhs != null) {
-                bean.available = bhs.isAvailable();
-                bean.reportedAsUnreachable = bhs.isReportedAsUnreachable();
-                bean.reportedAsUnreachableTs = bhs.getReportedAsUnreachableTs();
+                bean.available = bhs.getStatus() != BackendHealthStatus.Status.DOWN;
+                bean.reportedAsUnreachable = bhs.getStatus() == BackendHealthStatus.Status.DOWN;
+                bean.reportedAsUnreachableTs = bhs.getUnreachableSince();
                 BackendHealthCheck lastProbe = bhs.getLastProbe();
                 if (lastProbe != null) {
                     bean.lastProbeTs = lastProbe.endTs();
-                    bean.lastProbeSuccess = lastProbe.isOk();
+                    bean.lastProbeSuccess = lastProbe.ok();
                     bean.httpResponse = lastProbe.httpResponse();
                     bean.httpBody = lastProbe.httpBody();
                 }

--- a/carapace-server/src/main/java/org/carapaceproxy/api/DirectorsResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/DirectorsResource.java
@@ -59,11 +59,10 @@ public class DirectorsResource {
 
     @GET
     public List<DirectorBean> getAll() {
-        final List<DirectorBean> directors = new ArrayList();
+        final List<DirectorBean> directors = new ArrayList<>();
         HttpProxyServer server = (HttpProxyServer) context.getAttribute("server");
-        server.getMapper().getDirectors().forEach(director -> {
-            directors.add(new DirectorBean(director.getId(), director.getBackends()));
-        });
+        server.getMapper().getDirectors()
+                .forEach((directorId, director) -> directors.add(new DirectorBean(directorId, director.getBackends())));
 
         return directors;
     }

--- a/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
@@ -294,9 +294,7 @@ public class Listeners {
                 .handle((request, response) -> { // Custom request-response handling
                     if (LOG.isDebugEnabled()) {
                         LOG.debug(
-                                "Receive request {} From {} Timestamp {}",
-                                request.uri(),
-                                request.remoteAddress(),
+                                "Receive request {} From {} Timestamp {}", request.uri(), request.remoteAddress(),
                                 LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss.SSS"))
                         );
                     }
@@ -312,10 +310,7 @@ public class Listeners {
         // response compression
         if (currentConfiguration.getResponseCompressionThreshold() >= 0) {
             LOG.debug(
-                    "Response compression enabled with min size = {} bytes for listener {}",
-                    currentConfiguration.getResponseCompressionThreshold(),
-                    hostPort
-            );
+                    "Response compression enabled with min size = {} bytes for listener {}", currentConfiguration.getResponseCompressionThreshold(), hostPort);
             httpServer = httpServer.compress(currentConfiguration.getResponseCompressionThreshold());
         } else {
             LOG.debug("Response compression disabled for listener {}", hostPort);

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequest.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequest.java
@@ -213,13 +213,13 @@ public class ProxyRequest implements MatchingContext {
             if (hostAndPort == null) {
                 return false;
             }
-            HostAndPort parsed = HostAndPort.fromString(hostAndPort);
-            String host = parsed.getHost();
+            final HostAndPort parsed = HostAndPort.fromString(hostAndPort);
+            final String host = parsed.getHost();
             if (parsed.hasPort()) {
                 return !host.isBlank()
                         && (InternetDomainName.isValid(host) || InetAddresses.isInetAddress(host))
                         && parsed.getPort() >= 0
-                        && parsed.getPort() <= 65535;
+                        && parsed.getPort() <= EndpointKey.MAX_PORT;
             } else {
                 return !host.isBlank()
                         && (InternetDomainName.isValid(host) || InetAddresses.isInetAddress(host));

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -61,6 +61,7 @@ import jdk.net.ExtendedSocketOptions;
 import org.apache.http.HttpStatus;
 import org.carapaceproxy.EndpointStats;
 import org.carapaceproxy.SimpleHTTPResponse;
+import org.carapaceproxy.server.backends.BackendHealthStatus;
 import org.carapaceproxy.server.cache.ContentsCache;
 import org.carapaceproxy.server.config.BackendConfiguration;
 import org.carapaceproxy.server.config.ConnectionPoolConfiguration;
@@ -106,7 +107,7 @@ public class ProxyRequestsManager {
         this.parent = parent;
     }
 
-    public EndpointStats getEndpointStats(EndpointKey key) {
+    public EndpointStats getEndpointStats(final EndpointKey key) {
         return endpointsStats.get(key);
     }
 
@@ -148,8 +149,8 @@ public class ProxyRequestsManager {
                 case BAD_REQUEST -> serveBadRequestMessage(request);
                 case STATIC, ACME_CHALLENGE -> serveStaticMessage(request);
                 case REDIRECT -> serveRedirect(request);
-                case PROXY -> forward(request, false);
-                case CACHE -> serveFromCache(request); // cached content
+                case PROXY -> forward(request, false, action.getHealthStatus());
+                case CACHE -> serveFromCache(request, action.getHealthStatus()); // cached content
                 default -> throw new IllegalStateException("Action " + action.getAction() + " not supported");
             };
         } finally {
@@ -347,20 +348,22 @@ public class ProxyRequestsManager {
      *
      * @param request      the unpacked incoming request to forward to the corresponding backend endpoint
      * @param cache        whether the request is cacheable or not
+     * @param healthStatus the health status of the chosen backend; it should be notified when connection starts and ends
      * @return a {@link Flux} forwarding the returned {@link Publisher} sequence
      */
-    public Publisher<Void> forward(ProxyRequest request, boolean cache) {
+    public Publisher<Void> forward(final ProxyRequest request, final boolean cache, final BackendHealthStatus healthStatus) {
         Objects.requireNonNull(request.getAction());
         final String endpointHost = request.getAction().getHost();
+        Objects.requireNonNull(endpointHost);
         final int endpointPort = request.getAction().getPort();
-        EndpointKey key = EndpointKey.make(endpointHost, endpointPort);
-        EndpointStats endpointStats = endpointsStats.computeIfAbsent(key, EndpointStats::new);
+        final EndpointKey key = EndpointKey.make(endpointHost, endpointPort);
+        final EndpointStats endpointStats = endpointsStats.computeIfAbsent(key, EndpointStats::new);
 
-        var connectionToEndpoint = connectionsManager.apply(request);
-        ConnectionPoolConfiguration connectionConfig = connectionToEndpoint.getKey();
-        ConnectionProvider connectionProvider = connectionToEndpoint.getValue();
+        final var connectionToEndpoint = connectionsManager.apply(request);
+        final ConnectionPoolConfiguration connectionConfig = connectionToEndpoint.getKey();
+        final ConnectionProvider connectionProvider = connectionToEndpoint.getValue();
         if (LOGGER.isDebugEnabled()) {
-            Map<String, HttpProxyServer.ConnectionPoolStats> stats = parent.getConnectionPoolsStats().get(key);
+            final Map<String, HttpProxyServer.ConnectionPoolStats> stats = parent.getConnectionPoolsStats().get(key);
             if (stats != null) {
                 LOGGER.debug(
                         "Connection {} stats: {}",
@@ -401,12 +404,7 @@ public class ProxyRequestsManager {
                 .doOnRequest((req, conn) -> {
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug(
-                                "Start sending request for  Using client id {}_{} Uri {} Timestamp {} Backend {}:{}",
-                                key,
-                                connectionConfig.getId(),
-                                req.resourceUrl(),
-                                LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss.SSS")),
-                                endpointHost,
+                                "Start sending request for  Using client id {}_{} Uri {} Timestamp {} Backend {}:{}", key, connectionConfig.getId(), req.resourceUrl(), LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss.SSS")), endpointHost,
                                 endpointPort
                         );
                     }
@@ -415,17 +413,13 @@ public class ProxyRequestsManager {
                 }).doAfterRequest((req, conn) -> {
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug(
-                                "Finished sending request for  Using client id {}_{} Uri {} Timestamp {} Backend {}:{}",
-                                key,
-                                connectionConfig.getId(),
-                                request.getUri(),
-                                LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss.SSS")),
-                                endpointHost,
+                                "Finished sending request for  Using client id {}_{} Uri {} Timestamp {} Backend {}:{}", key, connectionConfig.getId(), request.getUri(), LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss.SSS")), endpointHost,
                                 endpointPort
                         );
                     }
                 }).doAfterResponseSuccess((resp, conn) -> {
                     PENDING_REQUESTS_GAUGE.dec();
+                    healthStatus.decrementConnections();
                     endpointStats.getLastActivity().set(System.currentTimeMillis());
                 }));
 
@@ -439,6 +433,7 @@ public class ProxyRequestsManager {
         }
 
         PENDING_REQUESTS_GAUGE.inc();
+        healthStatus.incrementConnections();
         return forwarder.request(request.getMethod())
                 .uri(request.getUri())
                 .send((req, out) -> {
@@ -451,12 +446,7 @@ public class ProxyRequestsManager {
                 .response((resp, flux) -> { // endpoint response
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug(
-                                "Receive response from backend for {} Using client id {}_{} uri{} timestamp {} Backend: {}",
-                                request.getRemoteAddress(),
-                                key,
-                                connectionConfig.getId(),
-                                request.getUri(),
-                                LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss.SSS")),
+                                "Receive response from backend for {} Using client id {}_{} uri{} timestamp {} Backend: {}", request.getRemoteAddress(), key, connectionConfig.getId(), request.getUri(), LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss.SSS")),
                                 request.getAction().getHost()
                         );
                     }
@@ -494,12 +484,7 @@ public class ProxyRequestsManager {
                     }).doOnComplete(() -> {
                         if (LOGGER.isDebugEnabled()) {
                             LOGGER.debug(
-                                    "Send all response to client {} Using client id {}_{} for uri {} timestamp {} Backend: {}",
-                                    request.getRemoteAddress(),
-                                    key,
-                                    connectionConfig.getId(),
-                                    request.getUri(),
-                                    LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss.SSS")),
+                                    "Send all response to client {} Using client id {}_{} for uri {} timestamp {} Backend: {}", request.getRemoteAddress(), key, connectionConfig.getId(), request.getUri(), LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss.SSS")),
                                     request.getAction().getHost()
                             );
                         }
@@ -509,6 +494,7 @@ public class ProxyRequestsManager {
                     }));
                 }).onErrorResume(err -> { // custom endpoint request/response error handling
                     PENDING_REQUESTS_GAUGE.dec();
+                    healthStatus.decrementConnections();
 
                     EndpointKey endpoint = EndpointKey.make(request.getAction().getHost(), request.getAction().getPort());
                     if (err instanceof ReadTimeoutException) {
@@ -577,11 +563,11 @@ public class ProxyRequestsManager {
         }
     }
 
-    private Publisher<Void> serveFromCache(ProxyRequest request) {
+    private Publisher<Void> serveFromCache(ProxyRequest request, final BackendHealthStatus healthStatus) {
         ContentsCache.ContentSender cacheSender = parent.getCache().getCacheSender(request);
         if (cacheSender == null) {
             // content non cached, forwarding and caching...
-            return forward(request, true);
+            return forward(request, true, healthStatus);
         }
         request.setServedFromCache(true);
 
@@ -644,12 +630,7 @@ public class ProxyRequestsManager {
                 // max connections per endpoint limit setup
                 newEndpoints.forEach(be -> {
                     LOGGER.debug(
-                            "Setup max connections per endpoint {}:{} = {} for connectionpool {}",
-                            be.host(),
-                            be.port(),
-                            connectionPool.getMaxConnectionsPerEndpoint(),
-                            connectionPool.getId()
-                    );
+                            "Setup max connections per endpoint {}:{} = {} for connectionpool {}", be.host(), be.port(), connectionPool.getMaxConnectionsPerEndpoint(), connectionPool.getId());
                     builder.forRemoteHost(InetSocketAddress.createUnresolved(be.host(), be.port()), spec -> {
                         spec.maxConnections(connectionPool.getMaxConnectionsPerEndpoint());
                         spec.pendingAcquireTimeout(Duration.ofMillis(connectionPool.getBorrowTimeout()));

--- a/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.security.NoSuchAlgorithmException;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -75,6 +76,7 @@ public class RuntimeServerConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(RuntimeServerConfiguration.class);
     private static final int DEFAULT_PROBE_PERIOD = 0;
+    public static final long DEFAULT_WARMUP_PERIOD = Duration.ofSeconds(30).toMillis();
 
     private final List<NetworkListenerConfiguration> listeners = new ArrayList<>();
     private final Map<String, SSLCertificateConfiguration> certificates = new HashMap<>();
@@ -116,6 +118,8 @@ public class RuntimeServerConfiguration {
     private String userRealmClassname;
     private int healthProbePeriod = DEFAULT_PROBE_PERIOD;
     private int healthConnectTimeout = 5_000;
+    private long warmupPeriod = DEFAULT_WARMUP_PERIOD;
+    private boolean tolerant = false;
     private int dynamicCertificatesManagerPeriod = 0;
     private int keyPairsSize = DEFAULT_KEYPAIRS_SIZE;
     private Set<String> domainsCheckerIPAddresses;
@@ -230,6 +234,12 @@ public class RuntimeServerConfiguration {
         if (healthProbePeriod <= DEFAULT_PROBE_PERIOD) {
             LOG.warn("BACKEND-HEALTH-MANAGER DISABLED");
         }
+
+        warmupPeriod = properties.getLong("healthmanager.warmupperiod", DEFAULT_WARMUP_PERIOD);
+        LOG.info("healthmanager.warmupperiod={}", warmupPeriod);
+
+        tolerant = properties.getBoolean("healthmanager.tolerant", false);
+        LOG.info("healthmanager.tolerant={}", tolerant);
 
         healthConnectTimeout = properties.getInt("healthmanager.connecttimeout", healthConnectTimeout);
         LOG.info("healthmanager.connecttimeout={}", healthConnectTimeout);

--- a/carapace-server/src/main/java/org/carapaceproxy/launcher/ServerMain.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/launcher/ServerMain.java
@@ -35,6 +35,7 @@ import org.carapaceproxy.configstore.ConfigurationStore;
 import org.carapaceproxy.configstore.PropertiesConfigurationStore;
 import org.carapaceproxy.core.HttpProxyServer;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
+import org.carapaceproxy.server.mapper.StandardEndpointMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -174,8 +175,7 @@ public class ServerMain implements AutoCloseable {
      */
     public void start() throws Exception {
         pidFileLocker.lock();
-
-        server = new HttpProxyServer(null, basePath);
+        server = new HttpProxyServer(StandardEndpointMapper::new, basePath);
         server.configureAtBoot(configuration);
         server.start();
         server.startMetrics();

--- a/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthManager.java
@@ -21,10 +21,8 @@ package org.carapaceproxy.server.backends;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.prometheus.client.Gauge;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -53,27 +51,31 @@ public class BackendHealthManager implements Runnable {
     private static final Gauge BACKEND_UPSTATUS_GAUGE = PrometheusUtils
             .createGauge("health", "backend_status", "backend status", "host")
             .register();
-
+    private final ConcurrentHashMap<EndpointKey, BackendHealthStatus> backends = new ConcurrentHashMap<>();
     private EndpointMapper mapper;
-
     private ScheduledExecutorService timer;
     private ScheduledFuture<?> scheduledFuture;
-
     // can change at runtime
     private volatile int period;
     // can change at runtime
     private volatile int connectTimeout;
     // keep track of start() calling
     private volatile boolean started;
-
-    private final ConcurrentHashMap<EndpointKey, BackendHealthStatus> backends = new ConcurrentHashMap<>();
+    private volatile long warmupPeriod;
+    private volatile boolean tolerant;
 
     public BackendHealthManager(final RuntimeServerConfiguration conf, final EndpointMapper mapper) {
         this.mapper = mapper;
+        this.connectTimeout = conf.getHealthConnectTimeout();
+        this.warmupPeriod = conf.getWarmupPeriod();
+        this.tolerant = conf.isTolerant();
 
         // will be overridden before start
         this.period = DEFAULT_PERIOD;
-        this.connectTimeout = conf.getHealthConnectTimeout();
+    }
+
+    public boolean isTolerant() {
+        return tolerant;
     }
 
     public int getPeriod() {
@@ -129,6 +131,17 @@ public class BackendHealthManager implements Runnable {
             LOG.info("Applying new connect timeout {} ms", this.connectTimeout);
         }
 
+        if (this.warmupPeriod != newConfiguration.getWarmupPeriod()) {
+            this.warmupPeriod = newConfiguration.getWarmupPeriod();
+            this.backends.values().forEach(it -> it.setWarmupPeriod(warmupPeriod));
+            LOG.info("Applying new warmup period of {} ms", this.warmupPeriod);
+        }
+
+        if (this.tolerant != newConfiguration.isTolerant()) {
+            this.tolerant = newConfiguration.isTolerant();
+            LOG.info("Applying new health tolerance configuration {}; cold backends now {} exceed safe capacity", this.tolerant, this.tolerant ? "may" : "may not");
+        }
+
         this.mapper = mapper;
 
         if (restart || started) {
@@ -141,72 +154,74 @@ public class BackendHealthManager implements Runnable {
         if (mapper == null) {
             return;
         }
-        Collection<BackendConfiguration> backendConfigurations = mapper.getBackends().values();
-        for (BackendConfiguration bconf : backendConfigurations) {
-            BackendHealthStatus status = backends.computeIfAbsent(bconf.hostPort(), BackendHealthStatus::new);
+        for (final BackendConfiguration backend : mapper.getBackends().values()) {
+            final EndpointKey endpoint = backend.hostPort();
+            final BackendHealthStatus status = getBackendStatus(endpoint);
+            final BackendHealthCheck checkResult = BackendHealthCheck.check(backend, connectTimeout);
 
-            BackendHealthCheck checkResult = BackendHealthCheck.check(
-                    bconf.host(), bconf.port(), bconf.probePath(), connectTimeout);
-
-            if (checkResult.isOk()) {
-                final var responseTime = checkResult.endTs() - checkResult.startTs();
-                if (status.isReportedAsUnreachable()) {
-                    LOG.warn("backend {} was unreachable, setting again to reachable. Response time {}ms", status.getHostPort(), responseTime);
-                    reportBackendReachable(status.getHostPort());
-                } else {
-                    LOG.debug("backend {} seems reachable. Response time {}ms", status.getHostPort(), responseTime);
+            if (checkResult.ok()) {
+                switch (status.getStatus()) {
+                    case DOWN ->
+                            LOG.warn("backend {} was unreachable, setting again to reachable. Response time {} ms", endpoint, checkResult.responseTime());
+                    case COLD, STABLE ->
+                            LOG.debug("backend {} seems reachable. Response time {} ms", endpoint, checkResult.responseTime());
                 }
+                reportBackendReachable(endpoint, checkResult.endTs());
             } else {
-                if (status.isReportedAsUnreachable()) {
-                    LOG.debug("backend {} still unreachable. Cause: {}", status.getHostPort(), checkResult.httpResponse());
-                } else {
-                    LOG.warn("backend {} became unreachable. Cause: {}", status.getHostPort(), checkResult.httpResponse());
-                    reportBackendUnreachable(status.getHostPort(), checkResult.endTs(), checkResult.httpResponse());
+                switch (status.getStatus()) {
+                    case DOWN ->
+                            LOG.debug("backend {} still unreachable. Cause: {}", endpoint, checkResult.httpResponse());
+                    case COLD, STABLE ->
+                            LOG.warn("backend {} became unreachable. Cause: {}", endpoint, checkResult.httpResponse());
                 }
+                reportBackendUnreachable(endpoint, checkResult.endTs(), checkResult.httpResponse());
             }
             status.setLastProbe(checkResult);
 
             BACKEND_UPSTATUS_GAUGE
-                    .labels(bconf.host() + "_" + bconf.port())
-                    .set(status.isReportedAsUnreachable() ? 0 : 1);
+                    .labels(backend.host() + "_" + backend.port())
+                    .set(status.getStatus() == BackendHealthStatus.Status.DOWN ? 0 : 1);
         }
-        List<EndpointKey> toRemove = new ArrayList<>();
-        for (final EndpointKey key : backends.keySet()) {
-            boolean found = false;
-            for (BackendConfiguration bconf : backendConfigurations) {
-                if (bconf.hostPort().equals(key)) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                toRemove.add(key);
-            }
+        cleanup();
+    }
+
+    private void cleanup() {
+        if (mapper == null) {
+            return;
         }
-        if (!toRemove.isEmpty()) {
-            LOG.info("discarding backends {}", toRemove);
-            toRemove.forEach(backends::remove);
-        }
+        backends.keySet().retainAll(mapper.getBackends().values().stream().map(BackendConfiguration::hostPort).toList());
+    }
+
+    public void reportBackendReachable(final EndpointKey hostPort, final long timestamp) {
+        getBackendStatus(hostPort).reportAsReachable(timestamp);
     }
 
     public void reportBackendUnreachable(final EndpointKey hostPort, final long timestamp, final String cause) {
         getBackendStatus(hostPort).reportAsUnreachable(timestamp, cause);
     }
 
-    private BackendHealthStatus getBackendStatus(final EndpointKey hostPort) {
-        return backends.computeIfAbsent(hostPort, BackendHealthStatus::new);
-    }
-
-    public void reportBackendReachable(final EndpointKey hostPort) {
-        getBackendStatus(hostPort).reportAsReachable();
-    }
-
     public Map<EndpointKey, BackendHealthStatus> getBackendsSnapshot() {
         return Map.copyOf(backends);
     }
 
-    public boolean isAvailable(final EndpointKey hostPort) {
-        return getBackendStatus(hostPort).isAvailable();
+    public BackendHealthStatus getBackendStatus(final EndpointKey hostPort) {
+        return backends.computeIfAbsent(hostPort, key -> new BackendHealthStatus(key, warmupPeriod));
+    }
+
+    public BackendHealthStatus getBackendStatus(final String backendId) {
+        final BackendConfiguration backendConfiguration = this.mapper.getBackends().get(backendId);
+        Objects.requireNonNull(backendConfiguration);
+        return getBackendStatus(backendConfiguration.hostPort());
+    }
+
+    public boolean exceedsCapacity(final String backendId) {
+        final BackendConfiguration backendConfiguration = this.mapper.getBackends().get(backendId);
+        Objects.requireNonNull(backendConfiguration);
+        if (backendConfiguration.safeCapacity() <= 0) {
+            return false;
+        }
+        final BackendHealthStatus backendStatus = getBackendStatus(backendConfiguration.hostPort());
+        return backendConfiguration.safeCapacity() > backendStatus.getConnections();
     }
 
     @VisibleForTesting

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/ActionConfiguration.java
@@ -33,10 +33,25 @@ import org.carapaceproxy.server.mapper.CustomHeader;
 @Data
 public class ActionConfiguration {
 
+    /**
+     * @see org.carapaceproxy.server.mapper.MapResult.Action#PROXY
+     */
     public static final String TYPE_PROXY = "proxy";
+    /**
+     * @see org.carapaceproxy.server.mapper.MapResult.Action#CACHE
+     */
     public static final String TYPE_CACHE = "cache";
+    /**
+     * @see org.carapaceproxy.server.mapper.MapResult.Action#STATIC
+     */
     public static final String TYPE_STATIC = "static";
+    /**
+     * @see org.carapaceproxy.server.mapper.MapResult.Action#ACME_CHALLENGE
+     */
     public static final String TYPE_ACME_CHALLENGE = "acme-challenge";
+    /**
+     * @see org.carapaceproxy.server.mapper.MapResult.Action#REDIRECT
+     */
     public static final String TYPE_REDIRECT = "redirect";
 
     private final String id;
@@ -61,7 +76,7 @@ public class ActionConfiguration {
     }
 
     public ActionConfiguration setCustomHeaders(List<CustomHeader> customHeaders) {
-        this.customHeaders = Collections.unmodifiableList(customHeaders == null ? new ArrayList() : customHeaders);
+        this.customHeaders = Collections.unmodifiableList(customHeaders == null ? new ArrayList<>() : customHeaders);
         return this;
     }
 

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/BackendConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/BackendConfiguration.java
@@ -20,14 +20,29 @@
 package org.carapaceproxy.server.config;
 
 import org.carapaceproxy.core.EndpointKey;
+import org.carapaceproxy.server.backends.BackendHealthStatus.Status;
 
 /**
- * Configuration of a single backend server
+ * Configuration of a single backend server.
+ *
+ * @param id           an arbitrary ID of the backend
+ * @param hostPort     the host:port tuple for the backend
+ * @param probePath    a path to use to probe the backend for reachability
+ * @param safeCapacity a capacity that is considered safe even when {@link Status#COLD cold}
  */
-public record BackendConfiguration(String id, EndpointKey hostPort, String probePath) {
+public record BackendConfiguration(String id, EndpointKey hostPort, String probePath, int safeCapacity) {
 
-    public BackendConfiguration(final String id, final String host, final int port, final String probePath) {
-        this(id, new EndpointKey(host, port), probePath);
+    /**
+     * Configuration of a single backend server.
+     *
+     * @param id           an arbitrary ID of the backend
+     * @param host         the host name
+     * @param port         the port to use
+     * @param probePath    a path to use to probe the backend for reachability
+     * @param safeCapacity a capacity that is considered safe even when {@link Status#COLD cold}, or 0 for an infinite capacity
+     */
+    public BackendConfiguration(final String id, final String host, final int port, final String probePath, final int safeCapacity) {
+        this(id, new EndpointKey(host, port), probePath, safeCapacity);
     }
 
     public String host() {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/BackendSelector.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/BackendSelector.java
@@ -20,6 +20,7 @@
 package org.carapaceproxy.server.config;
 
 import java.util.List;
+import org.carapaceproxy.server.mapper.EndpointMapper;
 
 /**
  * Chooses the backend which can serve the request
@@ -27,4 +28,13 @@ import java.util.List;
 public interface BackendSelector {
 
     List<String> selectBackends(String userId, String sessionId, String director);
+
+    /**
+     * Functional interface that models a factory for selectors given the mapper they should be applied to.
+     */
+    @FunctionalInterface
+    interface SelectorFactory {
+
+        BackendSelector build(EndpointMapper endpointMapper);
+    }
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/SafeBackendSelector.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/SafeBackendSelector.java
@@ -1,0 +1,49 @@
+package org.carapaceproxy.server.config;
+
+import static org.carapaceproxy.server.config.DirectorConfiguration.ALL_BACKENDS;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.SequencedCollection;
+import org.carapaceproxy.server.backends.BackendHealthStatus;
+import org.carapaceproxy.server.mapper.EndpointMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SafeBackendSelector implements BackendSelector {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SafeBackendSelector.class);
+    private final EndpointMapper mapper;
+
+    public SafeBackendSelector(final EndpointMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public List<String> selectBackends(final String userId, final String sessionId, final String director) {
+        final Map<String, DirectorConfiguration> directors = mapper.getDirectors();
+        if (!directors.containsKey(director)) {
+            LOGGER.error("Director \"{}\" not configured, while handling request userId={} sessionId={}", director, userId, sessionId);
+            return List.of();
+        }
+        final DirectorConfiguration directorConfig = directors.get(director);
+        if (directorConfig.getBackends().contains(ALL_BACKENDS)) {
+            return sortByConnections(mapper.getBackends().sequencedKeySet());
+        }
+        return sortByConnections(directorConfig.getBackends());
+    }
+
+    public List<String> sortByConnections(final SequencedCollection<String> backendIds) {
+        return backendIds.stream().sorted(Comparator.comparingLong(this::connections)).toList();
+    }
+
+    private long connections(final String backendId) {
+        final BackendHealthStatus backendStatus = mapper.getBackendHealthManager().getBackendStatus(backendId);
+        return switch (backendStatus.getStatus()) {
+            case DOWN -> Long.MAX_VALUE; // backends that are down are put last, but not dropped
+            case COLD -> mapper.getBackendHealthManager().exceedsCapacity(backendId)
+                    ? Long.MAX_VALUE - 1 // cold backends that exceed safe capacity are put last, just before down ones
+                    : backendStatus.getConnections();
+            case STABLE -> backendStatus.getConnections();
+        };
+    }
+}

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/EndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/EndpointMapper.java
@@ -44,7 +44,11 @@ import org.carapaceproxy.server.config.RouteConfiguration;
  */
 public abstract class EndpointMapper {
 
-    private HttpProxyServer parent;
+    private final HttpProxyServer parent;
+
+    protected EndpointMapper(final HttpProxyServer parent) {
+        this.parent = parent;
+    }
 
     /**
      * Get the pool of {@link BackendConfiguration backends} to choose from.
@@ -71,9 +75,9 @@ public abstract class EndpointMapper {
     /**
      * Get all the configured {@link DirectorConfiguration directors} for the {@link BackendConfiguration backends}.
      *
-     * @return a list of directors, sorted according to configuration order
+     * @return a map of directors, sorted according to configuration order
      */
-    public abstract List<DirectorConfiguration> getDirectors();
+    public abstract SequencedMap<String, DirectorConfiguration> getDirectors();
 
     /**
      * Get all the {@link CustomHeader custom headers} that can be applied to the requests.
@@ -86,7 +90,8 @@ public abstract class EndpointMapper {
      * Process a request for a {@link ProxyRequestsManager}.
      * <p>
      * According to the incoming request and the underlying configuration,
-     * it computes an {@link MapResult#getAction() action} to execute on a specific {@link MapResult#routeId route}.
+     * it computes an {@link MapResult#getAction() action}
+     * to execute on a specific {@link MapResult#getRouteId() route}.
      *
      * @param request the request of a resource to be proxied
      * @return the result of the mapping process
@@ -116,16 +121,12 @@ public abstract class EndpointMapper {
 
     public abstract void configure(ConfigurationStore properties) throws ConfigurationNotValidException;
 
-    public final void setParent(final HttpProxyServer parent) {
-        this.parent = parent;
-    }
-
     protected final DynamicCertificatesManager getDynamicCertificatesManager() {
         Objects.requireNonNull(parent);
         return parent.getDynamicCertificatesManager();
     }
 
-    protected final BackendHealthManager getBackendHealthManager() {
+    public final BackendHealthManager getBackendHealthManager() {
         Objects.requireNonNull(parent);
         return parent.getBackendHealthManager();
     }
@@ -133,5 +134,11 @@ public abstract class EndpointMapper {
     protected final RuntimeServerConfiguration getCurrentConfiguration() {
         Objects.requireNonNull(parent);
         return parent.getCurrentConfiguration();
+    }
+
+    @FunctionalInterface
+    public interface Factory {
+
+        EndpointMapper build(HttpProxyServer httpProxyServer) throws ConfigurationNotValidException;
     }
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/MapResult.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/MapResult.java
@@ -20,8 +20,13 @@
 package org.carapaceproxy.server.mapper;
 
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import org.carapaceproxy.server.backends.BackendHealthStatus;
 
 @Data
 @Builder
@@ -78,7 +83,6 @@ public class MapResult {
     public static final String REDIRECT_PROTO_HTTPS = "https";
     public static final String REDIRECT_PROTO_HTTP = "http";
 
-    // todo we don't actually want to have these nullable: probably we should have different classes for each case
     private String host;
     private int port;
     private Action action;
@@ -89,6 +93,11 @@ public class MapResult {
     private String redirectLocation;
     private String redirectProto;
     private String redirectPath;
+
+    @Setter(AccessLevel.NONE)
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    private BackendHealthStatus healthStatus;
 
     public static MapResult notFound(String routeId) {
         return MapResult.builder()

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/RandomBackendSelector.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/RandomBackendSelector.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.SequencedCollection;
 import java.util.random.RandomGenerator;
 import org.carapaceproxy.server.config.BackendSelector;
 import org.carapaceproxy.server.config.DirectorConfiguration;
@@ -19,14 +20,14 @@ import org.slf4j.LoggerFactory;
  * @see Collections#shuffle(List, RandomGenerator)
  * @see SecureRandom
  */
-class RandomBackendSelector implements BackendSelector {
+public class RandomBackendSelector implements BackendSelector {
     private static final Logger LOG = LoggerFactory.getLogger(RandomBackendSelector.class);
     private static final RandomGenerator RANDOM = new SecureRandom();
 
-    private final List<String> allBackendIds;
+    private final SequencedCollection<String> allBackendIds;
     private final Map<String, DirectorConfiguration> directors;
 
-    public RandomBackendSelector(final List<String> allBackendIds, final Map<String, DirectorConfiguration> directors) {
+    private RandomBackendSelector(final SequencedCollection<String> allBackendIds, final Map<String, DirectorConfiguration> directors) {
         this.allBackendIds = allBackendIds;
         this.directors = directors;
     }
@@ -44,7 +45,7 @@ class RandomBackendSelector implements BackendSelector {
         return shuffleCopy(directorConfig.getBackends());
     }
 
-    public List<String> shuffleCopy(final List<String> ids) {
+    public List<String> shuffleCopy(final SequencedCollection<String> ids) {
         if (ids.isEmpty()) {
             return List.of();
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/ApplyConfigurationTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/ApplyConfigurationTest.java
@@ -81,16 +81,19 @@ public class ApplyConfigurationTest {
      */
     public static final class StaticEndpointMapper extends TestEndpointMapper {
 
+        public StaticEndpointMapper(final HttpProxyServer ignoredServer) {
+            this(); // required for reflective construction
+        }
+
         public StaticEndpointMapper() {
             super("localhost", wireMockRule.port());
         }
-
     }
 
     @Test
     public void testChangeListenersConfig() throws Exception {
 
-        try (HttpProxyServer server = new HttpProxyServer(null, tmpDir.newFolder());) {
+        try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, tmpDir.newFolder());) {
 
             {
                 Properties configuration = new Properties();
@@ -217,7 +220,7 @@ public class ApplyConfigurationTest {
     @Test
     public void testReloadMapper() throws Exception {
 
-        try (HttpProxyServer server = new HttpProxyServer(null, tmpDir.newFolder());) {
+        try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, tmpDir.newFolder());) {
 
             {
                 Properties configuration = new Properties();
@@ -289,7 +292,7 @@ public class ApplyConfigurationTest {
     public void testUserRealm() throws Exception {
 
         // Default UserRealm
-        try (HttpProxyServer server = new HttpProxyServer(null, tmpDir.newFolder())) {
+        try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, tmpDir.newFolder())) {
             Properties configuration = new Properties();
             server.configureAtBoot(new PropertiesConfigurationStore(configuration));
             server.start();
@@ -307,7 +310,7 @@ public class ApplyConfigurationTest {
         }
 
         // TestUserRealm
-        try (HttpProxyServer server = new HttpProxyServer(null, tmpDir.newFolder())) {
+        try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, tmpDir.newFolder())) {
             Properties configuration = new Properties();
             configuration.put("userrealm.class", "org.carapaceproxy.utils.TestUserRealm");
             configuration.put("user.test1", "pass1");
@@ -336,7 +339,7 @@ public class ApplyConfigurationTest {
     @Test
     public void testChangeFiltersConfiguration() throws Exception {
 
-        try (HttpProxyServer server = new HttpProxyServer(null, tmpDir.newFolder());) {
+        try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, tmpDir.newFolder());) {
 
             {
                 Properties configuration = new Properties();
@@ -375,7 +378,7 @@ public class ApplyConfigurationTest {
     @Test
     public void testChangeBackendHealthManagerConfiguration() throws Exception {
 
-        try (HttpProxyServer server = new HttpProxyServer(null, tmpDir.newFolder());) {
+        try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, tmpDir.newFolder());) {
 
             {
                 Properties configuration = new Properties();

--- a/carapace-server/src/test/java/org/carapaceproxy/DatabaseConfigurationTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/DatabaseConfigurationTest.java
@@ -31,6 +31,7 @@ import org.carapaceproxy.configstore.PropertiesConfigurationStore;
 import org.carapaceproxy.core.HttpProxyServer;
 import org.carapaceproxy.server.filters.RegexpMapUserIdFilter;
 import org.carapaceproxy.server.filters.XForwardedForRequestFilter;
+import org.carapaceproxy.server.mapper.StandardEndpointMapper;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,7 +49,7 @@ public class DatabaseConfigurationTest {
     @Test
     public void testBootWithDatabaseStore() throws Exception {
 
-        try (HttpProxyServer server = new HttpProxyServer(null, tmpDir.newFolder());) {
+        try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, tmpDir.newFolder())) {
 
             Properties configuration = new Properties();
 
@@ -70,7 +71,7 @@ public class DatabaseConfigurationTest {
     public void testChangeFiltersConfiguration() throws Exception {
 
         File databaseFolder = tmpDir.newFolder();
-        try (HttpProxyServer server = new HttpProxyServer(null, tmpDir.newFolder());) {
+        try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, tmpDir.newFolder())) {
 
             Properties configurationAtBoot = new Properties();
             configurationAtBoot.put("db.jdbc.url", "jdbc:herddb:localhost");
@@ -100,7 +101,7 @@ public class DatabaseConfigurationTest {
         }
 
         // reboot, new configuration MUST be kept
-        try (HttpProxyServer server = new HttpProxyServer(null, tmpDir.newFolder());) {
+        try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, tmpDir.newFolder())) {
             Properties configurationAtBoot = new Properties();
             configurationAtBoot.put("db.jdbc.url", "jdbc:herddb:localhost");
             configurationAtBoot.put("db.server.base.dir", tmpDir.newFolder().getAbsolutePath());
@@ -119,7 +120,7 @@ public class DatabaseConfigurationTest {
 
         }
         // reboot, new configuration MUST be kept
-        try (HttpProxyServer server = new HttpProxyServer(null, tmpDir.newFolder());) {
+        try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, tmpDir.newFolder())) {
             Properties configurationAtBoot = new Properties();
             configurationAtBoot.put("db.jdbc.url", "jdbc:herddb:localhost");
             configurationAtBoot.put("db.server.base.dir", tmpDir.newFolder().getAbsolutePath());

--- a/carapace-server/src/test/java/org/carapaceproxy/MaintenanceModeTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/MaintenanceModeTest.java
@@ -1,21 +1,22 @@
 package org.carapaceproxy;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import org.carapaceproxy.api.UseAdminServer;
-import org.carapaceproxy.utils.TestUtils;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Base64;
 import java.util.Properties;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.carapaceproxy.api.UseAdminServer;
+import org.carapaceproxy.utils.TestUtils;
+import org.junit.Rule;
+import org.junit.Test;
 
 public class MaintenanceModeTest extends UseAdminServer {
 
@@ -35,6 +36,7 @@ public class MaintenanceModeTest extends UseAdminServer {
                         .withBody("it <b>works</b> !!")));
 
         config = new Properties(HTTP_ADMIN_SERVER_CONFIG);
+        config.put("healthmanager.tolerant", "true");
         startServer(config);
 
         // Default certificate
@@ -53,12 +55,12 @@ public class MaintenanceModeTest extends UseAdminServer {
         config.put("backend.1.id", "localhost");
         config.put("backend.1.enabled", "true");
         config.put("backend.1.host", "localhost");
-        config.put("backend.1.port", wireMockRule.port() + "");
+        config.put("backend.1.port", String.valueOf(wireMockRule.port()));
 
         config.put("backend.2.id", "localhost2");
         config.put("backend.2.enabled", "true");
         config.put("backend.2.host", "localhost2");
-        config.put("backend.2.port", wireMockRule.port() + "");
+        config.put("backend.2.port", String.valueOf(wireMockRule.port()));
 
         // Default director
         config.put("director.1.id", "*");
@@ -111,6 +113,7 @@ public class MaintenanceModeTest extends UseAdminServer {
                         .withBody("it <b>works</b> !!")));
 
         config = new Properties(HTTP_ADMIN_SERVER_CONFIG);
+        config.put("healthmanager.tolerant", "true");
         startServer(config);
 
         // Default certificate
@@ -129,12 +132,12 @@ public class MaintenanceModeTest extends UseAdminServer {
         config.put("backend.1.id", "localhost");
         config.put("backend.1.enabled", "true");
         config.put("backend.1.host", "localhost");
-        config.put("backend.1.port", wireMockRule.port() + "");
+        config.put("backend.1.port", String.valueOf(wireMockRule.port()));
 
         config.put("backend.2.id", "localhost2");
         config.put("backend.2.enabled", "true");
         config.put("backend.2.host", "localhost2");
-        config.put("backend.2.port", wireMockRule.port() + "");
+        config.put("backend.2.port", String.valueOf(wireMockRule.port()));
 
         // Default director
         config.put("director.1.id", "*");
@@ -160,7 +163,7 @@ public class MaintenanceModeTest extends UseAdminServer {
         HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         assertEquals("it <b>works</b> !!", response.body());
 
-        //ENABLE MAINTENANCE MODE VIA API
+        // ENABLE MAINTENANCE MODE VIA API
         HttpRequest enableMaintenanceRequest = HttpRequest.newBuilder()
                 .POST(HttpRequest.BodyPublishers.noBody())
                 .uri(URI.create("http://localhost:" + DEFAULT_ADMIN_PORT + "/api/config/maintenance?enable=true"))

--- a/carapace-server/src/test/java/org/carapaceproxy/RawClientTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/RawClientTest.java
@@ -320,7 +320,6 @@ public class RawClientTest {
 
             ExecutorService ex = Executors.newFixedThreadPool(2);
             List<Future<?>> futures = new ArrayList<>();
-
             try (HttpProxyServer proxy = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder())) {
                 ConnectionPoolConfiguration defaultConnectionPool = proxy.getCurrentConfiguration().getDefaultConnectionPool();
                 defaultConnectionPool.setMaxConnectionsPerEndpoint(1);
@@ -529,7 +528,6 @@ public class RawClientTest {
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.port());
         ExecutorService ex = Executors.newFixedThreadPool(2);
         List<Future<?>> futures = new ArrayList<>();
-
         try (HttpProxyServer proxy = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir.newFolder())) {
             ConnectionPoolConfiguration defaultConnectionPool = proxy.getCurrentConfiguration().getDefaultConnectionPool();
             defaultConnectionPool.setMaxConnectionsPerEndpoint(1);

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/ConnectionPoolTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/ConnectionPoolTest.java
@@ -69,7 +69,6 @@ public class ConnectionPoolTest extends UseAdminServer {
     public WireMockRule wireMockRule = new WireMockRule(0);
 
     private void configureAndStartServer() throws Exception {
-
         HttpTestUtils.overrideJvmWideHttpsVerifier();
 
         stubFor(get(urlEqualTo("/index.html"))
@@ -85,6 +84,7 @@ public class ConnectionPoolTest extends UseAdminServer {
         config.put("db.server.base.dir", tmpDir.newFolder().getAbsolutePath());
         config.put("aws.accesskey", "accesskey");
         config.put("aws.secretkey", "secretkey");
+        config.put("healthmanager.tolerant", "true");
         startServer(config);
 
         // Default certificate

--- a/carapace-server/src/test/java/org/carapaceproxy/core/Http2HeadersTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/Http2HeadersTest.java
@@ -1,0 +1,91 @@
+package org.carapaceproxy.core;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.Options.DYNAMIC_PORT;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_FORWARDED_STRATEGY;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_KEEP_ALIVE;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_KEEP_ALIVE_COUNT;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_KEEP_ALIVE_IDLE;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_KEEP_ALIVE_INTERVAL;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_MAX_KEEP_ALIVE_REQUESTS;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SO_BACKLOG;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import java.io.IOException;
+import java.util.Set;
+import org.carapaceproxy.server.config.ConfigurationNotValidException;
+import org.carapaceproxy.server.config.NetworkListenerConfiguration;
+import org.carapaceproxy.utils.TestEndpointMapper;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import reactor.netty.http.HttpProtocol;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.client.HttpClientResponse;
+
+public class Http2HeadersTest {
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
+
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
+
+    @Test
+    public void test() throws IOException, ConfigurationNotValidException, InterruptedException {
+        stubFor(get(urlEqualTo("/index.html"))
+                .willReturn(aResponse()
+                        .withStatus(HttpResponseStatus.OK.code())
+                        .withHeader("Content-Type", "text/html")
+                        .withHeader("Content-Length", String.valueOf("it <b>works</b> !!".length()))
+                        .withBody("it <b>works</b> !!"))
+        );
+        final var mapper = new TestEndpointMapper("localhost", wireMockRule.port());
+        try (final var server = new HttpProxyServer(mapper, tmpDir.newFolder())) {
+            server.addListener(new NetworkListenerConfiguration(
+                    "localhost",
+                    DYNAMIC_PORT,
+                    false,
+                    null,
+                    null,
+                    DEFAULT_SSL_PROTOCOLS,
+                    DEFAULT_SO_BACKLOG,
+                    DEFAULT_KEEP_ALIVE,
+                    DEFAULT_KEEP_ALIVE_IDLE,
+                    DEFAULT_KEEP_ALIVE_INTERVAL,
+                    DEFAULT_KEEP_ALIVE_COUNT,
+                    DEFAULT_MAX_KEEP_ALIVE_REQUESTS,
+                    DEFAULT_FORWARDED_STRATEGY,
+                    Set.of(),
+                    Set.of(HttpProtocol.H2C.name(), HttpProtocol.HTTP11.name())
+            ));
+
+            server.start();
+            final var port = server.getLocalPort();
+            final HttpClientResponse response = HttpClient.create()
+                    .protocol(HttpProtocol.H2C, HttpProtocol.HTTP11)
+                    .headers(headers -> headers
+                            .add(HttpHeaderNames.CONNECTION, "keep-alive")
+                            .add(HttpHeaderNames.CONNECTION, "upgrade")
+                            .add(HttpHeaderNames.UPGRADE, "HTTP/2.0")
+                    )
+                    .get()
+                    .uri("http://localhost:" + port + "/index.html")
+                    .response()
+                    .block();
+            assertThat(response, is(notNullValue()));
+            assertThat(response.status(), is(HttpResponseStatus.OK));
+            assertThat(response.version(), is(HttpVersion.HTTP_1_1));
+        }
+    }
+}

--- a/carapace-server/src/test/java/org/carapaceproxy/core/MaxHeaderSizeTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/MaxHeaderSizeTest.java
@@ -1,19 +1,20 @@
 package org.carapaceproxy.core;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.Assert.assertEquals;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import org.carapaceproxy.api.UseAdminServer;
-import org.carapaceproxy.utils.TestUtils;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Properties;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.junit.Assert.assertEquals;
+import org.carapaceproxy.api.UseAdminServer;
+import org.carapaceproxy.utils.TestUtils;
+import org.junit.Rule;
+import org.junit.Test;
 
 public class MaxHeaderSizeTest extends UseAdminServer {
 
@@ -33,6 +34,7 @@ public class MaxHeaderSizeTest extends UseAdminServer {
                         .withBody("it <b>works</b> !!")));
 
         config = new Properties(HTTP_ADMIN_SERVER_CONFIG);
+        config.put("healthmanager.tolerant", "true");
         startServer(config);
 
         // Default certificate
@@ -70,7 +72,6 @@ public class MaxHeaderSizeTest extends UseAdminServer {
         config.put("route.100.action", "proxy-all");
 
         changeDynamicConfiguration(config);
-
 
         HttpClient httpClient = HttpClient.newBuilder()
                 .version(HttpClient.Version.HTTP_1_1)

--- a/carapace-server/src/test/java/org/carapaceproxy/listeners/ListenerConfigurationTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/listeners/ListenerConfigurationTest.java
@@ -10,6 +10,7 @@ import org.carapaceproxy.core.EndpointKey;
 import org.carapaceproxy.core.HttpProxyServer;
 import org.carapaceproxy.core.Listeners;
 import org.carapaceproxy.server.config.ConfigurationChangeInProgressException;
+import org.carapaceproxy.server.mapper.StandardEndpointMapper;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -21,7 +22,7 @@ public class ListenerConfigurationTest {
 
     @Test
     public void testListenerKeepAliveConfiguration() throws Exception {
-        try (HttpProxyServer server = new HttpProxyServer(null, tmpDir.newFolder());) {
+        try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, tmpDir.newFolder())) {
 
             {
                 Properties configuration = new Properties();

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesTest.java
@@ -123,6 +123,7 @@ public class CertificatesTest extends UseAdminServer {
         config.put("db.server.base.dir", tmpDir.newFolder().getAbsolutePath());
         config.put("aws.accesskey", "accesskey");
         config.put("aws.secretkey", "secretkey");
+        config.put("healthmanager.tolerant", "true");
         startServer(config);
 
         // Default certificate

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/TestEndpointMapper.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/TestEndpointMapper.java
@@ -19,13 +19,16 @@
  */
 package org.carapaceproxy.utils;
 
+import static org.carapaceproxy.core.RuntimeServerConfiguration.DEFAULT_WARMUP_PERIOD;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SequencedMap;
 import org.carapaceproxy.configstore.ConfigurationStore;
+import org.carapaceproxy.core.HttpProxyServer;
 import org.carapaceproxy.core.ProxyRequest;
+import org.carapaceproxy.server.backends.BackendHealthStatus;
 import org.carapaceproxy.server.config.ActionConfiguration;
 import org.carapaceproxy.server.config.BackendConfiguration;
 import org.carapaceproxy.server.config.DirectorConfiguration;
@@ -34,7 +37,7 @@ import org.carapaceproxy.server.mapper.CustomHeader;
 import org.carapaceproxy.server.mapper.EndpointMapper;
 import org.carapaceproxy.server.mapper.MapResult;
 
-public class TestEndpointMapper extends EndpointMapper {
+public class TestEndpointMapper extends EndpointMapper implements EndpointMapper.Factory {
 
     private final String host;
     private final int port;
@@ -42,7 +45,7 @@ public class TestEndpointMapper extends EndpointMapper {
     private final SequencedMap<String, BackendConfiguration> backends;
     private final List<RouteConfiguration> routes = new ArrayList<>();
     private final List<ActionConfiguration> actions = new ArrayList<>();
-    private final List<DirectorConfiguration> directors = new ArrayList<>();
+    private final SequencedMap<String, DirectorConfiguration> directors;
     private final List<CustomHeader> headers = new ArrayList<>();
 
     public TestEndpointMapper(String host, int port) {
@@ -50,14 +53,20 @@ public class TestEndpointMapper extends EndpointMapper {
     }
 
     public TestEndpointMapper(String host, int port, boolean cacheAll) {
-        this(host, port, cacheAll, Map.of(host, new BackendConfiguration(host, host, port, "/index.html")));
+        this(host, port, cacheAll, Map.of(host, new BackendConfiguration(host, host, port, "/index.html", -1)));
     }
 
     public TestEndpointMapper(String host, int port, boolean cacheAll, Map<String, BackendConfiguration> backends) {
+        super(null);
         this.host = host;
         this.port = port;
         this.cacheAll = cacheAll;
         this.backends = new LinkedHashMap<>(backends);
+        this.directors = new LinkedHashMap<>();
+    }
+
+    public TestEndpointMapper(final HttpProxyServer ignoredServer) {
+        this("localhost", 0); // required for reflective construction
     }
 
     @Override
@@ -65,26 +74,30 @@ public class TestEndpointMapper extends EndpointMapper {
         String uri = request.getUri();
         if (uri.contains("not-found")) {
             return MapResult.notFound(MapResult.NO_ROUTE);
-        } else if (uri.contains("debug")) {
+        }
+        if (uri.contains("debug")) {
             return MapResult.builder()
                     .action(MapResult.Action.SYSTEM)
                     .routeId(MapResult.NO_ROUTE)
                     .build();
-        } else if (cacheAll) {
+        }
+        final BackendHealthStatus healthStatus = new BackendHealthStatus(request.getListener(), DEFAULT_WARMUP_PERIOD);
+        if (cacheAll) {
             return MapResult.builder()
                     .host(host)
                     .port(port)
                     .action(MapResult.Action.CACHE)
                     .routeId(MapResult.NO_ROUTE)
-                    .build();
-        } else {
-            return MapResult.builder()
-                    .host(host)
-                    .port(port)
-                    .action(MapResult.Action.PROXY)
-                    .routeId(MapResult.NO_ROUTE)
+                    .healthStatus(healthStatus)
                     .build();
         }
+        return MapResult.builder()
+                .host(host)
+                .port(port)
+                .action(MapResult.Action.PROXY)
+                .routeId(MapResult.NO_ROUTE)
+                .healthStatus(healthStatus)
+                .build();
     }
 
     @Override
@@ -103,7 +116,7 @@ public class TestEndpointMapper extends EndpointMapper {
     }
 
     @Override
-    public List<DirectorConfiguration> getDirectors() {
+    public SequencedMap<String, DirectorConfiguration> getDirectors() {
         return directors;
     }
 
@@ -114,5 +127,10 @@ public class TestEndpointMapper extends EndpointMapper {
 
     @Override
     public void configure(ConfigurationStore properties) {
+    }
+
+    @Override
+    public EndpointMapper build(final HttpProxyServer httpProxyServer) {
+        return this;
     }
 }


### PR DESCRIPTION
* always drop `HTTP2-Settings` header
* drop `Connection` and `Upgrade` header only if the upgrade is to HTTP/2