### PR TITLE
build: revert undesired version bump

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.carapaceproxy</groupId>
         <artifactId>carapace-parent</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/carapace-ui/pom.xml
+++ b/carapace-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.carapaceproxy</groupId>
         <artifactId>carapace-parent</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.carapaceproxy</groupId>
     <artifactId>carapace-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Carapace :: Parent</name>


### PR DESCRIPTION
This pull request reverts a previous commit that accidentally bumped the project version without any changes to the codebase. The change includes reverting the version bump and ensuring that the build process remains unaffected.

see diennea/carapaceproxy#546