### PR TITLE
Skip listener reload when no certificate binding actually changed

### DIFF
--- a/.github/workflows/master-snapshot.yml
+++ b/.github/workflows/master-snapshot.yml
@@ -20,6 +20,6 @@ jobs:
       - name: 'Build and publish snapshot'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./mvnw -B deploy --file pom.xml -DskipTests -Pproduction
+        run: ./mvnw -B deploy --file pom.xml -DskipTests -Pproduction -DaltDeploymentRepository=github::https://maven.pkg.github.com/${{ github.repository }}
       - name: 'Submit Dependency Snapshot'
         uses: advanced-security/maven-dependency-submission-action@v5

--- a/carapace-server/src/main/java/org/carapaceproxy/api/BackendsResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/BackendsResource.java
@@ -96,9 +96,10 @@ public class BackendsResource {
             }
             BackendHealthStatus bhs = backendsSnapshot.get(key);
             if (bhs != null) {
-                bean.available = bhs.getStatus() != BackendHealthStatus.Status.DOWN;
-                bean.reportedAsUnreachable = bhs.getStatus() == BackendHealthStatus.Status.DOWN;
-                bean.reportedAsUnreachableTs = bhs.getUnreachableSince();
+                final BackendHealthStatus.Snapshot snap = bhs.snapshot();
+                bean.available = snap.status() != BackendHealthStatus.Status.DOWN;
+                bean.reportedAsUnreachable = snap.status() == BackendHealthStatus.Status.DOWN;
+                bean.reportedAsUnreachableTs = snap.unreachableSince();
                 BackendHealthCheck lastProbe = bhs.getLastProbe();
                 if (lastProbe != null) {
                     bean.lastProbeTs = lastProbe.endTs();

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
@@ -21,6 +21,7 @@ package org.carapaceproxy.configstore;
 
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.REQUEST_FAILED;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
@@ -114,6 +115,34 @@ public class CertificateData {
                     Optional.ofNullable(subjectAltNames).stream().flatMap(Set::stream)
                 )
                 .collect(Collectors.toUnmodifiableSet());
+    }
+
+    /**
+     * Tells whether two certificates would bind identically on a TLS listener.
+     * <p>
+     * Compares only the binding-relevant fields: the decoded keystore bytes and the
+     * subject-alternative-name set. Differences in transient ACME state such as
+     * {@code state}, {@code attemptsCount}, {@code message}, or {@code pendingOrderLocation}
+     * are ignored, because those tick on every failing renewal attempt without changing
+     * what the listener actually serves.
+     * <p>
+     * The Lombok-generated {@link #equals(Object)} cannot be used here: it includes
+     * {@code attemptsCount} and {@code message}, so a stuck ACME order would report
+     * "changed" on every poll, defeating any reload-guard built on top of it.
+     *
+     * @param a a certificate (nullable)
+     * @param b a certificate (nullable)
+     * @return {@code true} if both are null, or if both carry the same keystore bytes and SANs
+     */
+    public static boolean bindingEquivalent(final CertificateData a, final CertificateData b) {
+        if (a == b) {
+            return true;
+        }
+        if (a == null || b == null) {
+            return false;
+        }
+        return Arrays.equals(a.getKeystoreData(), b.getKeystoreData())
+                && Objects.equals(a.getSubjectAltNames(), b.getSubjectAltNames());
     }
 
     /**

--- a/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
@@ -795,7 +795,7 @@ public class HttpProxyServer implements AutoCloseable {
                 zkAddress = staticConfiguration.getString("zkAddress", "localhost:2181");
                 zkSecure = staticConfiguration.getBoolean("zkSecure", false);
                 zkTimeout = staticConfiguration.getInt("zkTimeout", 40_000);
-                zkProperties = new Properties(staticConfiguration.asProperties("zookeeper."));
+                zkProperties = new Properties(staticConfiguration.asProperties("zookeeper"));
                 LOG.info("mode=cluster, zkAddress=\"{}\", zkTimeout={}, peer.id=\"{}\", zkSecure: {}", zkAddress, zkTimeout, peerId, zkSecure);
                 zkProperties.forEach((k, v) -> LOG.info("additional zkclient property: {}={}", k, v));
                 break;

--- a/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
@@ -742,11 +742,14 @@ public class HttpProxyServer implements AutoCloseable {
             throw new ConfigurationChangeInProgressException();
         }
         try {
+            // Build everything as locals first; do not touch the four `this.X` view fields yet.
             RuntimeServerConfiguration newConfiguration = buildValidConfiguration(storeWithConfig);
             EndpointMapper newMapper = buildMapper(newConfiguration.getMapperClassname(), this, storeWithConfig);
             UserRealm newRealm = buildRealm(userRealmClassname, storeWithConfig);
+            List<RequestFilter> newFilters = buildFilters(newConfiguration);
 
-            this.filters = buildFilters(newConfiguration);
+            // Reload subsystems. Any of these can throw; if it does, the four view fields below
+            // are left untouched, so request-time readers keep seeing a coherent old snapshot.
             this.backendHealthManager.reloadConfiguration(newConfiguration, newMapper);
             this.dynamicCertificatesManager.reloadConfiguration(newConfiguration);
             this.trustStoreManager.reloadConfiguration(newConfiguration);
@@ -754,10 +757,8 @@ public class HttpProxyServer implements AutoCloseable {
             this.listeners.reloadConfiguration(newConfiguration);
             this.cache.reloadConfiguration(newConfiguration);
             this.requestsLogger.reloadConfiguration(newConfiguration);
-            this.realm = newRealm;
             Map<String, BackendConfiguration> currentBackends = mapper != null ? mapper.getBackends() : Collections.emptyMap();
             Map<String, BackendConfiguration> newBackends = newMapper.getBackends();
-            this.mapper = newMapper;
 
             if (!newBackends.equals(currentBackends) || isConnectionsConfigurationChanged(newConfiguration)) {
                 proxyRequestsManager.reloadConfiguration(newConfiguration, newBackends.values());
@@ -767,6 +768,12 @@ public class HttpProxyServer implements AutoCloseable {
                 dynamicConfigurationStore.commitConfiguration(newConfigurationStore);
             }
 
+            // Commit point: every subsystem has reloaded and persistence succeeded; swap the four
+            // view fields back-to-back so the cross-field tearing window observed by readers shrinks
+            // from the full subsystem-reload duration to a handful of volatile writes.
+            this.filters = newFilters;
+            this.realm = newRealm;
+            this.mapper = newMapper;
             this.currentConfiguration = newConfiguration;
         } catch (ConfigurationNotValidException err) {
             // impossible to have a non valid configuration here

--- a/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
@@ -173,23 +173,23 @@ public class HttpProxyServer implements AutoCloseable {
     private OcspStaplingManager ocspStaplingManager;
 
     @Getter
-    private RuntimeServerConfiguration currentConfiguration;
+    private volatile RuntimeServerConfiguration currentConfiguration;
 
     @Getter
     private ConfigurationStore dynamicConfigurationStore;
 
     @Getter
-    private EndpointMapper mapper;
+    private volatile EndpointMapper mapper;
 
     @Getter
     @Setter
-    private UserRealm realm;
+    private volatile UserRealm realm;
 
     @Getter
     private final TrustStoreManager trustStoreManager;
 
     @Getter
-    private List<RequestFilter> filters;
+    private volatile List<RequestFilter> filters;
     private volatile boolean started;
 
     @Getter

--- a/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
@@ -151,23 +151,37 @@ public class Listeners {
         // apply new configuration, this has to be done before rebooting listeners
         currentConfiguration = newConfiguration;
 
+        // Per-listener try/catch isolates failures (e.g. disposeChannel timeouts, bad cert in bootListener)
+        // so one listener cannot cascade into halting the whole reload. InterruptedException still aborts.
         try {
             for (final EndpointKey hostPort : listenersToStop) {
                 LOG.info("Stopping {}", hostPort);
-                stopListener(hostPort);
+                try {
+                    stopListener(hostPort);
+                } catch (final RuntimeException ex) {
+                    LOG.error("Failed to stop listener {}", hostPort, ex);
+                }
             }
 
             for (final EndpointKey hostPort : listenersToRestart) {
                 LOG.info("Restart {}", hostPort);
-                stopListener(hostPort);
-                final var newConfigurationForListener = currentConfiguration.getListener(hostPort);
-                bootListener(newConfigurationForListener);
+                try {
+                    stopListener(hostPort);
+                    final var newConfigurationForListener = currentConfiguration.getListener(hostPort);
+                    bootListener(newConfigurationForListener);
+                } catch (final ConfigurationNotValidException | RuntimeException ex) {
+                    LOG.error("Failed to restart listener {}", hostPort, ex);
+                }
             }
 
             for (final EndpointKey hostPort : listenersToStart) {
                 LOG.info("Starting {}", hostPort);
-                final var newConfigurationForListener = currentConfiguration.getListener(hostPort);
-                bootListener(newConfigurationForListener);
+                try {
+                    final var newConfigurationForListener = currentConfiguration.getListener(hostPort);
+                    bootListener(newConfigurationForListener);
+                } catch (final ConfigurationNotValidException | RuntimeException ex) {
+                    LOG.error("Failed to start listener {}", hostPort, ex);
+                }
             }
         } catch (final InterruptedException stopMe) {
             Thread.currentThread().interrupt();
@@ -280,6 +294,8 @@ public class Listeners {
             } catch (InterruptedException ex) {
                 LOG.error("Interrupted while stopping a listener", ex);
                 Thread.currentThread().interrupt();
+            } catch (RuntimeException ex) {
+                LOG.error("Failed to stop listener {}", key, ex);
             }
         }
     }

--- a/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.Function;
 import jdk.net.ExtendedSocketOptions;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
@@ -204,7 +203,10 @@ public class Listeners {
             });
         }
         httpServer = httpServer
-                .metrics(true, Function.identity())
+                // Map empty/undecodable URIs to "/": on a decode failure reactor-netty hands an empty path to the
+                // metrics handler, which does path.substring(1) and throws. See reactor-netty 1.2.6
+                // https://github.com/reactor/reactor-netty/blob/b6e72c423245595c39ef00faa818e0109c96b57b/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsHandler.java#L199
+                .metrics(true, uri -> uri == null || uri.isEmpty() ? "/" : uri)
                 .forwarded(ForwardedStrategy.of(config.forwardedStrategy(), config.trustedIps()))
                 .option(ChannelOption.SO_BACKLOG, config.soBacklog())
                 .childOption(ChannelOption.SO_KEEPALIVE, config.keepAlive())

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ListeningChannel.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ListeningChannel.java
@@ -93,8 +93,15 @@ public class ListeningChannel {
     }
 
     public void disposeChannel() {
-        this.channel.disposeNow(Duration.ofSeconds(10));
-        FutureMono.from(this.config.group().close()).block(Duration.ofSeconds(10));
+        // 2s timeouts: a longer wait can't drain HTTP/2 connections that the client keeps idle anyway,
+        // and overlapping a 10s+ stall with a 30s certificate-rotation cycle stalls the reload pipeline.
+        // Always attempt the event-loop group close in a finally so a disposeNow timeout doesn't leak it;
+        // the group close itself can still throw IllegalStateException, callers must guard accordingly.
+        try {
+            this.channel.disposeNow(Duration.ofSeconds(2));
+        } finally {
+            FutureMono.from(this.config.group().close()).block(Duration.ofSeconds(2));
+        }
     }
 
     public void incRequests() {

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -142,6 +142,15 @@ public class ProxyRequestsManager implements AutoCloseable {
         });
     }
 
+    private static boolean rejectAsSmuggling(ProxyRequest request) {
+        final HttpHeaders headers = request.getRequestHeaders();
+        if (headers.get(HttpHeaderNames.CONTENT_LENGTH) != null && headers.get(HttpHeaderNames.TRANSFER_ENCODING) != null) {
+            LOGGER.warn("Potential CL.TE request smuggling attack: both Content-Length and Transfer-Encoding present. Request: {}", request.getUri());
+            return true;
+        }
+        return false;
+    }
+
     private static void cleanRequestFromCacheValidators(ProxyRequest request) {
         HttpHeaders headers = request.getRequestHeaders();
         headers.remove(HttpHeaderNames.IF_MATCH);
@@ -205,10 +214,12 @@ public class ProxyRequestsManager implements AutoCloseable {
         request.setLastActivity(request.getStartTs());
         request.getRequestHeaders().set(HttpHeaderNames.SERVER, ServerHeaderRequestFilter.DEFAULT_SERVER);
 
+        // HTTP/1.x request-smuggling validation runs on the raw inbound headers, before any request filter
+        // or the mapper, so a filter that mutates Content-Length / Transfer-Encoding cannot bypass it.
+        // HTTP/2 framing is not vulnerable.
+        final boolean smuggling = request.getHttpProtocol().majorVersion() < 2 && rejectAsSmuggling(request);
         parent.getFilters().forEach(filter -> filter.apply(request));
-
-        MapResult action = parent.getMapper().map(request);
-
+        final MapResult action = smuggling ? MapResult.badRequest() : parent.getMapper().map(request);
         request.setAction(action);
 
         if (LOGGER.isTraceEnabled()) {

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -163,7 +163,13 @@ public class ProxyRequestsManager implements AutoCloseable {
             for (final BackendConfiguration backend : newEndpoints) {
                 final String path = backend.caCertificatePath();
                 if (!StringUtils.isBlank(path)) {
-                    if (clientSslContexts.containsKey(path)) {
+                    if (newContexts.containsKey(path)) {
+                        LOGGER.debug("SSL context for backend {} was already prepared from {}", backend.id(), path);
+                        continue;
+                    }
+                    final SslContext cached = clientSslContexts.get(path);
+                    if (cached != null) {
+                        newContexts.put(path, cached);
                         LOGGER.debug("SSL context for backend {} was already loaded from {}", backend.id(), path);
                     } else {
                         final SslContext sslContext = parent.getTrustStoreManager()

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -159,6 +159,10 @@ public class ProxyRequestsManager implements AutoCloseable {
         headers.remove(HttpHeaderNames.IF_RANGE);
         headers.remove(HttpHeaderNames.IF_UNMODIFIED_SINCE);
         headers.remove(HttpHeaderNames.ETAG);
+        // Connection is a hop-by-hop header and must not influence cache validation (RFC 7234 §4.3.4).
+        // Only Connection is removed here (on the live headers object); full hop-by-hop stripping is
+        // performed later in forward() on a copy of the headers, so that getClientProtocols() can still
+        // read Transfer-Encoding via mayHaveBody() before the copy is made.
         headers.remove(HttpHeaderNames.CONNECTION);
     }
 
@@ -474,23 +478,11 @@ public class ProxyRequestsManager implements AutoCloseable {
         return forwarder.request(request.getMethod())
                 .uri(request.getUri())
                 .send((req, out) -> {
-                    // we don't want to upgrade to HTTP/2 if Carapace supports it, but the backend doesn't
                     final HttpHeaders copy = request.getRequestHeaders().copy();
-                    if (copy.contains(HttpHeaderNames.UPGRADE)) {
-                        final List<String> upgrade = copy.getAll(HttpHeaderNames.UPGRADE);
-                        if (upgrade.contains("HTTP/2")) {
-                            // we drop connection and upgrade only if the target upgrade is HTTP/2.0;
-                            // else, we want to preserve upgrades to HTTPS or similar
-                            final List<String> connection = copy.getAll(HttpHeaderNames.CONNECTION);
-                            connection.removeIf("upgrade"::equalsIgnoreCase);
-                            copy.remove(HttpHeaderNames.CONNECTION);
-                            copy.add(HttpHeaderNames.CONNECTION, connection);
-
-                            upgrade.remove("HTTP/2");
-                            copy.remove(HttpHeaderNames.UPGRADE);
-                            copy.add(HttpHeaderNames.UPGRADE, upgrade);
-                        }
-                    }
+                    // Strip hop-by-hop headers before forwarding to the backend (RFC 2616 §13.5.1, RFC 7230 §6.1).
+                    // This also ensures compliance with HTTP/2 which prohibits connection-specific headers (RFC 9113 §8.2.2).
+                    HttpUtils.stripHopByHopHeaders(copy);
+                    // HTTP2-Settings is connection-specific and must not be forwarded (RFC 7540 §3.2)
                     copy.remove(Http2CodecUtil.HTTP_UPGRADE_SETTINGS_HEADER);
                     req.headers(copy);
                     // netty overrides the value, we need to force it
@@ -511,7 +503,9 @@ public class ProxyRequestsManager implements AutoCloseable {
                     }
 
                     request.setResponseStatus(resp.status());
-                    request.setResponseHeaders(resp.responseHeaders().copy()); // headers from endpoint to client
+                    final HttpHeaders responseHeaders = resp.responseHeaders().copy();
+                    HttpUtils.stripHopByHopHeaders(responseHeaders);
+                    request.setResponseHeaders(responseHeaders);
                     if (cacheable.get() && parent.getCache().isCacheable(resp) && Objects.requireNonNull(cacheReceiver).receivedFromRemote(resp)) {
                         addCachedResponseHeaders(request);
                     } else {

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -448,8 +448,6 @@ public class ProxyRequestsManager implements AutoCloseable {
                         );
                     }
                 }).doAfterResponseSuccess((resp, conn) -> {
-                    PENDING_REQUESTS_GAUGE.dec();
-                    healthStatus.decrementConnections();
                     endpointStats.getLastActivity().set(System.currentTimeMillis());
                 });
 
@@ -550,9 +548,6 @@ public class ProxyRequestsManager implements AutoCloseable {
                         }
                     }));
                 }).onErrorResume(err -> { // custom endpoint request/response error handling
-                    PENDING_REQUESTS_GAUGE.dec();
-                    healthStatus.decrementConnections();
-
                     final EndpointKey endpoint = EndpointKey.make(request.getAction().getHost(), request.getAction().getPort());
                     if (err instanceof ReadTimeoutException) {
                         STUCK_REQUESTS_COUNTER.inc();
@@ -572,6 +567,11 @@ public class ProxyRequestsManager implements AutoCloseable {
                         );
                     }
                     return serveServiceUnavailable(request);
+                })
+                // decrement once per request: success and error callbacks can both fire (headers ok, body fails)
+                .doFinally(signal -> {
+                    PENDING_REQUESTS_GAUGE.dec();
+                    healthStatus.decrementConnections();
                 });
     }
 

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -226,22 +226,20 @@ public class ProxyRequestsManager implements AutoCloseable {
             LOGGER.trace("{} Mapped {} to {}, userid {}", this, request.getUri(), action, request.getUserId());
         }
 
-        try {
-            return switch (action.getAction()) {
-                case NOTFOUND -> serveNotFoundMessage(request);
-                case INTERNAL_ERROR -> serveInternalErrorMessage(request);
-                case SERVICE_UNAVAILABLE -> serveServiceUnavailable(request);
-                case MAINTENANCE_MODE -> serveMaintenanceMessage(request);
-                case BAD_REQUEST -> serveBadRequestMessage(request);
-                case STATIC, ACME_CHALLENGE -> serveStaticMessage(request);
-                case REDIRECT -> serveRedirect(request);
-                case PROXY -> forward(request, false, action.getHealthStatus());
-                case CACHE -> serveFromCache(request, action.getHealthStatus()); // cached content
-                default -> throw new IllegalStateException("Action " + action.getAction() + " not supported");
-            };
-        } finally {
-            parent.getRequestsLogger().logRequest(request);
-        }
+        final Publisher<Void> result = switch (action.getAction()) {
+            case NOTFOUND -> serveNotFoundMessage(request);
+            case INTERNAL_ERROR -> serveInternalErrorMessage(request);
+            case SERVICE_UNAVAILABLE -> serveServiceUnavailable(request);
+            case MAINTENANCE_MODE -> serveMaintenanceMessage(request);
+            case BAD_REQUEST -> serveBadRequestMessage(request);
+            case STATIC, ACME_CHALLENGE -> serveStaticMessage(request);
+            case REDIRECT -> serveRedirect(request);
+            case PROXY -> forward(request, false, action.getHealthStatus());
+            case CACHE -> serveFromCache(request, action.getHealthStatus()); // cached content
+            default -> throw new IllegalStateException("Action " + action.getAction() + " not supported");
+        };
+        // Log on terminal signal so response status, backend timing, and cache info are populated.
+        return Mono.from(result).doFinally(sig -> parent.getRequestsLogger().logRequest(request));
     }
 
     private Publisher<Void> serveNotFoundMessage(ProxyRequest request) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthManager.java
@@ -270,7 +270,7 @@ public class BackendHealthManager implements Runnable {
             return false;
         }
         final BackendHealthStatus backendStatus = getBackendStatus(backendConfiguration.hostPort());
-        return backendConfiguration.safeCapacity() > backendStatus.getConnections();
+        return backendStatus.getConnections() > backendConfiguration.safeCapacity();
     }
 
     @VisibleForTesting

--- a/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthStatus.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthStatus.java
@@ -21,6 +21,7 @@ package org.carapaceproxy.server.backends;
 
 import java.sql.Timestamp;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.carapaceproxy.core.EndpointKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,35 +38,33 @@ public class BackendHealthStatus {
     private final EndpointKey hostPort;
     private final AtomicInteger connections;
 
-    private volatile Status status;
-    private volatile long unreachableSince;
-    private volatile long lastUnreachable;
-    private volatile long lastReachable;
+    // Status + the three associated timestamps move together via a single AtomicReference so concurrent
+    // reportAs(Un)Reachable callers cannot leave the four fields in a torn combination (e.g. status=DOWN
+    // with unreachableSince=0). Configuration knobs (warmupPeriod) and the periodic probe handle
+    // (lastProbe) stay as separate volatile fields — they aren't part of the transition's atom.
+    private final AtomicReference<State> state;
     private volatile BackendHealthCheck lastProbe;
     private volatile long warmupPeriod;
 
     public BackendHealthStatus(final EndpointKey hostPort, final long warmupPeriod) {
         this.hostPort = hostPort;
         // we assume that the backend just became reachable when the status is created
-        this.status = Status.COLD;
-        this.unreachableSince = 0L;
         final long created = System.currentTimeMillis();
-        this.lastUnreachable = created;
-        this.lastReachable = created;
+        this.state = new AtomicReference<>(new State(Status.COLD, 0L, created, created));
         this.connections = new AtomicInteger();
         this.warmupPeriod = warmupPeriod;
     }
 
     public long getUnreachableSince() {
-        return unreachableSince;
+        return state.get().unreachableSince();
     }
 
     public long getLastUnreachable() {
-        return lastUnreachable;
+        return state.get().lastUnreachable();
     }
 
     public long getLastReachable() {
-        return lastReachable;
+        return state.get().lastReachable();
     }
 
     public EndpointKey getHostPort() {
@@ -81,48 +80,45 @@ public class BackendHealthStatus {
     }
 
     public Status getStatus() {
-        return status;
+        return state.get().status();
+    }
+
+    /**
+     * Returns a coherent snapshot of the four state-machine fields ({@code status}, {@code unreachableSince},
+     * {@code lastUnreachable}, {@code lastReachable}). Use this instead of calling several field-level getters
+     * in a row when more than one field is needed — each individual getter is itself atomic, but two
+     * consecutive getter calls can straddle a state transition and observe an inconsistent pair.
+     */
+    public Snapshot snapshot() {
+        final State s = state.get();
+        return new Snapshot(s.status(), s.unreachableSince(), s.lastUnreachable(), s.lastReachable());
     }
 
     public void reportAsUnreachable(final long timestamp, final String cause) {
         LOG.info("{}: reportAsUnreachable {}, cause {}", hostPort, new Timestamp(timestamp), cause);
-        if (this.status != Status.DOWN) {
-            this.status = Status.DOWN;
-            this.unreachableSince = timestamp;
-        }
-        this.lastUnreachable = timestamp;
-        this.connections.set(0);
+        state.updateAndGet(s -> s.withUnreachable(timestamp));
+        // The historical connections.set(0) reset has been dropped: with the inc/dec invariant
+        // restored (NiccoMlt/carapaceproxy#13 — single decrement on terminal) and the atomic
+        // clamp (#17), in-flight requests' decrements drain the counter naturally; SafeBackendSelector
+        // already ignores `connections` for DOWN backends, so the value while DOWN is irrelevant.
     }
 
     public void reportAsReachable(final long timestamp) {
         LOG.debug("{}: reportAsReachable {}", hostPort, new Timestamp(timestamp));
-        switch (this.status) {
-            case DOWN:
-                this.status = Status.COLD;
-                this.unreachableSince = 0;
-                this.lastReachable = timestamp;
-                break;
-            case COLD:
-                this.lastReachable = timestamp;
-                if (this.lastReachable - this.lastUnreachable > this.warmupPeriod) {
-                    this.status = Status.STABLE;
-                }
-                break;
-            case STABLE:
-                this.lastReachable = timestamp;
-                break;
-        }
+        final long warmup = this.warmupPeriod;
+        state.updateAndGet(s -> s.withReachable(timestamp, warmup));
     }
 
     @Override
     public String toString() {
+        final State snapshot = state.get();
         return "BackendHealthStatus{"
                 + " hostPort=" + this.hostPort
                 + ", connections=" + this.connections
-                + ", status=" + this.status
-                + ", unreachableSince=" + this.unreachableSince
-                + ", unreachableUntil=" + this.lastUnreachable
-                + ", lastReachable=" + this.lastReachable
+                + ", status=" + snapshot.status()
+                + ", unreachableSince=" + snapshot.unreachableSince()
+                + ", unreachableUntil=" + snapshot.lastUnreachable()
+                + ", lastReachable=" + snapshot.lastReachable()
                 + ", lastProbe=" + this.lastProbe
                 + '}';
     }
@@ -164,5 +160,41 @@ public class BackendHealthStatus {
          * The backend is reachable and was so since a reasonably-long time.
          */
         STABLE
+    }
+
+    /**
+     * Coherent read-only view of {@link #getStatus()}, {@link #getUnreachableSince()},
+     * {@link #getLastUnreachable()}, and {@link #getLastReachable()} captured atomically via {@link #snapshot()}.
+     */
+    public record Snapshot(Status status, long unreachableSince, long lastUnreachable, long lastReachable) {
+    }
+
+    /**
+     * Immutable internal record of the four state-machine fields that transition together.
+     * Held in an {@link AtomicReference} so {@code reportAs(Un)Reachable} callers cannot interleave their
+     * field writes; each {@link AtomicReference#updateAndGet} call is a single linearization point.
+     */
+    private record State(Status status, long unreachableSince, long lastUnreachable, long lastReachable) {
+        State withUnreachable(final long timestamp) {
+            if (status == Status.DOWN) {
+                // Already DOWN; just refresh lastUnreachable, preserve unreachableSince.
+                return new State(status, unreachableSince, timestamp, lastReachable);
+            }
+            // Transition from COLD/STABLE to DOWN.
+            return new State(Status.DOWN, timestamp, timestamp, lastReachable);
+        }
+
+        State withReachable(final long timestamp, final long warmupPeriod) {
+            return switch (status) {
+                case DOWN -> new State(Status.COLD, 0L, lastUnreachable, timestamp);
+                case COLD -> {
+                    // Warmup check uses a coherent (lastUnreachable, timestamp) pair from this snapshot,
+                    // so concurrent reportAsUnreachable cannot move lastUnreachable between the two reads.
+                    final Status next = (timestamp - lastUnreachable) > warmupPeriod ? Status.STABLE : Status.COLD;
+                    yield new State(next, unreachableSince, lastUnreachable, timestamp);
+                }
+                case STABLE -> new State(Status.STABLE, unreachableSince, lastUnreachable, timestamp);
+            };
+        }
     }
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthStatus.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthStatus.java
@@ -136,9 +136,10 @@ public class BackendHealthStatus {
     }
 
     public void decrementConnections() {
-        if (this.connections.getAcquire() > 0) {
-            this.connections.decrementAndGet();
-        }
+        // Clamp at 0 atomically: reportAsUnreachable resets the counter via set(0), so in-flight
+        // decrements that arrive afterwards would otherwise underflow. A bare check-then-decrement
+        // is non-atomic and can race with concurrent decrements or set(0).
+        this.connections.updateAndGet(v -> Math.max(0, v - 1));
     }
 
     public void setWarmupPeriod(final long warmupPeriod) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
@@ -105,7 +105,7 @@ public class DynamicCertificatesManager implements Runnable {
     private static final String EVENT_CERTIFICATES_STATE_CHANGED = "certificates_state_changed";
     private static final String EVENT_CERTIFICATES_REQUEST_STORE = "certificates_request_store";
 
-    private Map<String, CertificateData> certificates = new ConcurrentHashMap<>();
+    private volatile Map<String, CertificateData> certificates = new ConcurrentHashMap<>();
     private ACMEClient acmeClient; // Let's Encrypt client
     private Route53Client r53Client;
     private String awsAccessKey;
@@ -373,8 +373,9 @@ public class DynamicCertificatesManager implements Runnable {
         }
         if (flushCache) {
             groupMembershipHandler.fireEvent(EVENT_CERTIFICATES_STATE_CHANGED, null);
-            // remember that events  are not delivered to the local JVM
-            reloadCertificatesFromDB();
+            // remember that events  are not delivered to the local JVM;
+            // already running inside the mutex via certificatesLifecycle's caller, so skip the dispatcher.
+            reloadCertificatesFromDBInternal();
         }
     }
 
@@ -668,7 +669,19 @@ public class DynamicCertificatesManager implements Runnable {
         }
     }
 
