### PR TITLE
Prevent unnecessary listener restarts on configuration save

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
@@ -117,7 +117,7 @@ public class Listeners {
         }
         // Clear cached ssl contexts
         sslContexts.clear();
-        final boolean certificatesChanged = newConfiguration.getCertificates().equals(currentConfiguration.getCertificates());
+        final boolean certificatesChanged = !newConfiguration.getCertificates().equals(currentConfiguration.getCertificates());
 
         // stop dropped listeners, start new one
         final List<EndpointKey> listenersToStop = new ArrayList<>();


### PR DESCRIPTION
When saving configuration from the Admin interface, listeners were being restarted even when no actual changes were made. This caused:
- Port binding failures with `reactor.netty.ChannelBindException: Failed to bind on [0.0.0.0:4089]`
- Service interruptions during routine configuration saves
- Unnecessary downtime for proxy services

The `certificatesChanged` variable in `Listeners.java` line 120 had inverted logic;
this caused listeners to restart when certificates **hadn't changed**, which is the opposite of the intended behavior.

- Listeners now only restart when certificates **actually change**
- Eliminates unnecessary restarts during routine configuration saves
- Reduces port binding conflicts and service interruptions
- Maintains proper certificate reload functionality for when changes do occur