### PR TITLE
530 carapace http client is unable to forward requests in secure mode

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.carapaceproxy</groupId>
         <artifactId>carapace-parent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.carapaceproxy</groupId>
         <artifactId>carapace-parent</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/carapace-server/src/main/java/org/carapaceproxy/server/config/BackendConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/config/BackendConfiguration.java
@@ -25,12 +25,60 @@ import org.carapaceproxy.server.backends.BackendHealthStatus.Status;
 /**
  * Configuration of a single backend server.
  *
- * @param id           an arbitrary ID of the backend
- * @param hostPort     the host:port tuple for the backend
- * @param probePath    a path to use to probe the backend for reachability
- * @param safeCapacity a capacity that is considered safe even when {@link Status#COLD cold}
+ * @param id                   an arbitrary ID of the backend
+ * @param hostPort             the host:port tuple for the backend
+ * @param probePath            a path to use to probe the backend for reachability
+ * @param safeCapacity         a capacity that is considered safe even when {@link Status#COLD cold}
+ * @param ssl                  whether to use SSL when connecting to this backend
+ * @param caCertificatePath    path to a CA certificate to trust when connecting to this backend (optional)
+ * @param caCertificatePassword password for the CA certificate (optional)
  */
-public record BackendConfiguration(String id, EndpointKey hostPort, String probePath, int safeCapacity) {
+public record BackendConfiguration(String id, EndpointKey hostPort, String probePath, int safeCapacity, boolean ssl, String caCertificatePath, String caCertificatePassword) {
+
+    /**
+     * Configuration of a single backend server.
+     *
+     * @param id                   an arbitrary ID of the backend
+     * @param host                 the host name
+     * @param port                 the port to use
+     * @param probePath            a path to use to probe the backend for reachability
+     * @param safeCapacity         a capacity that is considered safe even when {@link Status#COLD cold}, or 0 for an infinite capacity
+     * @param ssl                  whether to use SSL when connecting to this backend
+     * @param caCertificatePath    path to a CA certificate to trust when connecting to this backend (optional)
+     * @param caCertificatePassword password for the CA certificate (optional)
+     */
+    public BackendConfiguration(final String id, final String host, final int port, final String probePath, final int safeCapacity, final boolean ssl, final String caCertificatePath, final String caCertificatePassword) {
+        this(id, new EndpointKey(host, port), probePath, safeCapacity, ssl, caCertificatePath, caCertificatePassword);
+    }
+
+    /**
+     * Configuration of a single backend server.
+     *
+     * @param id                   an arbitrary ID of the backend
+     * @param host                 the host name
+     * @param port                 the port to use
+     * @param probePath            a path to use to probe the backend for reachability
+     * @param safeCapacity         a capacity that is considered safe even when {@link Status#COLD cold}, or 0 for an infinite capacity
+     * @param ssl                  whether to use SSL when connecting to this backend
+     * @param caCertificatePath    path to a CA certificate to trust when connecting to this backend (optional)
+     */
+    public BackendConfiguration(final String id, final String host, final int port, final String probePath, final int safeCapacity, final boolean ssl, final String caCertificatePath) {
+        this(id, host, port, probePath, safeCapacity, ssl, caCertificatePath, null);
+    }
+
+    /**
+     * Configuration of a single backend server.
+     *
+     * @param id           an arbitrary ID of the backend
+     * @param host         the host name
+     * @param port         the port to use
+     * @param probePath    a path to use to probe the backend for reachability
+     * @param safeCapacity a capacity that is considered safe even when {@link Status#COLD cold}, or 0 for an infinite capacity
+     * @param ssl          whether to use SSL when connecting to this backend
+     */
+    public BackendConfiguration(final String id, final String host, final int port, final String probePath, final int safeCapacity, final boolean ssl) {
+        this(id, host, port, probePath, safeCapacity, ssl, null);
+    }
 
     /**
      * Configuration of a single backend server.
@@ -42,7 +90,7 @@ public record BackendConfiguration(String id, EndpointKey hostPort, String probe
      * @param safeCapacity a capacity that is considered safe even when {@link Status#COLD cold}, or 0 for an infinite capacity
      */
     public BackendConfiguration(final String id, final String host, final int port, final String probePath, final int safeCapacity) {
-        this(id, new EndpointKey(host, port), probePath, safeCapacity);
+        this(id, host, port, probePath, safeCapacity, false, null, null);
     }
 
     public String host() {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/MapResult.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/MapResult.java
@@ -93,6 +93,7 @@ public class MapResult {
     private String redirectLocation;
     private String redirectProto;
     private String redirectPath;
+    private boolean ssl;
 
     @Setter(AccessLevel.NONE)
     @EqualsAndHashCode.Exclude

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -255,6 +255,7 @@ public class StandardEndpointMapper extends EndpointMapper {
                                     .routeId(route.getId())
                                     .customHeaders(customHeaders)
                                     .healthStatus(backendStatus)
+                                    .ssl(backend.ssl())
                                     .build();
                         }
                     }
@@ -481,9 +482,13 @@ public class StandardEndpointMapper extends EndpointMapper {
                 final int port = properties.getInt(prefix + "port", 8086);
                 final String probePath = properties.getString(prefix + "probePath", "");
                 final int safeCapacity = properties.getInt(prefix + "safeCapacity", DEFAULT_CAPACITY);
-                LOG.info("configured backend {} {}:{} enabled={} capacity={}", id, host, port, enabled, safeCapacity);
+                final boolean ssl = properties.getBoolean(prefix + "ssl", false);
+                final String caCertificatePath = properties.getString(prefix + "cacertificate", null);
+                final String caCertificatePassword = properties.getString(prefix + "cacertificatepassword", null);
+                LOG.info("configured backend {} {}:{} enabled={} capacity={} ssl={} caCertificate={} caCertificatePassword={}",
+                         id, host, port, enabled, safeCapacity, ssl, caCertificatePath, caCertificatePassword != null ? "******" : null);
                 if (enabled) {
-                    addBackend(new BackendConfiguration(id, host, port, probePath, safeCapacity));
+                    addBackend(new BackendConfiguration(id, host, port, probePath, safeCapacity, ssl, caCertificatePath, caCertificatePassword));
                 }
             }
         }

--- a/carapace-server/src/main/resources/conf/server.dynamic.properties
+++ b/carapace-server/src/main/resources/conf/server.dynamic.properties
@@ -33,6 +33,22 @@ backend.1.port=8086
 backend.1.enabled=true
 # Setting a blank probePath will disable the probe check (status result will be mocked to always true)
 backend.1.probePath=/tomcatstatus/up
+# SSL configuration for backend
+# backend.1.ssl=false
+# Path to a CA certificate to trust when connecting to this backend (optional)
+# backend.1.cacertificate=conf/ca.p12
+# Password for the CA certificate (optional)
+# backend.1.cacertificatepassword=changeit
+
+# Example of an HTTPS backend configuration
+# backend.2.id=secure-backend
+# backend.2.host=secure.example.com
+# backend.2.port=8443
+# backend.2.enabled=true
+# backend.2.probePath=/health
+# backend.2.ssl=true
+# backend.2.cacertificate=conf/example-ca.p12
+# backend.2.cacertificatepassword=changeit
 
 # default director
 director.1.id=*

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/SSLBackendTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/SSLBackendTest.java
@@ -1,0 +1,155 @@
+package org.carapaceproxy.backends;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_FORWARDED_STRATEGY;
+import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
+import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.STATIC;
+import static org.junit.Assert.assertEquals;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.util.concurrent.DefaultEventExecutor;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.io.IOUtils;
+import org.carapaceproxy.core.HttpProxyServer;
+import org.carapaceproxy.core.ProxyRequest;
+import org.carapaceproxy.server.backends.BackendHealthStatus;
+import org.carapaceproxy.server.config.BackendConfiguration;
+import org.carapaceproxy.server.config.NetworkListenerConfiguration;
+import org.carapaceproxy.server.config.SSLCertificateConfiguration;
+import org.carapaceproxy.server.mapper.EndpointMapper;
+import org.carapaceproxy.server.mapper.MapResult;
+import org.carapaceproxy.utils.HttpTestUtils;
+import org.carapaceproxy.utils.TestEndpointMapper;
+import org.carapaceproxy.utils.TestUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import reactor.netty.http.HttpProtocol;
+
+@RunWith(Parameterized.class)
+public class SSLBackendTest {
+
+    private final boolean clientUsesHttps;
+    private final boolean backendUsesHttps;
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
+    private WireMockRule backend;
+
+    public SSLBackendTest(boolean clientUsesHttps, boolean backendUsesHttps) {
+        this.clientUsesHttps = clientUsesHttps;
+        this.backendUsesHttps = backendUsesHttps;
+    }
+
+    @Parameters(name = "Client HTTPS: {0}, Backend HTTPS: {1}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {false, false}, // HTTP client to HTTP backend
+                {false, true},  // HTTP client to HTTPS backend
+                {true, false},  // HTTPS client to HTTP backend
+                {true, true}    // HTTPS client to HTTPS backend
+        });
+    }
+
+    @Test
+    public void testHttpAndHttpsBackends() throws Exception {
+        // This is still needed for the client-side HTTPS connection to Carapace
+        HttpTestUtils.overrideJvmWideHttpsVerifier();
+
+        // Set up certificate for Carapace HTTPS listener
+        String certificate = TestUtils.deployResource("ia.p12", tmpDir.getRoot());
+
+        // Set up CA certificate for HTTPS backend
+        String caCertificate = TestUtils.deployResource("ca.p12", tmpDir.getRoot());
+
+        backend = new WireMockRule(options()
+                .dynamicPort()
+                .dynamicHttpsPort()
+                .keystorePath(caCertificate)
+                .keystoreType("PKCS12")
+                .keystorePassword("changeit")
+                .keyManagerPassword("changeit"));
+        backend.start();
+
+        try {
+            final int httpPort = TestUtils.getFreePort();
+            final int httpsPort = TestUtils.getFreePort();
+
+            final String path = "/test";
+            final String expectedResponse = "Response from backend";
+
+            backend.stubFor(get(urlEqualTo(path))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "text/plain")
+                            .withBody(expectedResponse)));
+
+            final EndpointMapper.Factory mapperFactory = parent -> {
+                final int backendPort = backendUsesHttps ? backend.httpsPort() : backend.port();
+
+                final BackendConfiguration backendConfig = backendUsesHttps
+                        ? new BackendConfiguration("test-backend", "localhost", backendPort, path, 1000, true, caCertificate, "changeit")
+                        : new BackendConfiguration("test-backend", "localhost", backendPort, path, 1000, false);
+
+                return new TestEndpointMapper("localhost", backendPort, false, Map.of("test-backend", backendConfig)) {
+                    @Override
+                    public MapResult map(final ProxyRequest request) {
+                        // Always return STABLE to bypass capacity check
+                        final BackendHealthStatus healthStatus = new BackendHealthStatus(request.getListener(), 0) {
+                            @Override
+                            public Status getStatus() {
+                                return Status.STABLE;
+                            }
+                        };
+
+                        return MapResult.builder()
+                                .host("localhost")
+                                .port(backendPort)
+                                .action(MapResult.Action.PROXY)
+                                .routeId("test-route")
+                                .healthStatus(healthStatus)
+                                .ssl(backendUsesHttps)
+                                .build();
+                    }
+                };
+            };
+
+            try (final HttpProxyServer server = new HttpProxyServer(mapperFactory, tmpDir.getRoot())) {
+                server.addCertificate(new SSLCertificateConfiguration("localhost", null, certificate, "changeit", STATIC));
+
+                server.addListener(new NetworkListenerConfiguration(
+                        "localhost", httpPort, false, null, null,
+                        DEFAULT_SSL_PROTOCOLS, 128, true, 300, 60, 8, 1000,
+                        DEFAULT_FORWARDED_STRATEGY, Set.of(), Set.of(HttpProtocol.HTTP11),
+                        new DefaultChannelGroup(new DefaultEventExecutor())));
+
+                server.addListener(new NetworkListenerConfiguration(
+                        "localhost", httpsPort, true, null, "localhost",
+                        DEFAULT_SSL_PROTOCOLS, 128, true, 300, 60, 8, 1000,
+                        DEFAULT_FORWARDED_STRATEGY, Set.of(), Set.of(HttpProtocol.HTTP11),
+                        new DefaultChannelGroup(new DefaultEventExecutor())));
+
+                server.start();
+
+                final int port = clientUsesHttps ? httpsPort : httpPort;
+                final String protocol = clientUsesHttps ? "https" : "http";
+                final String url = protocol + "://localhost:" + port + path;
+
+                final String response = IOUtils.toString(URI.create(url), StandardCharsets.UTF_8);
+                assertEquals(expectedResponse, response);
+            }
+        } finally {
+            backend.stop();
+        }
+    }
+}

