### PR TITLE
fix: enforce the request-smuggling (CL.TE) check at the proxy chokepoint

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -211,9 +211,13 @@ public class ProxyRequestsManager implements AutoCloseable {
         // HTTP/1.x request-smuggling validation runs on the raw inbound headers, before any request filter
         // or the mapper, so a filter that mutates Content-Length / Transfer-Encoding cannot bypass it.
         // HTTP/2 framing is not vulnerable.
-        final boolean smuggling = request.getHttpProtocol().majorVersion() < 2 && rejectAsSmuggling(request);
-        parent.getFilters().forEach(filter -> filter.apply(request));
-        final MapResult action = smuggling ? MapResult.badRequest() : parent.getMapper().map(request);
+        final MapResult action;
+        if (request.getHttpProtocol().majorVersion() < 2 && rejectAsSmuggling(request)) {
+            action = MapResult.badRequest();
+        } else {
+            parent.getFilters().forEach(filter -> filter.apply(request));
+            action = parent.getMapper().map(request);
+        }
         request.setAction(action);
 
         if (LOGGER.isTraceEnabled()) {

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -142,6 +142,15 @@ public class ProxyRequestsManager implements AutoCloseable {
         });
     }
 
+    private static boolean rejectAsSmuggling(ProxyRequest request) {
+        final HttpHeaders headers = request.getRequestHeaders();
+        if (headers.get(HttpHeaderNames.CONTENT_LENGTH) != null && headers.get(HttpHeaderNames.TRANSFER_ENCODING) != null) {
+            LOGGER.warn("Potential CL.TE request smuggling attack: both Content-Length and Transfer-Encoding present. Request: {}", request.getUri());
+            return true;
+        }
+        return false;
+    }
+
     private static void cleanRequestFromCacheValidators(ProxyRequest request) {
         HttpHeaders headers = request.getRequestHeaders();
         headers.remove(HttpHeaderNames.IF_MATCH);
@@ -199,10 +208,12 @@ public class ProxyRequestsManager implements AutoCloseable {
         request.setLastActivity(request.getStartTs());
         request.getRequestHeaders().set(HttpHeaderNames.SERVER, ServerHeaderRequestFilter.DEFAULT_SERVER);
 
+        // HTTP/1.x request-smuggling validation runs on the raw inbound headers, before any request filter
+        // or the mapper, so a filter that mutates Content-Length / Transfer-Encoding cannot bypass it.
+        // HTTP/2 framing is not vulnerable.
+        final boolean smuggling = request.getHttpProtocol().majorVersion() < 2 && rejectAsSmuggling(request);
         parent.getFilters().forEach(filter -> filter.apply(request));
-
-        MapResult action = parent.getMapper().map(request);
-
+        final MapResult action = smuggling ? MapResult.badRequest() : parent.getMapper().map(request);
         request.setAction(action);
 
         if (LOGGER.isTraceEnabled()) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/mapper/StandardEndpointMapper.java
@@ -26,8 +26,6 @@ import static org.carapaceproxy.core.StaticContentsManager.IN_MEMORY_RESOURCE;
 import com.google.common.net.HostAndPort;
 import com.google.common.net.InetAddresses;
 import com.google.common.net.InternetDomainName;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -147,30 +145,6 @@ public class StandardEndpointMapper extends EndpointMapper {
                 LOG.trace("Invalid header host {} for request {}", request.getRequestHostname(), request.getUri());
             }
             return MapResult.badRequest();
-        }
-
-        // CL.0 and CL.TE request smuggling validation
-        // HTTP/2 requests are not vulnerable to these attacks, so we only check HTTP/1.x
-        if (request.getHttpProtocol().majorVersion() < 2) {
-            HttpHeaders headers = request.getRequestHeaders();
-            String contentLength = headers.get(HttpHeaderNames.CONTENT_LENGTH);
-            String transferEncoding = headers.get(HttpHeaderNames.TRANSFER_ENCODING);
-
-            // Check for CL.TE attack: both Content-Length and Transfer-Encoding headers present
-            if (contentLength != null && transferEncoding != null) {
-                LOG.warn("Potential CL.TE request smuggling attack detected: both Content-Length and Transfer-Encoding headers present. Request: {}", request.getUri());
-                return MapResult.badRequest();
-            }
-
-            // Check for CL.0 attack: Content-Length: 0 but with body
-            if (contentLength != null && contentLength.trim().equals("0")) {
-                // It's OK to consume the string in the flux, as it should be empty anyway
-                final String body = request.getRequestData().asString().blockFirst();
-                if (body != null && !body.isEmpty()) {
-                    LOG.warn("Request with Content-Length: 0 but with body detected: {}", request.getUri());
-                    return MapResult.badRequest();
-                }
-            }
         }
 
         for (final RouteConfiguration route : routes) {


### PR DESCRIPTION
## Context

The request-smuggling mitigation lived inside `StandardEndpointMapper.map()`, which has two problems. Any custom or test `EndpointMapper` that overrides `map()` bypasses it entirely — including `RequestSmugglingVulnerabilityTest`, whose `TestEndpointMapper` meant the mitigation never actually ran in the test that was supposed to cover it. And the CL.0 branch did a blocking body read (`blockFirst()`) on a Netty event-loop thread: besides violating the non-blocking contract, it cannot catch the smuggle anyway — with `Content-Length: 0` the decoder frames any trailing bytes as the *next* pipelined request, so that read is always empty. (Refs #533.)

## Approach

Move the smuggling validation out of `StandardEndpointMapper` and into `ProxyRequestsManager.processRequest()`, ahead of the filter chain and the mapper call, so no `EndpointMapper` implementation can bypass it. Keep the header-only CL.TE rejection — a request carrying both `Content-Length` and `Transfer-Encoding` is rejected with `400` — and drop the broken, blocking CL.0 body-read entirely.

Pure CL.0 smuggling is intentionally **not** addressed here: the proxy layer can't reliably distinguish a pipelined-burst smuggle from ordinary sequential keep-alive reuse without channel-buffer inspection, so that case is left to end-to-end HTTP/2.