### PR TITLE
fix: stop mangling ZooKeeper client property names

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
@@ -795,7 +795,7 @@ public class HttpProxyServer implements AutoCloseable {
                 zkAddress = staticConfiguration.getString("zkAddress", "localhost:2181");
                 zkSecure = staticConfiguration.getBoolean("zkSecure", false);
                 zkTimeout = staticConfiguration.getInt("zkTimeout", 40_000);
-                zkProperties = new Properties(staticConfiguration.asProperties("zookeeper."));
+                zkProperties = new Properties(staticConfiguration.asProperties("zookeeper"));
                 LOG.info("mode=cluster, zkAddress=\"{}\", zkTimeout={}, peer.id=\"{}\", zkSecure: {}", zkAddress, zkTimeout, peerId, zkSecure);
                 zkProperties.forEach((k, v) -> LOG.info("additional zkclient property: {}={}", k, v));
                 break;


### PR DESCRIPTION
## Context

`ConfigurationStore.asProperties(prefix)` returns the properties under a prefix, stripping one character past the prefix length to drop the dot separator:

```java
copy.put(k.substring(prefix.length() + 1), v);
```

The ZooKeeper caller passed the prefix *with* a trailing dot (`"zookeeper."`), so the `+ 1` ate the first letter of every key — `zookeeper.clientCnxnSocket` became `lientCnxnSocket` and was silently ignored by the ZooKeeper client. The `db` caller already passes its prefix without the trailing dot, so it works by coincidence.

This is masked in most deployments because they rely on ZooKeeper client defaults; it bites any cluster that sets custom `zookeeper.*` client properties.

## Approach

Pass the prefix without the trailing dot, matching the `db` caller:

```java
- asProperties("zookeeper.")
+ asProperties("zookeeper")
```