### PR TITLE
Upgrade Netty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,23 +134,6 @@
         <libs.asm>9.4</libs.asm>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>apache-snapshots</id>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <url>https://repository.apache.org/snapshots/</url>
-        </repository>
-        <repository>
-            <id>dev.majordodo.org.snapshots</id>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <url>https://dev.majordodo.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <!-- BOMs -->

--- a/pom.xml
+++ b/pom.xml
@@ -91,8 +91,8 @@
         <maven.compiler.release>${toolchain.java.version}</maven.compiler.release>
         <javacc-maven-plugin.version>2.4</javacc-maven-plugin.version>
 
-        <libs.projectreactor>2024.0.3</libs.projectreactor>
-        <libs.netty>4.1.118.Final</libs.netty>
+        <libs.projectreactor>2024.0.6</libs.projectreactor>
+        <libs.netty>4.1.121.Final</libs.netty>
         <libs.acme4j>3.4.0</libs.acme4j>
         <libs.bouncycastle>1.78.1</libs.bouncycastle>
         <libs.awssdk>2.17.113</libs.awssdk>
@@ -112,7 +112,7 @@
         <libs.commons.io>2.14.0</libs.commons.io>
         <libs.commons.net>3.11.0</libs.commons.net>
 
-        <libs.jetty>9.4.52.v20230823</libs.jetty>
+        <libs.jetty>9.4.57.v20241219</libs.jetty>
         <libs.jersey>2.35</libs.jersey>
         <libs.jackson>2.14.3</libs.jackson>
         <libs.javassist>3.27.0-GA</libs.javassist>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <url>git@github.com:diennea/carapaceproxy.git</url>
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
-        <tag>release/2.1</tag>
+        <tag>release/2.2</tag>
     </scm>
 
     <distributionManagement>
@@ -91,8 +91,8 @@
         <maven.compiler.release>${toolchain.java.version}</maven.compiler.release>
         <javacc-maven-plugin.version>2.4</javacc-maven-plugin.version>
 
-        <libs.projectreactor>2024.0.2</libs.projectreactor>
-        <libs.netty>4.1.117.Final</libs.netty>
+        <libs.projectreactor>2024.0.3</libs.projectreactor>
+        <libs.netty>4.1.118.Final</libs.netty>
         <libs.acme4j>3.4.0</libs.acme4j>
         <libs.bouncycastle>1.78.1</libs.bouncycastle>
         <libs.awssdk>2.17.113</libs.awssdk>
@@ -352,6 +352,7 @@
                             --add-opens java.base/java.lang=ALL-UNNAMED
                             --add-opens java.base/java.util=ALL-UNNAMED
                             --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+                            --add-opens java.logging/java.util.logging=ALL-UNNAMED
                             --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED
                             --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
                         </argLine>


### PR DESCRIPTION
Following the wave of #538 and #539, I'm upgrading Netty, Reactor Netty and Eclipse Jetty also on `master`, as @hamadodene requested.

Differently from what was done on hotfix releases on `release/2.0` and `release/2.1`, I'm bumping it straight to latest version.

I also dropped a couple of Maven repositories hoping to speed up a painfully slow release process