### PR TITLE
feat: implement hop-by-hop header stripping for compliance with HTTP standards

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -150,6 +150,10 @@ public class ProxyRequestsManager implements AutoCloseable {
         headers.remove(HttpHeaderNames.IF_RANGE);
         headers.remove(HttpHeaderNames.IF_UNMODIFIED_SINCE);
         headers.remove(HttpHeaderNames.ETAG);
+        // Connection is a hop-by-hop header and must not influence cache validation (RFC 7234 §4.3.4).
+        // Only Connection is removed here (on the live headers object); full hop-by-hop stripping is
+        // performed later in forward() on a copy of the headers, so that getClientProtocols() can still
+        // read Transfer-Encoding via mayHaveBody() before the copy is made.
         headers.remove(HttpHeaderNames.CONNECTION);
     }
 
@@ -461,23 +465,11 @@ public class ProxyRequestsManager implements AutoCloseable {
         return forwarder.request(request.getMethod())
                 .uri(request.getUri())
                 .send((req, out) -> {
-                    // we don't want to upgrade to HTTP/2 if Carapace supports it, but the backend doesn't
                     final HttpHeaders copy = request.getRequestHeaders().copy();
-                    if (copy.contains(HttpHeaderNames.UPGRADE)) {
-                        final List<String> upgrade = copy.getAll(HttpHeaderNames.UPGRADE);
-                        if (upgrade.contains("HTTP/2")) {
-                            // we drop connection and upgrade only if the target upgrade is HTTP/2.0;
-                            // else, we want to preserve upgrades to HTTPS or similar
-                            final List<String> connection = copy.getAll(HttpHeaderNames.CONNECTION);
-                            connection.removeIf("upgrade"::equalsIgnoreCase);
-                            copy.remove(HttpHeaderNames.CONNECTION);
-                            copy.add(HttpHeaderNames.CONNECTION, connection);
-
-                            upgrade.remove("HTTP/2");
-                            copy.remove(HttpHeaderNames.UPGRADE);
-                            copy.add(HttpHeaderNames.UPGRADE, upgrade);
-                        }
-                    }
+                    // Strip hop-by-hop headers before forwarding to the backend (RFC 2616 §13.5.1, RFC 7230 §6.1).
+                    // This also ensures compliance with HTTP/2 which prohibits connection-specific headers (RFC 9113 §8.2.2).
+                    HttpUtils.stripHopByHopHeaders(copy);
+                    // HTTP2-Settings is connection-specific and must not be forwarded (RFC 7540 §3.2)
                     copy.remove(Http2CodecUtil.HTTP_UPGRADE_SETTINGS_HEADER);
                     req.headers(copy);
                     // netty overrides the value, we need to force it
@@ -498,7 +490,9 @@ public class ProxyRequestsManager implements AutoCloseable {
                     }
 
                     request.setResponseStatus(resp.status());
-                    request.setResponseHeaders(resp.responseHeaders().copy()); // headers from endpoint to client
+                    final HttpHeaders responseHeaders = resp.responseHeaders().copy();
+                    HttpUtils.stripHopByHopHeaders(responseHeaders);
+                    request.setResponseHeaders(responseHeaders);
                     if (cacheable.get() && parent.getCache().isCacheable(resp) && Objects.requireNonNull(cacheReceiver).receivedFromRemote(resp)) {
                         addCachedResponseHeaders(request);
                     } else {

--- a/carapace-server/src/main/java/org/carapaceproxy/utils/HttpUtils.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/utils/HttpUtils.java
@@ -27,6 +27,7 @@ import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpVersion;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Set;
 import reactor.netty.http.HttpProtocol;
 
 /**
@@ -41,6 +42,54 @@ import reactor.netty.http.HttpProtocol;
 public class HttpUtils {
 
     private static final ZoneId GMT = ZoneId.of("GMT");
+
+    /**
+     * Standard hop-by-hop headers that must not be forwarded by a reverse proxy,
+     * as defined by RFC 2616 §13.5.1 and RFC 7230 §6.1.
+     * The {@code Proxy-Connection} header is a non-standard but widely-used extension that is also treated as hop-by-hop.
+     *
+     * <p>Note: {@code Transfer-Encoding} is intentionally excluded from this set. It is connection-specific
+     * between adjacent peers, but Reactor Netty's HTTP/2 codec already enforces its removal at the wire
+     * level (RFC 9113 §8.2.2). Stripping it here would break HTTP/1.1 chunked proxying by removing the
+     * framing signal that clients need to reassemble the response body.
+     */
+    @SuppressWarnings("deprecation")
+    private static final Set<CharSequence> HOP_BY_HOP_HEADERS = Set.of(
+            HttpHeaderNames.CONNECTION,
+            HttpHeaderNames.KEEP_ALIVE,
+            HttpHeaderNames.PROXY_AUTHENTICATE,
+            HttpHeaderNames.PROXY_AUTHORIZATION,
+            HttpHeaderNames.TE,
+            HttpHeaderNames.TRAILER,
+            HttpHeaderNames.UPGRADE,
+            HttpHeaderNames.PROXY_CONNECTION
+    );
+
+    /**
+     * Strips hop-by-hop headers from the given {@link HttpHeaders} in place.
+     *
+     * <p>A reverse proxy must not forward hop-by-hop headers between connections
+     * (RFC 2616 §13.5.1, RFC 7230 §6.1). This method:
+     * <ol>
+     *   <li>Removes any headers dynamically nominated as hop-by-hop via the {@code Connection}
+     *       header value (RFC 7230 §6.1).</li>
+     *   <li>Removes the standard set of hop-by-hop headers.</li>
+     * </ol>
+     * This also ensures compliance with HTTP/2, which prohibits connection-specific headers
+     * (RFC 9113 §8.2.2).
+     *
+     * @param headers the headers to strip in place (must be mutable)
+     */
+    public static void stripHopByHopHeaders(final HttpHeaders headers) {
+        // Remove headers dynamically nominated via the Connection header (RFC 7230 §6.1)
+        for (final String connectionValue : headers.getAll(HttpHeaderNames.CONNECTION)) {
+            for (final String token : connectionValue.split(",")) {
+                headers.remove(token.trim());
+            }
+        }
+        // Remove standard hop-by-hop headers
+        HOP_BY_HOP_HEADERS.forEach(headers::remove);
+    }
 
     public static String formatDateHeader(java.util.Date date) {
         return RFC_1123_DATE_TIME.format(ZonedDateTime.ofInstant(date.toInstant(), GMT));

--- a/carapace-server/src/test/java/org/carapaceproxy/core/Http2HeadersTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/Http2HeadersTest.java
@@ -2,8 +2,10 @@ package org.carapaceproxy.core;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.Options.DYNAMIC_PORT;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_FORWARDED_STRATEGY;
@@ -16,6 +18,7 @@ import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAU
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.netty.channel.group.DefaultChannelGroup;
@@ -43,8 +46,32 @@ public class Http2HeadersTest {
     @Rule
     public TemporaryFolder tmpDir = new TemporaryFolder();
 
+    private NetworkListenerConfiguration newH2CListenerConfiguration() {
+        return new NetworkListenerConfiguration(
+                "localhost",
+                DYNAMIC_PORT,
+                false,
+                null,
+                null,
+                DEFAULT_SSL_PROTOCOLS,
+                DEFAULT_SO_BACKLOG,
+                DEFAULT_KEEP_ALIVE,
+                DEFAULT_KEEP_ALIVE_IDLE,
+                DEFAULT_KEEP_ALIVE_INTERVAL,
+                DEFAULT_KEEP_ALIVE_COUNT,
+                DEFAULT_MAX_KEEP_ALIVE_REQUESTS,
+                DEFAULT_FORWARDED_STRATEGY,
+                Set.of(),
+                Set.of(HttpProtocol.H2C, HttpProtocol.HTTP11),
+                new DefaultChannelGroup(new DefaultEventExecutor()));
+    }
+
+    /**
+     * Regression test for the original H2C upgrade scenario: a client sending Connection/Upgrade
+     * headers should still get a successful response via Carapace.
+     */
     @Test
-    public void test() throws IOException, ConfigurationNotValidException, InterruptedException {
+    public void testH2CUpgradeRequestSucceeds() throws IOException, ConfigurationNotValidException, InterruptedException {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(HttpResponseStatus.OK.code())
@@ -55,25 +82,7 @@ public class Http2HeadersTest {
         final var mapper = new TestEndpointMapper("localhost", wireMockRule.port());
         final HttpClientResponse response;
         try (final var server = new HttpProxyServer(mapper, tmpDir.newFolder())) {
-            server.addListener(new NetworkListenerConfiguration(
-                    "localhost",
-                    DYNAMIC_PORT,
-                    false,
-                    null,
-                    null,
-                    DEFAULT_SSL_PROTOCOLS,
-                    DEFAULT_SO_BACKLOG,
-                    DEFAULT_KEEP_ALIVE,
-                    DEFAULT_KEEP_ALIVE_IDLE,
-                    DEFAULT_KEEP_ALIVE_INTERVAL,
-                    DEFAULT_KEEP_ALIVE_COUNT,
-                    DEFAULT_MAX_KEEP_ALIVE_REQUESTS,
-                    DEFAULT_FORWARDED_STRATEGY,
-                    Set.of(),
-                    Set.of(HttpProtocol.H2C, HttpProtocol.HTTP11),
-                    new DefaultChannelGroup(new DefaultEventExecutor()))
-            );
-
+            server.addListener(newH2CListenerConfiguration());
             server.start();
             final var port = server.getLocalPort();
             response = HttpClient.create()
@@ -91,5 +100,81 @@ public class Http2HeadersTest {
         assertThat(response, is(notNullValue()));
         assertThat(response.status(), is(HttpResponseStatus.OK));
         assertThat(response.version(), is(HttpVersion.valueOf("HTTP/2.0")));
+    }
+
+    /**
+     * Hop-by-hop headers sent by the client must not be forwarded to the backend.
+     * A reverse proxy must strip them before forwarding (RFC 2616 §13.5.1, RFC 7230 §6.1).
+     * Note: Reactor Netty manages its own Connection header for the backend connection (e.g. for
+     * H2C upgrade), so we verify the absence of the specific client-originated hop-by-hop headers.
+     */
+    @Test
+    public void testHopByHopHeadersStrippedFromRequest() throws IOException, ConfigurationNotValidException, InterruptedException {
+        stubFor(get(urlEqualTo("/index.html"))
+                .willReturn(aResponse()
+                        .withStatus(HttpResponseStatus.OK.code())
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("ok"))
+        );
+        final var mapper = new TestEndpointMapper("localhost", wireMockRule.port());
+        try (final var server = new HttpProxyServer(mapper, tmpDir.newFolder())) {
+            server.addListener(newH2CListenerConfiguration());
+            server.start();
+            final var port = server.getLocalPort();
+            HttpClient.create()
+                    .protocol(HttpProtocol.HTTP11)
+                    .headers(headers -> headers
+                            .add(HttpHeaderNames.CONNECTION, "keep-alive")
+                            .add(HttpHeaderNames.KEEP_ALIVE, "timeout=5, max=100")
+                    )
+                    .get()
+                    .uri("http://localhost:" + port + "/index.html")
+                    .response()
+                    .block();
+        }
+        // Verify the backend did not receive the client's hop-by-hop headers.
+        // Connection is excluded from this check because Reactor Netty adds its own value
+        // when initiating a backend connection (e.g. "HTTP2-Settings, upgrade" for H2C upgrade).
+        verify(getRequestedFor(urlEqualTo("/index.html"))
+                .withoutHeader(HttpHeaderNames.KEEP_ALIVE.toString())
+        );
+    }
+
+    /**
+     * Hop-by-hop headers in the backend response must not be forwarded to the client.
+     * A reverse proxy must strip them before sending the response (RFC 2616 §13.5.1, RFC 7230 §6.1).
+     * This also ensures HTTP/2 compliance on the client-facing connection (RFC 9113 §8.2.2).
+     * Note: Reactor Netty's HTTP server layer manages the Connection header for the client-facing
+     * connection autonomously, so we verify the absence of Keep-Alive (which Reactor Netty never sets).
+     */
+    @Test
+    public void testHopByHopHeadersStrippedFromResponse() throws IOException, ConfigurationNotValidException, InterruptedException {
+        stubFor(get(urlEqualTo("/index.html"))
+                .willReturn(aResponse()
+                        .withStatus(HttpResponseStatus.OK.code())
+                        .withHeader("Content-Type", "text/plain")
+                        .withHeader("Connection", "keep-alive")
+                        .withHeader("Keep-Alive", "timeout=5, max=100")
+                        .withBody("ok"))
+        );
+        final var mapper = new TestEndpointMapper("localhost", wireMockRule.port());
+        final HttpClientResponse response;
+        try (final var server = new HttpProxyServer(mapper, tmpDir.newFolder())) {
+            server.addListener(newH2CListenerConfiguration());
+            server.start();
+            final var port = server.getLocalPort();
+            response = HttpClient.create()
+                    .protocol(HttpProtocol.HTTP11)
+                    .get()
+                    .uri("http://localhost:" + port + "/index.html")
+                    .response()
+                    .block();
+        }
+        assertThat(response, is(notNullValue()));
+        assertThat(response.status(), is(HttpResponseStatus.OK));
+        // Keep-Alive must be stripped from the backend response before forwarding to the client.
+        // Connection is excluded from this check because Reactor Netty's HTTP server manages it
+        // autonomously for the client-facing connection.
+        assertThat(response.responseHeaders().get(HttpHeaderNames.KEEP_ALIVE), is(nullValue()));
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/core/Http2HeadersTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/Http2HeadersTest.java
@@ -23,20 +23,25 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.concurrent.DefaultEventExecutor;
 import java.io.IOException;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.carapaceproxy.utils.TestEndpointMapper;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import reactor.core.publisher.Mono;
+import reactor.netty.DisposableServer;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.client.HttpClientResponse;
+import reactor.netty.http.server.HttpServer;
 
 public class Http2HeadersTest {
 
@@ -176,5 +181,57 @@ public class Http2HeadersTest {
         // Connection is excluded from this check because Reactor Netty's HTTP server manages it
         // autonomously for the client-facing connection.
         assertThat(response.responseHeaders().get(HttpHeaderNames.KEEP_ALIVE), is(nullValue()));
+    }
+
+    /**
+     * Anchors the original PR symptom: an HTTP/1.x client sending hop-by-hop headers through Carapace
+     * to an HTTP/2-capable backend. Without the strip, Carapace would forward the client's
+     * {@code Connection}/{@code Keep-Alive} verbatim onto an H2C-upgraded backend connection, where
+     * Netty's strict H2 encoder rejects connection-specific headers (RFC 9113 §8.2.2) and the
+     * request fails with a {@code StreamException}. Uses a Reactor Netty {@code HttpServer} configured
+     * for H2C as the backend so Carapace's outbound {@code HttpClient} can negotiate H2.
+     */
+    @Test
+    public void testHopByHopHeadersStrippedForH2cBackend() throws IOException, ConfigurationNotValidException, InterruptedException {
+        final AtomicReference<HttpHeaders> capturedRequestHeaders = new AtomicReference<>();
+        final DisposableServer h2cBackend = HttpServer.create()
+                .host("localhost")
+                .port(0)
+                .protocol(HttpProtocol.H2C, HttpProtocol.HTTP11)
+                .route(routes -> routes.get("/index.html", (req, resp) -> {
+                    capturedRequestHeaders.set(req.requestHeaders().copy());
+                    return resp.status(HttpResponseStatus.OK)
+                            .sendString(Mono.just("ok"));
+                }))
+                .bindNow();
+        try {
+            final var mapper = new TestEndpointMapper("localhost", h2cBackend.port());
+            final HttpClientResponse response;
+            try (final var server = new HttpProxyServer(mapper, tmpDir.newFolder())) {
+                server.addListener(newH2CListenerConfiguration());
+                server.start();
+                final var port = server.getLocalPort();
+                response = HttpClient.create()
+                        .protocol(HttpProtocol.HTTP11)
+                        .headers(headers -> headers
+                                .add(HttpHeaderNames.CONNECTION, "keep-alive")
+                                .add(HttpHeaderNames.KEEP_ALIVE, "timeout=5, max=100")
+                        )
+                        .get()
+                        .uri("http://localhost:" + port + "/index.html")
+                        .response()
+                        .block();
+            }
+            // The request itself must succeed: pre-fix this would 503 once the connection switches to H2
+            // and Netty's H2 encoder rejects the forwarded Keep-Alive header.
+            assertThat(response, is(notNullValue()));
+            assertThat(response.status(), is(HttpResponseStatus.OK));
+            // And the backend must never see Keep-Alive — regardless of which protocol the proxy used
+            // to talk to it.
+            assertThat(capturedRequestHeaders.get(), is(notNullValue()));
+            assertThat(capturedRequestHeaders.get().get(HttpHeaderNames.KEEP_ALIVE), is(nullValue()));
+        } finally {
+            h2cBackend.disposeNow();
+        }
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/core/Http2HeadersTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/Http2HeadersTest.java
@@ -36,7 +36,9 @@ import org.carapaceproxy.utils.TestEndpointMapper;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.netty.ByteBufFlux;
 import reactor.netty.DisposableServer;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.client.HttpClient;
@@ -230,6 +232,56 @@ public class Http2HeadersTest {
             // to talk to it.
             assertThat(capturedRequestHeaders.get(), is(notNullValue()));
             assertThat(capturedRequestHeaders.get().get(HttpHeaderNames.KEEP_ALIVE), is(nullValue()));
+        } finally {
+            h2cBackend.disposeNow();
+        }
+    }
+
+    /**
+     * Companion to {@link #testHopByHopHeadersStrippedForH2cBackend}: a chunked ({@code Transfer-Encoding})
+     * request body proxied to the backend. {@code Transfer-Encoding} is connection-specific and forbidden in
+     * HTTP/2 (RFC 9113 §8.2.2), yet — unlike {@code Connection}/{@code Keep-Alive} — it is intentionally NOT
+     * in the hop-by-hop strip set, because removing it would break HTTP/1.1 chunked proxying (it carries the
+     * body framing). This asserts that forwarding a {@code Transfer-Encoding} request body proxies end-to-end
+     * without tripping the outbound encoder, confirming the deliberate non-stripping is safe. (The proxy
+     * negotiates HTTP/1.1 to the backend here, where forwarding {@code Transfer-Encoding} is correct.)
+     */
+    @Test
+    public void testChunkedRequestBodyForwardedToH2cBackend() throws IOException, ConfigurationNotValidException, InterruptedException {
+        final AtomicReference<HttpHeaders> capturedRequestHeaders = new AtomicReference<>();
+        final DisposableServer h2cBackend = HttpServer.create()
+                .host("localhost")
+                .port(0)
+                .protocol(HttpProtocol.H2C, HttpProtocol.HTTP11)
+                .route(routes -> routes.post("/upload", (req, resp) -> {
+                    capturedRequestHeaders.set(req.requestHeaders().copy());
+                    return req.receive() // drain the request body
+                            .then(resp.status(HttpResponseStatus.OK).sendString(Mono.just("ok")).then());
+                }))
+                .bindNow();
+        try {
+            final var mapper = new TestEndpointMapper("localhost", h2cBackend.port());
+            final HttpClientResponse response;
+            try (final var server = new HttpProxyServer(mapper, tmpDir.newFolder())) {
+                server.addListener(newH2CListenerConfiguration());
+                server.start();
+                final var port = server.getLocalPort();
+                response = HttpClient.create()
+                        .protocol(HttpProtocol.HTTP11)
+                        .post()
+                        .uri("http://localhost:" + port + "/upload")
+                        // A multi-element body with no Content-Length makes the client frame the request with
+                        // Transfer-Encoding: chunked, which Carapace then forwards toward the H2 backend.
+                        .send(ByteBufFlux.fromString(Flux.just("a", "b", "c")))
+                        .response()
+                        .block();
+            }
+            // The concern was that a forwarded Transfer-Encoding could trip the encoder (RFC 9113 §8.2.2) and 503;
+            // the request must instead complete normally.
+            assertThat(response, is(notNullValue()));
+            assertThat(response.status(), is(HttpResponseStatus.OK));
+            // The chunked request reached the backend — forwarding Transfer-Encoding did not break the hop.
+            assertThat(capturedRequestHeaders.get(), is(notNullValue()));
         } finally {
             h2cBackend.disposeNow();
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/HttpUtilsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/HttpUtilsTest.java
@@ -1,0 +1,107 @@
+package org.carapaceproxy.utils;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import org.junit.Test;
+
+public class HttpUtilsTest {
+
+    @Test
+    public void testStripHopByHopHeaders_standardHeaders() {
+        final HttpHeaders headers = new DefaultHttpHeaders();
+        headers.add(HttpHeaderNames.HOST, "example.com");
+        headers.add(HttpHeaderNames.CONTENT_TYPE, "text/html");
+        headers.add(HttpHeaderNames.CONNECTION, "keep-alive");
+        headers.add(HttpHeaderNames.KEEP_ALIVE, "timeout=5, max=100");
+        headers.add(HttpHeaderNames.TRANSFER_ENCODING, "chunked");
+        headers.add(HttpHeaderNames.UPGRADE, "websocket");
+        headers.add(HttpHeaderNames.TE, "trailers");
+        headers.add(HttpHeaderNames.TRAILER, "Expires");
+        headers.add(HttpHeaderNames.PROXY_AUTHENTICATE, "Basic realm=\"test\"");
+        headers.add(HttpHeaderNames.PROXY_AUTHORIZATION, "Basic dXNlcjpwYXNz");
+        headers.add("proxy-connection", "keep-alive");
+
+        HttpUtils.stripHopByHopHeaders(headers);
+
+        // End-to-end headers must be preserved
+        assertThat(headers.get(HttpHeaderNames.HOST), is("example.com"));
+        assertThat(headers.get(HttpHeaderNames.CONTENT_TYPE), is("text/html"));
+
+        // Hop-by-hop headers must be stripped
+        assertThat(headers.get(HttpHeaderNames.CONNECTION), is(nullValue()));
+        assertThat(headers.get(HttpHeaderNames.KEEP_ALIVE), is(nullValue()));
+        assertThat(headers.get(HttpHeaderNames.UPGRADE), is(nullValue()));
+        assertThat(headers.get(HttpHeaderNames.TE), is(nullValue()));
+        assertThat(headers.get(HttpHeaderNames.TRAILER), is(nullValue()));
+        assertThat(headers.get(HttpHeaderNames.PROXY_AUTHENTICATE), is(nullValue()));
+        assertThat(headers.get(HttpHeaderNames.PROXY_AUTHORIZATION), is(nullValue()));
+        assertThat(headers.get("proxy-connection"), is(nullValue()));
+
+        // Transfer-Encoding is intentionally NOT stripped by stripHopByHopHeaders:
+        // Reactor Netty's HTTP/2 codec enforces its removal at the wire level (RFC 9113 §8.2.2),
+        // and stripping it here would break HTTP/1.1 chunked proxying.
+        assertThat(headers.get(HttpHeaderNames.TRANSFER_ENCODING), is("chunked"));
+    }
+
+    @Test
+    public void testStripHopByHopHeaders_dynamicNomination() {
+        // RFC 7230 §6.1: any header listed in the Connection header value is also hop-by-hop
+        final HttpHeaders headers = new DefaultHttpHeaders();
+        headers.add(HttpHeaderNames.HOST, "example.com");
+        headers.add("x-custom-connection-option", "some-value");
+        headers.add("another-option", "another-value");
+        headers.add(HttpHeaderNames.CONNECTION, "x-custom-connection-option, another-option");
+
+        HttpUtils.stripHopByHopHeaders(headers);
+
+        assertThat(headers.get(HttpHeaderNames.HOST), is("example.com"));
+        // Both the Connection header itself and the dynamically nominated headers must be stripped
+        assertThat(headers.get(HttpHeaderNames.CONNECTION), is(nullValue()));
+        assertThat(headers.get("x-custom-connection-option"), is(nullValue()));
+        assertThat(headers.get("another-option"), is(nullValue()));
+    }
+
+    @Test
+    public void testStripHopByHopHeaders_multipleConnectionValues() {
+        // Connection header may have multiple values across multiple header entries
+        final HttpHeaders headers = new DefaultHttpHeaders(false);  // false = allow duplicate header names
+        headers.add(HttpHeaderNames.HOST, "example.com");
+        headers.add("opt-a", "val-a");
+        headers.add("opt-b", "val-b");
+        headers.add(HttpHeaderNames.CONNECTION, "opt-a");
+        headers.add(HttpHeaderNames.CONNECTION, "opt-b");
+
+        HttpUtils.stripHopByHopHeaders(headers);
+
+        assertThat(headers.get(HttpHeaderNames.HOST), is("example.com"));
+        assertThat(headers.get(HttpHeaderNames.CONNECTION), is(nullValue()));
+        assertThat(headers.get("opt-a"), is(nullValue()));
+        assertThat(headers.get("opt-b"), is(nullValue()));
+    }
+
+    @Test
+    public void testStripHopByHopHeaders_noHopByHopHeaders() {
+        // Headers with no hop-by-hop headers are left unchanged
+        final HttpHeaders headers = new DefaultHttpHeaders();
+        headers.add(HttpHeaderNames.HOST, "example.com");
+        headers.add(HttpHeaderNames.CONTENT_TYPE, "application/json");
+        headers.add(HttpHeaderNames.CONTENT_LENGTH, "42");
+
+        HttpUtils.stripHopByHopHeaders(headers);
+
+        assertThat(headers.get(HttpHeaderNames.HOST), is("example.com"));
+        assertThat(headers.get(HttpHeaderNames.CONTENT_TYPE), is("application/json"));
+        assertThat(headers.get(HttpHeaderNames.CONTENT_LENGTH), is("42"));
+    }
+
+    @Test
+    public void testStripHopByHopHeaders_emptyHeaders() {
+        final HttpHeaders headers = new DefaultHttpHeaders();
+        HttpUtils.stripHopByHopHeaders(headers);
+        assertThat(headers.isEmpty(), is(true));
+    }
+}


### PR DESCRIPTION
## Problem

Backends that advertise HTTP/2 via ALPN (e.g. Tomcat on port 8443) returned HTTP/2 responses containing connection-specific headers such as `Keep-Alive`. Netty's strict H2 stream decoder rejected these, producing:

```
Http2Exception$StreamException: Illegal connection-specific header 'keep-alive' encountered
```

and causing 503s for every request routed to those backends. This violates RFC 9113 §8.2.2, which forbids connection-specific headers in HTTP/2.

The underlying cause was that `ProxyRequestsManager` was forwarding client and backend headers verbatim, without stripping the hop-by-hop headers that a reverse proxy must not propagate between connections, as required by RFC 2616 §13.5.1 and RFC 7230 §6.1.

## Solution

Add `HttpUtils.stripHopByHopHeaders()`, which removes the standard hop-by-hop set (`Connection`, `Keep-Alive`, `Proxy-Authenticate`, `Proxy-Authorization`, `TE`, `Trailer`, `Upgrade`, `Proxy-Connection`) plus any headers dynamically nominated via the `Connection` header value (RFC 7230 §6.1). Call it in `ProxyRequestsManager` in both directions: on the outgoing request copy before forwarding to the backend, and on the backend response headers before forwarding to the client.

`Transfer-Encoding` is intentionally excluded from the stripped set: Reactor Netty's H2 codec enforces its removal at the wire level (RFC 9113 §8.2.2), and stripping it in Carapace would break HTTP/1.1 chunked proxying.