+    /**
+     * Dispatcher entry point: serialises reloads across the scheduler thread, ZK callbacks,
+     * and the admin REST path through {@link GroupMembershipHandler#executeInMutex}, which
+     * is reentrant per-thread in both standalone and cluster modes.
+     * <p>
+     * Callers already running inside the mutex (e.g. {@link #certificatesLifecycle()})
+     * should invoke {@link #reloadCertificatesFromDBInternal()} directly instead.
+     */
     private void reloadCertificatesFromDB() {
+        groupMembershipHandler.executeInMutex(THREAD_NAME, period > 0 ? period : 1, this::reloadCertificatesFromDBInternal);
+    }
+
+    private void reloadCertificatesFromDBInternal() {
         LOG.info("Reloading certificates from db");
         try {
             Map<String, CertificateData> newCertificates = new ConcurrentHashMap<>();
@@ -681,13 +694,31 @@ public class DynamicCertificatesManager implements Runnable {
                 LOG.info("RELOADED certificate for domain {}: {}", domain, freshCert);
             }
             var oldCertificates = this.certificates;
+            final boolean anyBindingChange = hasAnyBindingChange(oldCertificates, newCertificates);
             this.certificates = newCertificates; // only certificates/domains specified in the config have to be managed.
-            server.getListeners().reloadCurrentConfiguration();
+            if (anyBindingChange) {
+                server.getListeners().reloadCurrentConfiguration();
+            } else {
+                LOG.debug("No certificate binding change detected; skipping listener reload");
+            }
             // storing certificates on local path
             storeLocalCertificates(newCertificates.values(), oldCertificates);
         } catch (GeneralSecurityException | MalformedURLException | InterruptedException | ConfigurationNotValidException e) {
             throw new DynamicCertificatesManagerException("Unable to load dynamic certificates from db.", e);
         }
+    }
+
+    static boolean hasAnyBindingChange(final Map<String, CertificateData> oldCertificates,
+                                       final Map<String, CertificateData> newCertificates) {
+        if (!oldCertificates.keySet().equals(newCertificates.keySet())) {
+            return true;
+        }
+        for (final Entry<String, CertificateData> entry : newCertificates.entrySet()) {
+            if (!CertificateData.bindingEquivalent(oldCertificates.get(entry.getKey()), entry.getValue())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void storeLocalCertificates(Collection<CertificateData> newCertificates, Map<String, CertificateData> oldCertificates) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -26,8 +26,6 @@ import static org.carapaceproxy.core.StaticContentsManager.IN_MEMORY_RESOURCE;
 import com.google.common.net.HostAndPort;
 import com.google.common.net.InetAddresses;
 import com.google.common.net.InternetDomainName;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -147,30 +145,6 @@ public class StandardEndpointMapper extends EndpointMapper {
                 LOG.trace("Invalid header host {} for request {}", request.getRequestHostname(), request.getUri());
             }
             return MapResult.badRequest();
-        }
-
-        // CL.0 and CL.TE request smuggling validation
-        // HTTP/2 requests are not vulnerable to these attacks, so we only check HTTP/1.x
-        if (request.getHttpProtocol().majorVersion() < 2) {
-            HttpHeaders headers = request.getRequestHeaders();
-            String contentLength = headers.get(HttpHeaderNames.CONTENT_LENGTH);
-            String transferEncoding = headers.get(HttpHeaderNames.TRANSFER_ENCODING);
-
-            // Check for CL.TE attack: both Content-Length and Transfer-Encoding headers present
-            if (contentLength != null && transferEncoding != null) {
-                LOG.warn("Potential CL.TE request smuggling attack detected: both Content-Length and Transfer-Encoding headers present. Request: {}", request.getUri());
-                return MapResult.badRequest();
-            }
-
-            // Check for CL.0 attack: Content-Length: 0 but with body
-            if (contentLength != null && contentLength.trim().equals("0")) {
-                // It's OK to consume the string in the flux, as it should be empty anyway
-                final String body = request.getRequestData().asString().blockFirst();
-                if (body != null && !body.isEmpty()) {
-                    LOG.warn("Request with Content-Length: 0 but with body detected: {}", request.getUri());
-                    return MapResult.badRequest();
-                }
-            }
         }
 
         for (final RouteConfiguration route : routes) {

--- a/carapace-server/src/main/java/org/carapaceproxy/utils/HttpUtils.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/utils/HttpUtils.java
@@ -27,6 +27,7 @@ import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpVersion;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Set;
 import reactor.netty.http.HttpProtocol;
 
 /**
@@ -41,6 +42,54 @@ import reactor.netty.http.HttpProtocol;
 public class HttpUtils {
 
     private static final ZoneId GMT = ZoneId.of("GMT");
+
+    /**
+     * Standard hop-by-hop headers that must not be forwarded by a reverse proxy,
+     * as defined by RFC 2616 §13.5.1 and RFC 7230 §6.1.
+     * The {@code Proxy-Connection} header is a non-standard but widely-used extension that is also treated as hop-by-hop.
+     *
+     * <p>Note: {@code Transfer-Encoding} is intentionally excluded from this set. It is connection-specific
+     * between adjacent peers, but Reactor Netty's HTTP/2 codec already enforces its removal at the wire
+     * level (RFC 9113 §8.2.2). Stripping it here would break HTTP/1.1 chunked proxying by removing the
+     * framing signal that clients need to reassemble the response body.
+     */
+    @SuppressWarnings("deprecation")
+    private static final Set<CharSequence> HOP_BY_HOP_HEADERS = Set.of(
+            HttpHeaderNames.CONNECTION,
+            HttpHeaderNames.KEEP_ALIVE,
+            HttpHeaderNames.PROXY_AUTHENTICATE,
+            HttpHeaderNames.PROXY_AUTHORIZATION,
+            HttpHeaderNames.TE,
+            HttpHeaderNames.TRAILER,
+            HttpHeaderNames.UPGRADE,
+            HttpHeaderNames.PROXY_CONNECTION
+    );
+
+    /**
+     * Strips hop-by-hop headers from the given {@link HttpHeaders} in place.
+     *
+     * <p>A reverse proxy must not forward hop-by-hop headers between connections
+     * (RFC 2616 §13.5.1, RFC 7230 §6.1). This method:
+     * <ol>
+     *   <li>Removes any headers dynamically nominated as hop-by-hop via the {@code Connection}
+     *       header value (RFC 7230 §6.1).</li>
+     *   <li>Removes the standard set of hop-by-hop headers.</li>
+     * </ol>
+     * This also ensures compliance with HTTP/2, which prohibits connection-specific headers
+     * (RFC 9113 §8.2.2).
+     *
+     * @param headers the headers to strip in place (must be mutable)
+     */
+    public static void stripHopByHopHeaders(final HttpHeaders headers) {
+        // Remove headers dynamically nominated via the Connection header (RFC 7230 §6.1)
+        for (final String connectionValue : headers.getAll(HttpHeaderNames.CONNECTION)) {
+            for (final String token : connectionValue.split(",")) {
+                headers.remove(token.trim());
+            }
+        }
+        // Remove standard hop-by-hop headers
+        HOP_BY_HOP_HEADERS.forEach(headers::remove);
+    }
 
     public static String formatDateHeader(java.util.Date date) {
         return RFC_1123_DATE_TIME.format(ZonedDateTime.ofInstant(date.toInstant(), GMT));

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/StuckRequestsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/StuckRequestsTest.java
@@ -42,6 +42,7 @@ import org.carapaceproxy.server.config.ActionConfiguration;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.carapaceproxy.server.mapper.StandardEndpointMapper;
 import org.carapaceproxy.utils.RawHttpClient;
+import org.carapaceproxy.utils.TestUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -125,6 +126,7 @@ public class StuckRequestsTest {
                         """, resp.getBodyString());
             }
 
+            TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
             assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
             assertThat((int) ProxyRequestsManager.STUCK_REQUESTS_COUNTER.get() > 0, is(true));
 

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendTest.java
@@ -42,6 +42,7 @@ import org.carapaceproxy.server.config.ActionConfiguration;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.carapaceproxy.utils.RawHttpClient;
 import org.carapaceproxy.utils.TestEndpointMapper;
+import org.carapaceproxy.utils.TestUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -101,6 +102,7 @@ public class UnreachableBackendTest {
                         """, resp.getBodyString());
             }
             assertSame(BackendHealthStatus.Status.DOWN, server.getBackendHealthManager().getBackendStatus(key).getStatus());
+            TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
             assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
         }
     }
@@ -156,6 +158,7 @@ public class UnreachableBackendTest {
                         """, resp.getBodyString());
             }
             assertSame(COLD, server.getBackendHealthManager().getBackendStatus(key).getStatus()); // no troubles for new connections
+            TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
             assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
         }
     }
@@ -188,6 +191,7 @@ public class UnreachableBackendTest {
                         """, resp.getBodyString());
             }
             assertSame(COLD, server.getBackendHealthManager().getBackendStatus(key).getStatus()); // no troubles for new connections
