### PR TITLE
Fix regression after switching from JUL to Logback

### DIFF
--- a/carapace-server/src/main/assemble/zip-assembly.xml
+++ b/carapace-server/src/main/assemble/zip-assembly.xml
@@ -8,6 +8,13 @@
     <includeBaseDirectory>true</includeBaseDirectory>
     <fileSets>
         <fileSet>
+            <directory>src/main/resources</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>logback.xml</include>
+            </includes>
+        </fileSet>
+        <fileSet>
             <directory>src/main/resources/conf</directory>
             <outputDirectory>conf</outputDirectory>
             <includes>
@@ -30,7 +37,6 @@
                 <include>*</include>
             </includes>
         </fileSet>
-
     </fileSets>
     <dependencySets>
         <dependencySet>

--- a/carapace-server/src/main/java/org/carapaceproxy/launcher/ServerMain.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/launcher/ServerMain.java
@@ -131,6 +131,7 @@ public class ServerMain implements AutoCloseable {
             runningInstance.join();
 
         } catch (Exception t) {
+            LOG.error("Error while starting server", t);
             System.exit(1);
         }
     }

--- a/carapace-server/src/main/resources/bin/setenv.sh
+++ b/carapace-server/src/main/resources/bin/setenv.sh
@@ -2,7 +2,7 @@
 
 #JAVA_HOME=
 JDK_JAVA_OPTIONS="--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.logging/java.util.logging=ALL-UNNAMED"
-JAVA_OPTS="-XX:+UseG1GC -Duser.language=en -Xmx4g -Xms4g -Djava.net.preferIPv4Stack=true -XX:MaxDirectMemorySize=4g  -Djava.util.logging.config.file=conf/logging.properties"
+JAVA_OPTS="-XX:+UseG1GC -Duser.language=en -Xmx4g -Xms4g -Djava.net.preferIPv4Stack=true -XX:MaxDirectMemorySize=4g"
 
 if [ -z "$JAVA_HOME" ]; then
   JAVA_PATH=`which java 2>/dev/null`

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-
-
 # Licensed to Diennea S.r.l. under one
 # or more contributor license agreements. See the NOTICE file
 # distributed with this work for additional information
@@ -19,12 +17,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
+for service in carapace-server/target/carapace-server-*/bin/service;
+do
+    if [ -f "$service" ]; then
+        # stop if running
+        $service server stop
+    fi
+done
 
 # Carapace version
 CARAPACE_V=$(mvn org.apache.maven.plugins:maven-help-plugin:3.1.1:evaluate -Dexpression=project.version -q -DforceStdout -Dmaven.wagon.http.ssl.insecure=true)
-
-# stop if running
-carapace-server/target/carapace-server-${CARAPACE_V}/bin/service server stop
 
 mvn clean install -DskipTests -Pproduction
 cd carapace-server/target || exit
@@ -38,4 +40,3 @@ timeout 22 sh -c "until nc -z \$0 \$1; do sleep 1; done" localhost 8001
 curl -X POST --data-binary @conf/server.dynamic.properties http://localhost:8001/api/config/apply --user admin:admin -H "Content-Type: text/plain"
 
 tail -f server.service.log
-


### PR DESCRIPTION
`run.sh` could not start server anymore:

```
2025-01-22 18:03:49 [main] ERROR o.carapaceproxy.launcher.ServerMain - Error while starting server
java.io.FileNotFoundException: conf/logging.properties (No such file or directory)
        at java.base/java.io.FileInputStream.open0(Native Method)
        at java.base/java.io.FileInputStream.open(FileInputStream.java:213)
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:152)
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:106)
        at java.logging/java.util.logging.LogManager.readConfiguration(LogManager.java:1383)
        at org.carapaceproxy.launcher.ServerMain.main(ServerMain.java:109)
```

Also, it showed an undesired warning if the service is not there for some reason, i.e. after a fresh clone, or a clean, or a version bump:

```bash
❯ ./run.sh                                   
./run.sh: line 27: carapace-server/target/carapace-server-2.3.0-SNAPSHOT/bin/service: No such file or directory
```

Closes #523 #524