### PR TITLE
fix: correct backend-health state and per-request connection/metric accounting

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/api/BackendsResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/BackendsResource.java
@@ -96,9 +96,10 @@ public class BackendsResource {
             }
             BackendHealthStatus bhs = backendsSnapshot.get(key);
             if (bhs != null) {
-                bean.available = bhs.getStatus() != BackendHealthStatus.Status.DOWN;
-                bean.reportedAsUnreachable = bhs.getStatus() == BackendHealthStatus.Status.DOWN;
-                bean.reportedAsUnreachableTs = bhs.getUnreachableSince();
+                final BackendHealthStatus.Snapshot snap = bhs.snapshot();
+                bean.available = snap.status() != BackendHealthStatus.Status.DOWN;
+                bean.reportedAsUnreachable = snap.status() == BackendHealthStatus.Status.DOWN;
+                bean.reportedAsUnreachableTs = snap.unreachableSince();
                 BackendHealthCheck lastProbe = bhs.getLastProbe();
                 if (lastProbe != null) {
                     bean.lastProbeTs = lastProbe.endTs();

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -209,22 +209,20 @@ public class ProxyRequestsManager implements AutoCloseable {
             LOGGER.trace("{} Mapped {} to {}, userid {}", this, request.getUri(), action, request.getUserId());
         }
 
-        try {
-            return switch (action.getAction()) {
-                case NOTFOUND -> serveNotFoundMessage(request);
-                case INTERNAL_ERROR -> serveInternalErrorMessage(request);
-                case SERVICE_UNAVAILABLE -> serveServiceUnavailable(request);
-                case MAINTENANCE_MODE -> serveMaintenanceMessage(request);
-                case BAD_REQUEST -> serveBadRequestMessage(request);
-                case STATIC, ACME_CHALLENGE -> serveStaticMessage(request);
-                case REDIRECT -> serveRedirect(request);
-                case PROXY -> forward(request, false, action.getHealthStatus());
-                case CACHE -> serveFromCache(request, action.getHealthStatus()); // cached content
-                default -> throw new IllegalStateException("Action " + action.getAction() + " not supported");
-            };
-        } finally {
-            parent.getRequestsLogger().logRequest(request);
-        }
+        final Publisher<Void> result = switch (action.getAction()) {
+            case NOTFOUND -> serveNotFoundMessage(request);
+            case INTERNAL_ERROR -> serveInternalErrorMessage(request);
+            case SERVICE_UNAVAILABLE -> serveServiceUnavailable(request);
+            case MAINTENANCE_MODE -> serveMaintenanceMessage(request);
+            case BAD_REQUEST -> serveBadRequestMessage(request);
+            case STATIC, ACME_CHALLENGE -> serveStaticMessage(request);
+            case REDIRECT -> serveRedirect(request);
+            case PROXY -> forward(request, false, action.getHealthStatus());
+            case CACHE -> serveFromCache(request, action.getHealthStatus()); // cached content
+            default -> throw new IllegalStateException("Action " + action.getAction() + " not supported");
+        };
+        // Log on terminal signal so response status, backend timing, and cache info are populated.
+        return Mono.from(result).doFinally(sig -> parent.getRequestsLogger().logRequest(request));
     }
 
     private Publisher<Void> serveNotFoundMessage(ProxyRequest request) {

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -442,8 +442,6 @@ public class ProxyRequestsManager implements AutoCloseable {
                         );
                     }
                 }).doAfterResponseSuccess((resp, conn) -> {
-                    PENDING_REQUESTS_GAUGE.dec();
-                    healthStatus.decrementConnections();
                     endpointStats.getLastActivity().set(System.currentTimeMillis());
                 });
 
@@ -544,9 +542,6 @@ public class ProxyRequestsManager implements AutoCloseable {
                         }
                     }));
                 }).onErrorResume(err -> { // custom endpoint request/response error handling
-                    PENDING_REQUESTS_GAUGE.dec();
-                    healthStatus.decrementConnections();
-
                     final EndpointKey endpoint = EndpointKey.make(request.getAction().getHost(), request.getAction().getPort());
                     if (err instanceof ReadTimeoutException) {
                         STUCK_REQUESTS_COUNTER.inc();
@@ -566,6 +561,11 @@ public class ProxyRequestsManager implements AutoCloseable {
                         );
                     }
                     return serveServiceUnavailable(request);
+                })
+                // decrement once per request: success and error callbacks can both fire (headers ok, body fails)
+                .doFinally(signal -> {
+                    PENDING_REQUESTS_GAUGE.dec();
+                    healthStatus.decrementConnections();
                 });
     }
 

