### PR TITLE
ci: stop submitting the dependency snapshot from PR validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -36,7 +36,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -59,8 +59,6 @@ jobs:
           retention-days: 7
       - name: 'Run validations with Maven'
         run: ./mvnw -B test --file pom.xml
-      - name: 'Submit Dependency Snapshot'
-        uses: advanced-security/maven-dependency-submission-action@v5
       - uses: actions/upload-artifact@v4
         if: always()
         with:


### PR DESCRIPTION
## Context

`pr-validation.yml` (triggered on `pull_request`) runs a `Submit Dependency Snapshot` step. On cross-fork PRs GitHub issues a read-only `GITHUB_TOKEN`, so the submission `POST .../dependency-graph/snapshots` returns `403 Resource not accessible by integration` and the build fails — even though the build and tests pass. (From a same-repo branch the token is full-permission and the step succeeds, which is why it only goes red on fork PRs.)

The dependency graph is a default-branch concern, and `master-snapshot.yml` already submits the snapshot on push to `master`, so the PR-time copy is both redundant and broken for forks.

## Approach

Remove the `Submit Dependency Snapshot` step from PR validation — `master-snapshot.yml` keeps the graph current on merge. Also narrow this workflow's `permissions` from `contents: write` to `contents: read`, since that write scope existed only for the now-removed step (build / test / upload-artifact need read).