### PR TITLE
Ignore Eclipse-specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,71 @@
-# Created by https://www.toptal.com/developers/gitignore/api/git,java,linux,macos,maven,windows,netbeans,intellij+all
-# Edit at https://www.toptal.com/developers/gitignore?templates=git,java,linux,macos,maven,windows,netbeans,intellij+all
+# Created by https://www.toptal.com/developers/gitignore/api/git,java,linux,macos,maven,windows,netbeans,intellij+all,eclipse
+# Edit at https://www.toptal.com/developers/gitignore?templates=git,java,linux,macos,maven,windows,netbeans,intellij+all,eclipse
+
+### Eclipse ###
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+.apt_generated_test/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+# Uncomment this line if you wish to ignore the project description file.
+# Typically, this file would be tracked if it contains build/dependency configurations:
+.project
+
+### Eclipse Patch ###
+# Spring Boot Tooling
+.sts4-cache/
 
 ### Git ###
 # Created by git for backups. To disable backups in Git:
@@ -233,4 +299,4 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-# End of https://www.toptal.com/developers/gitignore/api/git,java,linux,macos,maven,windows,netbeans,intellij+all
+# End of https://www.toptal.com/developers/gitignore/api/git,java,linux,macos,maven,windows,netbeans,intellij+all,eclipse


### PR DESCRIPTION
Update `.gitignore` not to track Eclipse-specific files.

This especially useful to ignore files spawned automatically by LSP servers that use [Eclipse JDT Language Server](https://github.com/eclipse-jdtls/eclipse.jdt.ls); for example, [OpenCode built-in LSP](https://opencode.ai/docs/lsp/) and [Visual Studio Code](https://code.visualstudio.com/docs/languages/java) [Language Support for Java by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.java) both use `jdtls` under the hood.