### PR TITLE
build: upgrade Reactor BOM to 2023.0.12

### DIFF
--- a/carapace-server/src/test/java/org/carapaceproxy/core/Http2HeadersTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/Http2HeadersTest.java
@@ -51,6 +51,7 @@ public class Http2HeadersTest {
                         .withBody("it <b>works</b> !!"))
         );
         final var mapper = new TestEndpointMapper("localhost", wireMockRule.port());
+        final HttpClientResponse response;
         try (final var server = new HttpProxyServer(mapper, tmpDir.newFolder())) {
             server.addListener(new NetworkListenerConfiguration(
                     "localhost",
@@ -72,7 +73,7 @@ public class Http2HeadersTest {
 
             server.start();
             final var port = server.getLocalPort();
-            final HttpClientResponse response = HttpClient.create()
+            response = HttpClient.create()
                     .protocol(HttpProtocol.H2C, HttpProtocol.HTTP11)
                     .headers(headers -> headers
                             .add(HttpHeaderNames.CONNECTION, "keep-alive")
@@ -83,9 +84,9 @@ public class Http2HeadersTest {
                     .uri("http://localhost:" + port + "/index.html")
                     .response()
                     .block();
-            assertThat(response, is(notNullValue()));
-            assertThat(response.status(), is(HttpResponseStatus.OK));
-            assertThat(response.version(), is(HttpVersion.HTTP_1_1));
         }
+        assertThat(response, is(notNullValue()));
+        assertThat(response.status(), is(HttpResponseStatus.OK));
+        assertThat(response.version(), is(HttpVersion.valueOf("HTTP/2.0")));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <maven.compiler.release>${toolchain.java.version}</maven.compiler.release>
         <javacc-maven-plugin.version>2.4</javacc-maven-plugin.version>
 
-        <libs.projectreactor>2023.0.11</libs.projectreactor>
+        <libs.projectreactor>2023.0.12</libs.projectreactor>
         <libs.netty>4.1.114.Final</libs.netty>
         <libs.acme4j>3.4.0</libs.acme4j>
         <libs.bouncycastle>1.78.1</libs.bouncycastle>


### PR DESCRIPTION
Upgrade Reactor Netty to 1.1.24; needed for #410 

* see reactor/reactor-netty#3473
* see reactor/reactor-netty#3475