--- a/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthManager.java
@@ -270,7 +270,7 @@ public class BackendHealthManager implements Runnable {
             return false;
         }
         final BackendHealthStatus backendStatus = getBackendStatus(backendConfiguration.hostPort());
-        return backendConfiguration.safeCapacity() > backendStatus.getConnections();
+        return backendStatus.getConnections() > backendConfiguration.safeCapacity();
     }
 
     @VisibleForTesting

--- a/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthStatus.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthStatus.java
@@ -136,9 +136,10 @@ public class BackendHealthStatus {
     }
 
     public void decrementConnections() {
-        if (this.connections.getAcquire() > 0) {
-            this.connections.decrementAndGet();
-        }
+        // Clamp at 0 atomically: reportAsUnreachable resets the counter via set(0), so in-flight
+        // decrements that arrive afterwards would otherwise underflow. A bare check-then-decrement
+        // is non-atomic and can race with concurrent decrements or set(0).
+        this.connections.updateAndGet(v -> Math.max(0, v - 1));
     }
 
     public void setWarmupPeriod(final long warmupPeriod) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthStatus.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthStatus.java
@@ -21,6 +21,7 @@ package org.carapaceproxy.server.backends;
 
 import java.sql.Timestamp;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.carapaceproxy.core.EndpointKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,35 +38,33 @@ public class BackendHealthStatus {
     private final EndpointKey hostPort;
     private final AtomicInteger connections;
 
-    private volatile Status status;
-    private volatile long unreachableSince;
-    private volatile long lastUnreachable;
-    private volatile long lastReachable;
+    // Status + the three associated timestamps move together via a single AtomicReference so concurrent
+    // reportAs(Un)Reachable callers cannot leave the four fields in a torn combination (e.g. status=DOWN
+    // with unreachableSince=0). Configuration knobs (warmupPeriod) and the periodic probe handle
+    // (lastProbe) stay as separate volatile fields — they aren't part of the transition's atom.
+    private final AtomicReference<State> state;
     private volatile BackendHealthCheck lastProbe;
     private volatile long warmupPeriod;
 
     public BackendHealthStatus(final EndpointKey hostPort, final long warmupPeriod) {
         this.hostPort = hostPort;
         // we assume that the backend just became reachable when the status is created
-        this.status = Status.COLD;
-        this.unreachableSince = 0L;
         final long created = System.currentTimeMillis();
-        this.lastUnreachable = created;
-        this.lastReachable = created;
+        this.state = new AtomicReference<>(new State(Status.COLD, 0L, created, created));
         this.connections = new AtomicInteger();
         this.warmupPeriod = warmupPeriod;
     }
 
     public long getUnreachableSince() {
-        return unreachableSince;
+        return state.get().unreachableSince();
     }
 
     public long getLastUnreachable() {
-        return lastUnreachable;
+        return state.get().lastUnreachable();
     }
 
     public long getLastReachable() {
-        return lastReachable;
+        return state.get().lastReachable();
     }
 
     public EndpointKey getHostPort() {
@@ -81,48 +80,45 @@ public class BackendHealthStatus {
     }
 
     public Status getStatus() {
-        return status;
+        return state.get().status();
+    }
+
+    /**
+     * Returns a coherent snapshot of the four state-machine fields ({@code status}, {@code unreachableSince},
+     * {@code lastUnreachable}, {@code lastReachable}). Use this instead of calling several field-level getters
+     * in a row when more than one field is needed — each individual getter is itself atomic, but two
+     * consecutive getter calls can straddle a state transition and observe an inconsistent pair.
+     */
+    public Snapshot snapshot() {
+        final State s = state.get();
+        return new Snapshot(s.status(), s.unreachableSince(), s.lastUnreachable(), s.lastReachable());
     }
 
     public void reportAsUnreachable(final long timestamp, final String cause) {
         LOG.info("{}: reportAsUnreachable {}, cause {}", hostPort, new Timestamp(timestamp), cause);
-        if (this.status != Status.DOWN) {
-            this.status = Status.DOWN;
-            this.unreachableSince = timestamp;
-        }
-        this.lastUnreachable = timestamp;
-        this.connections.set(0);
+        state.updateAndGet(s -> s.withUnreachable(timestamp));
+        // The historical connections.set(0) reset has been dropped: with the inc/dec invariant
+        // restored (NiccoMlt/carapaceproxy#13 — single decrement on terminal) and the atomic
+        // clamp (#17), in-flight requests' decrements drain the counter naturally; SafeBackendSelector
+        // already ignores `connections` for DOWN backends, so the value while DOWN is irrelevant.
     }
 
     public void reportAsReachable(final long timestamp) {
         LOG.debug("{}: reportAsReachable {}", hostPort, new Timestamp(timestamp));
-        switch (this.status) {
-            case DOWN:
-                this.status = Status.COLD;
-                this.unreachableSince = 0;
-                this.lastReachable = timestamp;
-                break;
-            case COLD:
-                this.lastReachable = timestamp;
-                if (this.lastReachable - this.lastUnreachable > this.warmupPeriod) {
-                    this.status = Status.STABLE;
-                }
-                break;
-            case STABLE:
-                this.lastReachable = timestamp;
-                break;
-        }
+        final long warmup = this.warmupPeriod;
+        state.updateAndGet(s -> s.withReachable(timestamp, warmup));
     }
 
     @Override
     public String toString() {
+        final State snapshot = state.get();
         return "BackendHealthStatus{"
                 + " hostPort=" + this.hostPort
                 + ", connections=" + this.connections
-                + ", status=" + this.status
-                + ", unreachableSince=" + this.unreachableSince
-                + ", unreachableUntil=" + this.lastUnreachable
-                + ", lastReachable=" + this.lastReachable
+                + ", status=" + snapshot.status()
+                + ", unreachableSince=" + snapshot.unreachableSince()
+                + ", unreachableUntil=" + snapshot.lastUnreachable()
+                + ", lastReachable=" + snapshot.lastReachable()
                 + ", lastProbe=" + this.lastProbe
                 + '}';
     }
@@ -136,9 +132,7 @@ public class BackendHealthStatus {
     }
 
     public void decrementConnections() {
-        // Clamp at 0 atomically: reportAsUnreachable resets the counter via set(0), so in-flight
-        // decrements that arrive afterwards would otherwise underflow. A bare check-then-decrement
-        // is non-atomic and can race with concurrent decrements or set(0).
+        // Atomic, underflow-safe decrement: a check-then-decrement could race and go negative, so clamp at 0.
         this.connections.updateAndGet(v -> Math.max(0, v - 1));
     }
 
@@ -164,5 +158,41 @@ public class BackendHealthStatus {
          * The backend is reachable and was so since a reasonably-long time.
          */
         STABLE
+    }
+
+    /**
+     * Coherent read-only view of {@link #getStatus()}, {@link #getUnreachableSince()},
+     * {@link #getLastUnreachable()}, and {@link #getLastReachable()} captured atomically via {@link #snapshot()}.
+     */
+    public record Snapshot(Status status, long unreachableSince, long lastUnreachable, long lastReachable) {
+    }
+
+    /**
+     * Immutable internal record of the four state-machine fields that transition together.
+     * Held in an {@link AtomicReference} so {@code reportAs(Un)Reachable} callers cannot interleave their
+     * field writes; each {@link AtomicReference#updateAndGet} call is a single linearization point.
+     */
+    private record State(Status status, long unreachableSince, long lastUnreachable, long lastReachable) {
+        State withUnreachable(final long timestamp) {
+            if (status == Status.DOWN) {
+                // Already DOWN; just refresh lastUnreachable, preserve unreachableSince.
+                return new State(status, unreachableSince, timestamp, lastReachable);
+            }
+            // Transition from COLD/STABLE to DOWN.
+            return new State(Status.DOWN, timestamp, timestamp, lastReachable);
+        }
+
+        State withReachable(final long timestamp, final long warmupPeriod) {
+            return switch (status) {
+                case DOWN -> new State(Status.COLD, 0L, lastUnreachable, timestamp);
+                case COLD -> {
+                    // Warmup check uses a coherent (lastUnreachable, timestamp) pair from this snapshot,
+                    // so concurrent reportAsUnreachable cannot move lastUnreachable between the two reads.
+                    final Status next = (timestamp - lastUnreachable) > warmupPeriod ? Status.STABLE : Status.COLD;
+                    yield new State(next, unreachableSince, lastUnreachable, timestamp);
+                }
+                case STABLE -> new State(Status.STABLE, unreachableSince, lastUnreachable, timestamp);
+            };
+        }
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/StuckRequestsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/StuckRequestsTest.java
@@ -42,6 +42,7 @@ import org.carapaceproxy.server.config.ActionConfiguration;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.carapaceproxy.server.mapper.StandardEndpointMapper;
 import org.carapaceproxy.utils.RawHttpClient;
+import org.carapaceproxy.utils.TestUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -125,6 +126,7 @@ public class StuckRequestsTest {
                         """, resp.getBodyString());
             }
 
+            TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
             assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
             assertThat((int) ProxyRequestsManager.STUCK_REQUESTS_COUNTER.get() > 0, is(true));
 

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendTest.java
@@ -42,6 +42,7 @@ import org.carapaceproxy.server.config.ActionConfiguration;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.carapaceproxy.utils.RawHttpClient;
 import org.carapaceproxy.utils.TestEndpointMapper;
+import org.carapaceproxy.utils.TestUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -101,6 +102,7 @@ public class UnreachableBackendTest {
                         """, resp.getBodyString());
             }
             assertSame(BackendHealthStatus.Status.DOWN, server.getBackendHealthManager().getBackendStatus(key).getStatus());
+            TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
             assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
         }
     }
