### PR TITLE
fix: make dynamic configuration reload atomic, visible, and lossless

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
@@ -742,11 +742,14 @@ public class HttpProxyServer implements AutoCloseable {
             throw new ConfigurationChangeInProgressException();
         }
         try {
+            // Build everything as locals first; do not touch the four `this.X` view fields yet.
             RuntimeServerConfiguration newConfiguration = buildValidConfiguration(storeWithConfig);
             EndpointMapper newMapper = buildMapper(newConfiguration.getMapperClassname(), this, storeWithConfig);
             UserRealm newRealm = buildRealm(userRealmClassname, storeWithConfig);
+            List<RequestFilter> newFilters = buildFilters(newConfiguration);
 
-            this.filters = buildFilters(newConfiguration);
+            // Reload subsystems. Any of these can throw; if it does, the four view fields below
+            // are left untouched, so request-time readers keep seeing a coherent old snapshot.
             this.backendHealthManager.reloadConfiguration(newConfiguration, newMapper);
             this.dynamicCertificatesManager.reloadConfiguration(newConfiguration);
             this.trustStoreManager.reloadConfiguration(newConfiguration);
@@ -754,10 +757,8 @@ public class HttpProxyServer implements AutoCloseable {
             this.listeners.reloadConfiguration(newConfiguration);
             this.cache.reloadConfiguration(newConfiguration);
             this.requestsLogger.reloadConfiguration(newConfiguration);
-            this.realm = newRealm;
             Map<String, BackendConfiguration> currentBackends = mapper != null ? mapper.getBackends() : Collections.emptyMap();
             Map<String, BackendConfiguration> newBackends = newMapper.getBackends();
-            this.mapper = newMapper;
 
             if (!newBackends.equals(currentBackends) || isConnectionsConfigurationChanged(newConfiguration)) {
                 proxyRequestsManager.reloadConfiguration(newConfiguration, newBackends.values());
@@ -767,6 +768,12 @@ public class HttpProxyServer implements AutoCloseable {
                 dynamicConfigurationStore.commitConfiguration(newConfigurationStore);
             }
 
+            // Commit point: every subsystem has reloaded and persistence succeeded; swap the four
+            // view fields back-to-back so the cross-field tearing window observed by readers shrinks
+            // from the full subsystem-reload duration to a handful of volatile writes.
+            this.filters = newFilters;
+            this.realm = newRealm;
+            this.mapper = newMapper;
             this.currentConfiguration = newConfiguration;
         } catch (ConfigurationNotValidException err) {
             // impossible to have a non valid configuration here

--- a/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
@@ -173,23 +173,23 @@ public class HttpProxyServer implements AutoCloseable {
     private OcspStaplingManager ocspStaplingManager;
 
     @Getter
-    private RuntimeServerConfiguration currentConfiguration;
+    private volatile RuntimeServerConfiguration currentConfiguration;
 
     @Getter
     private ConfigurationStore dynamicConfigurationStore;
 
     @Getter
-    private EndpointMapper mapper;
+    private volatile EndpointMapper mapper;
 
     @Getter
     @Setter
-    private UserRealm realm;
+    private volatile UserRealm realm;
 
     @Getter
     private final TrustStoreManager trustStoreManager;
 
     @Getter
-    private List<RequestFilter> filters;
+    private volatile List<RequestFilter> filters;
     private volatile boolean started;
 
     @Getter

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -163,7 +163,13 @@ public class ProxyRequestsManager implements AutoCloseable {
             for (final BackendConfiguration backend : newEndpoints) {
                 final String path = backend.caCertificatePath();
                 if (!StringUtils.isBlank(path)) {
-                    if (clientSslContexts.containsKey(path)) {
+                    if (newContexts.containsKey(path)) {
+                        LOGGER.debug("SSL context for backend {} was already prepared from {}", backend.id(), path);
+                        continue;
+                    }
+                    final SslContext cached = clientSslContexts.get(path);
+                    if (cached != null) {
+                        newContexts.put(path, cached);
                         LOGGER.debug("SSL context for backend {} was already loaded from {}", backend.id(), path);
                     } else {
                         final SslContext sslContext = parent.getTrustStoreManager()


### PR DESCRIPTION
## Context

`applyDynamicConfiguration` had three independent integrity problems in how the proxy's view of the configuration is published and swapped during a hot reload, and in how per-backend client SSL contexts survive it. None changes the happy path; they bite on weakly-ordered CPUs, on partial reload failures, and on reloads that don't change the backend set.

## Approach

- **Stale config reads** (`HttpProxyServer`): `mapper`, `filters`, `currentConfiguration` and `realm` are written under `configurationLock` but read by Netty I/O threads that never take the lock — no happens-before, so after a reload a request thread can keep using the old mapper/filters/config indefinitely (only `started` was `volatile`). Mark the four fields `volatile`.

- **Torn swap on partial failure** (`HttpProxyServer`): those four view fields were assigned mid-reload, *before* the subsystem reloads and the DB commit had all succeeded — so a failure (e.g. a bad certificate) left some subsystems on the new config while the view fields straddled old/new. Stage them as locals and assign only after every subsystem `reloadConfiguration(...)` and the commit succeed.

- **Dropped client SSL contexts** (`ProxyRequestsManager`): when a backend's CA path was already cached, the reload logged "already loaded" but never copied the existing `SslContext` into the rebuilt map, so the backend-specific CA was lost and later requests silently fell back to the default trust store. Carry the cached context forward into the new map.