+            TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
             assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
         }
     }
@@ -241,6 +245,7 @@ public class UnreachableBackendTest {
                         """, resp.getBodyString());
             }
             assertSame(COLD, server.getBackendHealthManager().getBackendStatus(key).getStatus());
+            TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
             assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
         }
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/CertificateDataBindingEquivalentTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/CertificateDataBindingEquivalentTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.carapaceproxy.configstore;
+
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.AVAILABLE;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.REQUEST_FAILED;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.WAITING;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.net.URI;
+import java.util.Set;
+import org.junit.Test;
+
+public class CertificateDataBindingEquivalentTest {
+
+    private static final byte[] KEYSTORE_A = {0x01, 0x02, 0x03};
+    private static final byte[] KEYSTORE_B = {0x04, 0x05, 0x06};
+    private static final Set<String> SANS_A = Set.of("alt-a.example.com");
+    private static final Set<String> SANS_B = Set.of("alt-b.example.com");
+
+    @Test
+    public void testBothNullReturnsTrue() {
+        assertTrue(CertificateData.bindingEquivalent(null, null));
+    }
+
+    @Test
+    public void testOneNullReturnsFalse() {
+        final CertificateData cert = buildCert(KEYSTORE_A, SANS_A);
+        assertFalse(CertificateData.bindingEquivalent(cert, null));
+        assertFalse(CertificateData.bindingEquivalent(null, cert));
+    }
+
+    @Test
+    public void testSameReferenceReturnsTrue() {
+        final CertificateData cert = buildCert(KEYSTORE_A, SANS_A);
+        assertTrue(CertificateData.bindingEquivalent(cert, cert));
+    }
+
+    @Test
+    public void testIdenticalKeystoreAndSansReturnsTrueDespiteTransientState() throws Exception {
+        // Staging symptom: a stuck ACME order ticks attemptsCount/message/state/pendingOrderLocation
+        // every poll while keystore bytes and SANs stay the same.
+        final CertificateData stable = buildCert(KEYSTORE_A, SANS_A);
+        stable.setState(AVAILABLE);
+        stable.setAttemptsCount(0);
+        stable.setMessage("");
+        stable.setPendingOrderLocation(null);
+
+        final CertificateData ticked = buildCert(KEYSTORE_A.clone(), SANS_A);
+        ticked.setState(REQUEST_FAILED);
+        ticked.setAttemptsCount(11);
+        ticked.setMessage("stuck order");
+        ticked.setPendingOrderLocation(URI.create("https://acme/order/42").toURL());
+
+        assertTrue(CertificateData.bindingEquivalent(stable, ticked));
+    }
+
+    @Test
+    public void testKeystoreBytesDifferReturnsFalse() {
+        final CertificateData a = buildCert(KEYSTORE_A, SANS_A);
+        final CertificateData b = buildCert(KEYSTORE_B, SANS_A);
+        assertFalse(CertificateData.bindingEquivalent(a, b));
+    }
+
+    @Test
+    public void testKeystoreNullVsBytesReturnsFalse() {
+        final CertificateData a = buildCert(null, SANS_A);
+        final CertificateData b = buildCert(KEYSTORE_A, SANS_A);
+        assertFalse(CertificateData.bindingEquivalent(a, b));
+    }
+
+    @Test
+    public void testSubjectAltNamesDifferReturnsFalse() {
+        final CertificateData a = buildCert(KEYSTORE_A, SANS_A);
+        final CertificateData b = buildCert(KEYSTORE_A, SANS_B);
+        assertFalse(CertificateData.bindingEquivalent(a, b));
+    }
+
+    private static CertificateData buildCert(final byte[] keystoreData, final Set<String> sans) {
+        final CertificateData cert = new CertificateData("example.com", sans, null, WAITING, null, null);
+        cert.setKeystoreData(keystoreData);
+        return cert;
+    }
+}

--- a/carapace-server/src/test/java/org/carapaceproxy/core/Http2HeadersTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/Http2HeadersTest.java
@@ -2,8 +2,10 @@ package org.carapaceproxy.core;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.Options.DYNAMIC_PORT;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_FORWARDED_STRATEGY;
@@ -16,24 +18,30 @@ import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAU
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.concurrent.DefaultEventExecutor;
 import java.io.IOException;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.carapaceproxy.utils.TestEndpointMapper;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import reactor.core.publisher.Mono;
+import reactor.netty.DisposableServer;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.client.HttpClientResponse;
+import reactor.netty.http.server.HttpServer;
 
 public class Http2HeadersTest {
 
@@ -43,8 +51,32 @@ public class Http2HeadersTest {
     @Rule
     public TemporaryFolder tmpDir = new TemporaryFolder();
 
+    private NetworkListenerConfiguration newH2CListenerConfiguration() {
+        return new NetworkListenerConfiguration(
+                "localhost",
+                DYNAMIC_PORT,
+                false,
+                null,
+                null,
+                DEFAULT_SSL_PROTOCOLS,
+                DEFAULT_SO_BACKLOG,
+                DEFAULT_KEEP_ALIVE,
+                DEFAULT_KEEP_ALIVE_IDLE,
+                DEFAULT_KEEP_ALIVE_INTERVAL,
+                DEFAULT_KEEP_ALIVE_COUNT,
+                DEFAULT_MAX_KEEP_ALIVE_REQUESTS,
+                DEFAULT_FORWARDED_STRATEGY,
+                Set.of(),
+                Set.of(HttpProtocol.H2C, HttpProtocol.HTTP11),
+                new DefaultChannelGroup(new DefaultEventExecutor()));
+    }
+
+    /**
+     * Regression test for the original H2C upgrade scenario: a client sending Connection/Upgrade
+     * headers should still get a successful response via Carapace.
+     */
     @Test
-    public void test() throws IOException, ConfigurationNotValidException, InterruptedException {
+    public void testH2CUpgradeRequestSucceeds() throws IOException, ConfigurationNotValidException, InterruptedException {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(HttpResponseStatus.OK.code())
@@ -55,25 +87,7 @@ public class Http2HeadersTest {
         final var mapper = new TestEndpointMapper("localhost", wireMockRule.port());
         final HttpClientResponse response;
         try (final var server = new HttpProxyServer(mapper, tmpDir.newFolder())) {
-            server.addListener(new NetworkListenerConfiguration(
-                    "localhost",
-                    DYNAMIC_PORT,
-                    false,
-                    null,
-                    null,
-                    DEFAULT_SSL_PROTOCOLS,
-                    DEFAULT_SO_BACKLOG,
-                    DEFAULT_KEEP_ALIVE,
-                    DEFAULT_KEEP_ALIVE_IDLE,
-                    DEFAULT_KEEP_ALIVE_INTERVAL,
-                    DEFAULT_KEEP_ALIVE_COUNT,
-                    DEFAULT_MAX_KEEP_ALIVE_REQUESTS,
-                    DEFAULT_FORWARDED_STRATEGY,
-                    Set.of(),
-                    Set.of(HttpProtocol.H2C, HttpProtocol.HTTP11),
-                    new DefaultChannelGroup(new DefaultEventExecutor()))
-            );
-
+            server.addListener(newH2CListenerConfiguration());
             server.start();
             final var port = server.getLocalPort();
             response = HttpClient.create()
@@ -91,5 +105,133 @@ public class Http2HeadersTest {
         assertThat(response, is(notNullValue()));
         assertThat(response.status(), is(HttpResponseStatus.OK));
         assertThat(response.version(), is(HttpVersion.valueOf("HTTP/2.0")));
+    }
+
+    /**
+     * Hop-by-hop headers sent by the client must not be forwarded to the backend.
+     * A reverse proxy must strip them before forwarding (RFC 2616 §13.5.1, RFC 7230 §6.1).
+     * Note: Reactor Netty manages its own Connection header for the backend connection (e.g. for
+     * H2C upgrade), so we verify the absence of the specific client-originated hop-by-hop headers.
+     */
+    @Test
+    public void testHopByHopHeadersStrippedFromRequest() throws IOException, ConfigurationNotValidException, InterruptedException {
+        stubFor(get(urlEqualTo("/index.html"))
+                .willReturn(aResponse()
+                        .withStatus(HttpResponseStatus.OK.code())
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("ok"))
+        );
+        final var mapper = new TestEndpointMapper("localhost", wireMockRule.port());
+        try (final var server = new HttpProxyServer(mapper, tmpDir.newFolder())) {
+            server.addListener(newH2CListenerConfiguration());
+            server.start();
+            final var port = server.getLocalPort();
+            HttpClient.create()
+                    .protocol(HttpProtocol.HTTP11)
+                    .headers(headers -> headers
+                            .add(HttpHeaderNames.CONNECTION, "keep-alive")
+                            .add(HttpHeaderNames.KEEP_ALIVE, "timeout=5, max=100")
+                    )
+                    .get()
+                    .uri("http://localhost:" + port + "/index.html")
+                    .response()
+                    .block();
+        }
+        // Verify the backend did not receive the client's hop-by-hop headers.
+        // Connection is excluded from this check because Reactor Netty adds its own value
+        // when initiating a backend connection (e.g. "HTTP2-Settings, upgrade" for H2C upgrade).
+        verify(getRequestedFor(urlEqualTo("/index.html"))
+                .withoutHeader(HttpHeaderNames.KEEP_ALIVE.toString())
+        );
+    }
+
+    /**
+     * Hop-by-hop headers in the backend response must not be forwarded to the client.
+     * A reverse proxy must strip them before sending the response (RFC 2616 §13.5.1, RFC 7230 §6.1).
+     * This also ensures HTTP/2 compliance on the client-facing connection (RFC 9113 §8.2.2).
+     * Note: Reactor Netty's HTTP server layer manages the Connection header for the client-facing
+     * connection autonomously, so we verify the absence of Keep-Alive (which Reactor Netty never sets).
+     */
+    @Test
+    public void testHopByHopHeadersStrippedFromResponse() throws IOException, ConfigurationNotValidException, InterruptedException {
+        stubFor(get(urlEqualTo("/index.html"))
+                .willReturn(aResponse()
+                        .withStatus(HttpResponseStatus.OK.code())
+                        .withHeader("Content-Type", "text/plain")
+                        .withHeader("Connection", "keep-alive")
+                        .withHeader("Keep-Alive", "timeout=5, max=100")
+                        .withBody("ok"))
+        );
+        final var mapper = new TestEndpointMapper("localhost", wireMockRule.port());
+        final HttpClientResponse response;
+        try (final var server = new HttpProxyServer(mapper, tmpDir.newFolder())) {
+            server.addListener(newH2CListenerConfiguration());
+            server.start();
+            final var port = server.getLocalPort();
+            response = HttpClient.create()
+                    .protocol(HttpProtocol.HTTP11)
+                    .get()
+                    .uri("http://localhost:" + port + "/index.html")
+                    .response()
+                    .block();
+        }
+        assertThat(response, is(notNullValue()));
+        assertThat(response.status(), is(HttpResponseStatus.OK));
+        // Keep-Alive must be stripped from the backend response before forwarding to the client.
+        // Connection is excluded from this check because Reactor Netty's HTTP server manages it
+        // autonomously for the client-facing connection.
+        assertThat(response.responseHeaders().get(HttpHeaderNames.KEEP_ALIVE), is(nullValue()));
+    }
+
+    /**
+     * Anchors the original PR symptom: an HTTP/1.x client sending hop-by-hop headers through Carapace
+     * to an HTTP/2-capable backend. Without the strip, Carapace would forward the client's
+     * {@code Connection}/{@code Keep-Alive} verbatim onto an H2C-upgraded backend connection, where
+     * Netty's strict H2 encoder rejects connection-specific headers (RFC 9113 §8.2.2) and the
+     * request fails with a {@code StreamException}. Uses a Reactor Netty {@code HttpServer} configured
+     * for H2C as the backend so Carapace's outbound {@code HttpClient} can negotiate H2.
+     */
+    @Test
+    public void testHopByHopHeadersStrippedForH2cBackend() throws IOException, ConfigurationNotValidException, InterruptedException {
+        final AtomicReference<HttpHeaders> capturedRequestHeaders = new AtomicReference<>();
+        final DisposableServer h2cBackend = HttpServer.create()
+                .host("localhost")
+                .port(0)
+                .protocol(HttpProtocol.H2C, HttpProtocol.HTTP11)
+                .route(routes -> routes.get("/index.html", (req, resp) -> {
+                    capturedRequestHeaders.set(req.requestHeaders().copy());
+                    return resp.status(HttpResponseStatus.OK)
+                            .sendString(Mono.just("ok"));
+                }))
+                .bindNow();
+        try {
+            final var mapper = new TestEndpointMapper("localhost", h2cBackend.port());
+            final HttpClientResponse response;
+            try (final var server = new HttpProxyServer(mapper, tmpDir.newFolder())) {
+                server.addListener(newH2CListenerConfiguration());
+                server.start();
+                final var port = server.getLocalPort();
+                response = HttpClient.create()
+                        .protocol(HttpProtocol.HTTP11)
+                        .headers(headers -> headers
+                                .add(HttpHeaderNames.CONNECTION, "keep-alive")
+                                .add(HttpHeaderNames.KEEP_ALIVE, "timeout=5, max=100")
+                        )
+                        .get()
+                        .uri("http://localhost:" + port + "/index.html")
+                        .response()
+                        .block();
+            }
+            // The request itself must succeed: pre-fix this would 503 once the connection switches to H2
+            // and Netty's H2 encoder rejects the forwarded Keep-Alive header.
+            assertThat(response, is(notNullValue()));
+            assertThat(response.status(), is(HttpResponseStatus.OK));
+            // And the backend must never see Keep-Alive — regardless of which protocol the proxy used
+            // to talk to it.
+            assertThat(capturedRequestHeaders.get(), is(notNullValue()));
+            assertThat(capturedRequestHeaders.get().get(HttpHeaderNames.KEEP_ALIVE), is(nullValue()));
+        } finally {
+            h2cBackend.disposeNow();
+        }
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerReloadGuardTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerReloadGuardTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.carapaceproxy.server.certificates;
+
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.AVAILABLE;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.REQUEST_FAILED;
+import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.hasAnyBindingChange;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.util.Map;
+import java.util.Set;
+import org.carapaceproxy.configstore.CertificateData;
+import org.junit.Test;
+
+/**
+ * Tests for the listener-reload gate added in {@link DynamicCertificatesManager#hasAnyBindingChange}.
+ * Each test name describes the high-level behaviour driven by the predicate: when it returns
+ * {@code false}, the reload skips {@code server.getListeners().reloadCurrentConfiguration()}.
+ */
+public class DynamicCertificatesManagerReloadGuardTest {
+
+    private static final byte[] KEYSTORE_A = {0x10, 0x11, 0x12};
+    private static final byte[] KEYSTORE_B = {0x20, 0x21, 0x22};
+
+    @Test
+    public void testReloadSkipsListenerWhenNoCertChanged() {
+        final CertificateData stable = certWithKeystore("example.com", KEYSTORE_A);
+        final Map<String, CertificateData> old = Map.of("example.com", stable);
+        final Map<String, CertificateData> fresh = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_A.clone()));
+        assertFalse(hasAnyBindingChange(old, fresh));
+    }
+
+    @Test
+    public void testReloadTriggersListenerOnKeystoreChange() {
+        final Map<String, CertificateData> old = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_A));
+        final Map<String, CertificateData> fresh = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_B));
+        assertTrue(hasAnyBindingChange(old, fresh));
+    }
+
+    @Test
+    public void testReloadTriggersListenerOnDomainAdded() {
+        final Map<String, CertificateData> old = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_A));
+        final Map<String, CertificateData> fresh = Map.of(
+                "example.com", certWithKeystore("example.com", KEYSTORE_A.clone()),
+                "second.example.com", certWithKeystore("second.example.com", KEYSTORE_B));
+        assertTrue(hasAnyBindingChange(old, fresh));
+    }
+
+    @Test
+    public void testReloadTriggersListenerOnDomainRemoved() {
+        final Map<String, CertificateData> old = Map.of(
+                "example.com", certWithKeystore("example.com", KEYSTORE_A),
+                "second.example.com", certWithKeystore("second.example.com", KEYSTORE_B));
+        final Map<String, CertificateData> fresh = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_A.clone()));
+        assertTrue(hasAnyBindingChange(old, fresh));
+    }
+
+    @Test
+    public void testReloadSkipsListenerWhenOnlyAttemptsCountIncremented() {
+        // Exact staging symptom: a stuck ACME order ticks attemptsCount+message+state every poll
+        // while keystoreData stays at its last successful value (or null on a brand-new domain).
+        final CertificateData stuckPrev = certWithKeystore("stuck.example.com", null);
+        stuckPrev.setState(REQUEST_FAILED);
+        stuckPrev.setAttemptsCount(10);
+        stuckPrev.setMessage("Challenge response verification failed, status is INVALID");
+
+        final CertificateData stuckTicked = certWithKeystore("stuck.example.com", null);
+        stuckTicked.setState(REQUEST_FAILED);
+        stuckTicked.setAttemptsCount(11);
+        stuckTicked.setMessage("Challenge response verification failed, status is INVALID");
+
+        final Map<String, CertificateData> old = Map.of("stuck.example.com", stuckPrev);
+        final Map<String, CertificateData> fresh = Map.of("stuck.example.com", stuckTicked);
+        assertFalse(hasAnyBindingChange(old, fresh));
+    }
+
+    @Test
+    public void testReloadTriggersListenerOnSanChange() {
+        final CertificateData oldCert = certWithKeystoreAndSans("example.com", KEYSTORE_A, Set.of("alt.example.com"));
+        final CertificateData freshCert = certWithKeystoreAndSans("example.com", KEYSTORE_A.clone(), Set.of("other.example.com"));
+        final Map<String, CertificateData> old = Map.of("example.com", oldCert);
+        final Map<String, CertificateData> fresh = Map.of("example.com", freshCert);
+        assertTrue(hasAnyBindingChange(old, fresh));
+    }
+
+    private static CertificateData certWithKeystore(final String domain, final byte[] keystoreData) {
+        return certWithKeystoreAndSans(domain, keystoreData, null);
+    }
+
+    private static CertificateData certWithKeystoreAndSans(final String domain, final byte[] keystoreData, final Set<String> sans) {
+        final CertificateData cert = new CertificateData(domain, sans, null, AVAILABLE, null, null);
+        cert.setKeystoreData(keystoreData);
+        return cert;
+    }
+}

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/HttpUtilsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/HttpUtilsTest.java
@@ -1,0 +1,107 @@
+package org.carapaceproxy.utils;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import org.junit.Test;
+
+public class HttpUtilsTest {
+
+    @Test
+    public void testStripHopByHopHeaders_standardHeaders() {
+        final HttpHeaders headers = new DefaultHttpHeaders();
+        headers.add(HttpHeaderNames.HOST, "example.com");
+        headers.add(HttpHeaderNames.CONTENT_TYPE, "text/html");
+        headers.add(HttpHeaderNames.CONNECTION, "keep-alive");
+        headers.add(HttpHeaderNames.KEEP_ALIVE, "timeout=5, max=100");
+        headers.add(HttpHeaderNames.TRANSFER_ENCODING, "chunked");
+        headers.add(HttpHeaderNames.UPGRADE, "websocket");
+        headers.add(HttpHeaderNames.TE, "trailers");
+        headers.add(HttpHeaderNames.TRAILER, "Expires");
+        headers.add(HttpHeaderNames.PROXY_AUTHENTICATE, "Basic realm=\"test\"");
+        headers.add(HttpHeaderNames.PROXY_AUTHORIZATION, "Basic dXNlcjpwYXNz");
+        headers.add("proxy-connection", "keep-alive");
+
+        HttpUtils.stripHopByHopHeaders(headers);
+
+        // End-to-end headers must be preserved
+        assertThat(headers.get(HttpHeaderNames.HOST), is("example.com"));
+        assertThat(headers.get(HttpHeaderNames.CONTENT_TYPE), is("text/html"));
+
+        // Hop-by-hop headers must be stripped
+        assertThat(headers.get(HttpHeaderNames.CONNECTION), is(nullValue()));
+        assertThat(headers.get(HttpHeaderNames.KEEP_ALIVE), is(nullValue()));
+        assertThat(headers.get(HttpHeaderNames.UPGRADE), is(nullValue()));
+        assertThat(headers.get(HttpHeaderNames.TE), is(nullValue()));
+        assertThat(headers.get(HttpHeaderNames.TRAILER), is(nullValue()));
+        assertThat(headers.get(HttpHeaderNames.PROXY_AUTHENTICATE), is(nullValue()));
+        assertThat(headers.get(HttpHeaderNames.PROXY_AUTHORIZATION), is(nullValue()));
+        assertThat(headers.get("proxy-connection"), is(nullValue()));
+
+        // Transfer-Encoding is intentionally NOT stripped by stripHopByHopHeaders:
+        // Reactor Netty's HTTP/2 codec enforces its removal at the wire level (RFC 9113 §8.2.2),
+        // and stripping it here would break HTTP/1.1 chunked proxying.
+        assertThat(headers.get(HttpHeaderNames.TRANSFER_ENCODING), is("chunked"));
+    }
+
+    @Test
+    public void testStripHopByHopHeaders_dynamicNomination() {
+        // RFC 7230 §6.1: any header listed in the Connection header value is also hop-by-hop
+        final HttpHeaders headers = new DefaultHttpHeaders();
+        headers.add(HttpHeaderNames.HOST, "example.com");
+        headers.add("x-custom-connection-option", "some-value");
+        headers.add("another-option", "another-value");
+        headers.add(HttpHeaderNames.CONNECTION, "x-custom-connection-option, another-option");
+
+        HttpUtils.stripHopByHopHeaders(headers);
+
+        assertThat(headers.get(HttpHeaderNames.HOST), is("example.com"));
+        // Both the Connection header itself and the dynamically nominated headers must be stripped
+        assertThat(headers.get(HttpHeaderNames.CONNECTION), is(nullValue()));
+        assertThat(headers.get("x-custom-connection-option"), is(nullValue()));
+        assertThat(headers.get("another-option"), is(nullValue()));
+    }
+
+    @Test
+    public void testStripHopByHopHeaders_multipleConnectionValues() {
+        // Connection header may have multiple values across multiple header entries
+        final HttpHeaders headers = new DefaultHttpHeaders(false);  // false = allow duplicate header names
+        headers.add(HttpHeaderNames.HOST, "example.com");
+        headers.add("opt-a", "val-a");
+        headers.add("opt-b", "val-b");
+        headers.add(HttpHeaderNames.CONNECTION, "opt-a");
+        headers.add(HttpHeaderNames.CONNECTION, "opt-b");
+
+        HttpUtils.stripHopByHopHeaders(headers);
+
+        assertThat(headers.get(HttpHeaderNames.HOST), is("example.com"));
+        assertThat(headers.get(HttpHeaderNames.CONNECTION), is(nullValue()));
+        assertThat(headers.get("opt-a"), is(nullValue()));
+        assertThat(headers.get("opt-b"), is(nullValue()));
+    }
+
+    @Test
+    public void testStripHopByHopHeaders_noHopByHopHeaders() {
+        // Headers with no hop-by-hop headers are left unchanged
+        final HttpHeaders headers = new DefaultHttpHeaders();
+        headers.add(HttpHeaderNames.HOST, "example.com");
+        headers.add(HttpHeaderNames.CONTENT_TYPE, "application/json");
+        headers.add(HttpHeaderNames.CONTENT_LENGTH, "42");
+
+        HttpUtils.stripHopByHopHeaders(headers);
+
+        assertThat(headers.get(HttpHeaderNames.HOST), is("example.com"));
+        assertThat(headers.get(HttpHeaderNames.CONTENT_TYPE), is("application/json"));
+        assertThat(headers.get(HttpHeaderNames.CONTENT_LENGTH), is("42"));
+    }
+
+    @Test
+    public void testStripHopByHopHeaders_emptyHeaders() {
+        final HttpHeaders headers = new DefaultHttpHeaders();
+        HttpUtils.stripHopByHopHeaders(headers);
+        assertThat(headers.isEmpty(), is(true));
+    }
+}


### PR DESCRIPTION
This PR was opened against the wrong target (upstream instead of the maintainer's fork) and was closed for that reason. The original description has been redacted.