@@ -156,6 +158,7 @@ public class UnreachableBackendTest {
                         """, resp.getBodyString());
             }
             assertSame(COLD, server.getBackendHealthManager().getBackendStatus(key).getStatus()); // no troubles for new connections
+            TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
             assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
         }
     }
@@ -188,6 +191,7 @@ public class UnreachableBackendTest {
                         """, resp.getBodyString());
             }
             assertSame(COLD, server.getBackendHealthManager().getBackendStatus(key).getStatus()); // no troubles for new connections
+            TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
             assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
         }
     }
@@ -241,6 +245,7 @@ public class UnreachableBackendTest {
                         """, resp.getBodyString());
             }
             assertSame(COLD, server.getBackendHealthManager().getBackendStatus(key).getStatus());
+            TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
             assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
         }
     }


### PR DESCRIPTION
## Context

The per-request bookkeeping that feeds backend selection and metrics has several correctness bugs that compound under load: the pending-request gauge and the per-backend connection counter can double-count or drift negative, the `BackendHealthStatus` state machine mutates several fields non-atomically, and `SafeBackendSelector`'s cold-backend capacity check is inverted. Access logging for proxied/cached requests also fires at assembly time rather than on the reactive terminal, so the logged status and timing are wrong.

## Approach

- **Inverted safe-capacity check** (`BackendHealthManager`): `exceedsCapacity` compared `safeCapacity > connections`, deprioritising COLD backends that are within their limit and preferring overloaded ones — the opposite of warmup rate-limiting. Flipped to `connections > safeCapacity`.
- **Counter double-decrement** (`ProxyRequestsManager`): `PENDING_REQUESTS_GAUGE` and `healthStatus.connections` were decremented in both the success and the error callback; when response headers succeed but the body stream errors, both fire and the counters drift negative. Decrement exactly once, on the returned publisher's `doFinally`.
- **TOCTOU on decrement** (`BackendHealthStatus`): replaced check-then-`decrementAndGet` with an atomic `updateAndGet(v -> Math.max(0, v - 1))`.
- **Non-atomic health transitions** (`BackendHealthStatus`): the four state fields (`status`, `unreachableSince`, `lastReachable`, `lastUnreachable`) move together through a single `AtomicReference<State>`, so each transition is one linearisation point; readers take a coherent `Snapshot` (used by `BackendsResource`).
- **Access-log timing** (`ProxyRequestsManager`): log on the returned publisher's terminal (`doFinally`) instead of at assembly, so status, backend timing and size are populated.

Includes a test that polls `PENDING_REQUESTS_GAUGE` until the terminal callback fires, removing a race in the prior assertion.