--- a/carapace-ui/pom.xml
+++ b/carapace-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.carapaceproxy</groupId>
         <artifactId>carapace-parent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/carapace-ui/pom.xml
+++ b/carapace-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.carapaceproxy</groupId>
         <artifactId>carapace-parent</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.carapaceproxy</groupId>
     <artifactId>carapace-parent</artifactId>
-    <version>2.2.0</version>
+    <version>2.3.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Carapace :: Parent</name>
@@ -74,7 +74,7 @@
         <url>git@github.com:diennea/carapaceproxy.git</url>
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
-        <tag>v2.2.0</tag>
+        <tag>release/2.2</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.carapaceproxy</groupId>
     <artifactId>carapace-parent</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.2.0</version>
     <packaging>pom</packaging>
 
     <name>Carapace :: Parent</name>
@@ -74,7 +74,7 @@
         <url>git@github.com:diennea/carapaceproxy.git</url>
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
-        <tag>release/2.2</tag>
+        <tag>v2.2.0</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
## Purpose

This PR introduces support for forwarding HTTP requests to backend servers in secure (SSL/TLS) mode in Carapace Proxy. The changes allow the proxy to connect to HTTPS backends, with custom CA certificate support, improving flexibility and security for enterprise deployments.

## New Features

- **Backend SSL Support:** 
  -  `backend.<n>.ssl=true`: configure backend servers to use SSL/TLS for secure connections.
- **Custom Certificate Authority (CA) Support:** (optional)
  - `backend.<n>.cacertificate`: specify custom CA certificates for backend SSL validation.
  - `backend.<n>.cacertificatepassword`: support for CA certificate password in configuration.

## Why

Previously, Carapace Proxy was unable to forward requests to backend servers using secure (HTTPS) connections. This limitation caused failures when attempting to proxy to Tomcat or other backends configured with SSL, resulting in errors such as “Bad Request – This combination of host and port requires TLS.” This PR resolves the issue by enabling secure forwarding, ensuring that Carapace Proxy can properly connect to HTTPS backends as required for modern web application architectures.

You can include the following sample configuration in your PR body to show how to enable secure (SSL/TLS) backend forwarding in Carapace Proxy:

## How to Enable Secure Backend Forwarding

To enable SSL/TLS for a backend server, add these properties to your `server.dynamic.properties` configuration file:

```properties
backend.1.host=your-backend-host
backend.1.port=443
backend.1.ssl=true
# Optional: specify a custom CA certificate for backend validation
backend.1.cacertificate=/path/to/your/ca-certificate.p12
backend.1.cacertificatepassword=yourpassword
```