### PR TITLE
Fix the Maven release workflow and harden CI

### DIFF
--- a/.github/actions/configure-git/action.yml
+++ b/.github/actions/configure-git/action.yml
@@ -1,0 +1,16 @@
+name: 'Configure Git'
+description: 'Configure the diennea-bot Git identity and set up the gh credential helper for pushes'
+inputs:
+  token:
+    description: 'GitHub App token used by the gh Git credential helper for pushes'
+    required: true
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        git config user.name "diennea-bot"
+        git config user.email "172403682+diennea-bot@users.noreply.github.com"
+        gh auth setup-git

--- a/.github/workflows/master-snapshot.yml
+++ b/.github/workflows/master-snapshot.yml
@@ -10,9 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: 'Set up JDK 21'
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -22,4 +22,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./mvnw -B deploy --file pom.xml -DskipTests -Pproduction
       - name: 'Submit Dependency Snapshot'
-        uses: advanced-security/maven-dependency-submission-action@v5
+        uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # v5.0.0

--- a/.github/workflows/master-snapshot.yml
+++ b/.github/workflows/master-snapshot.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: 'Set up JDK 21'
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:

--- a/.github/workflows/pr-validation-report.yml
+++ b/.github/workflows/pr-validation-report.yml
@@ -13,7 +13,7 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-      - uses: dorny/test-reporter@v2
+      - uses: dorny/test-reporter@v3
         with:
           artifact: test-results # as named in pr-validation workflow
           name: Maven Tests

--- a/.github/workflows/pr-validation-report.yml
+++ b/.github/workflows/pr-validation-report.yml
@@ -13,7 +13,7 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-      - uses: dorny/test-reporter@v3
+      - uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           artifact: test-results # as named in pr-validation workflow
           name: Maven Tests

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -25,6 +25,7 @@ on:
       - 'mvnw'
       - 'mvnw.cmd'
       - '.github/workflows/pr-validation.yml'
+      - '.github/workflows/pr-validation-report.yml'
 
 env:
   MAVEN_OPTS: >-
@@ -50,9 +51,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: 'Set up JDK 21'
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -17,6 +17,14 @@ name: PR Validation
 
 on:
   pull_request:
+    paths:
+      - 'carapace-server/**'
+      - 'carapace-ui/**'
+      - 'pom.xml'
+      - '.mvn/**'
+      - 'mvnw'
+      - 'mvnw.cmd'
+      - '.github/workflows/pr-validation.yml'
 
 env:
   MAVEN_OPTS: >-
@@ -51,7 +59,7 @@ jobs:
           cache: 'maven'
       - name: 'Build with Maven'
         run: ./mvnw -B package -DskipTests --file pom.xml
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: packages
@@ -59,7 +67,7 @@ jobs:
           retention-days: 7
       - name: 'Run validations with Maven'
         run: ./mvnw -B test --file pom.xml
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results # as expected by pr-validation-report workflow

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -59,7 +59,7 @@ jobs:
           cache: 'maven'
       - name: 'Build with Maven'
         run: ./mvnw -B package -DskipTests --file pom.xml
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: packages
@@ -67,7 +67,7 @@ jobs:
           retention-days: 7
       - name: 'Run validations with Maven'
         run: ./mvnw -B test --file pom.xml
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: test-results # as expected by pr-validation-report workflow

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -52,6 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: 'Set up JDK 21'
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Generate GitHub App token'
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
@@ -33,7 +33,7 @@ jobs:
           permission-contents: write
 
       - name: 'Checkout ${{ github.ref_name }} branch'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.ref_name }}
           token: ${{ steps.app-token.outputs.token }}
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 0
 
       - name: 'Set up JDK 21'
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -112,7 +112,7 @@ jobs:
 
       - if: ${{ inputs.bump == 'major' || inputs.bump == 'minor' }}
         name: 'Checkout ${{ inputs.bump }} release branch ${{ steps.compute_versions.outputs.branch_name }}'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ steps.compute_versions.outputs.branch_name }}
           token: ${{ steps.app-token.outputs.token }}
@@ -142,7 +142,7 @@ jobs:
 
       - name: 'Create GitHub Release'
         id: create_release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,12 +51,9 @@ jobs:
           server-password: GITHUB_TOKEN
 
       - name: 'Configure Git'
-        run: |
-            git config user.name "diennea-bot"
-            git config user.email "172403682+diennea-bot@users.noreply.github.com"
-            gh auth setup-git
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        uses: ./.github/actions/configure-git
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: 'Verify Git remote'
         run: |
@@ -124,12 +121,9 @@ jobs:
 
       - if: ${{ inputs.bump == 'major' || inputs.bump == 'minor' }}
         name: 'Reconfigure Git after branch checkout'
-        run: |
-          git config user.name 'diennea-bot'
-          git config user.email '172403682+diennea-bot@users.noreply.github.com'
-          gh auth setup-git
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        uses: ./.github/actions/configure-git
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: 'Prepare release ${{ inputs.bump }} version ${{ steps.compute_versions.outputs.release_version }} on branch ${{ steps.compute_versions.outputs.branch_name }}'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: 'Create GitHub Release'
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,9 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
+          server-id: github
+          server-username: ${{ github.actor }}
+          server-password: ${{ steps.app-token.outputs.token }}
 
       - name: 'Configure Git'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,28 @@ jobs:
     name: 'Perform ${{ inputs.bump }} release'
     runs-on: ubuntu-latest
     steps:
+      - name: 'Generate GitHub App token'
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-packages: write
+
+      - name: 'Get GitHub App User ID'
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+
       - name: 'Checkout ${{ github.ref_name }} branch'
         uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
-          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
           fetch-depth: 0
 
       - name: 'Set up JDK 21'
@@ -40,8 +57,13 @@ jobs:
 
       - name: 'Configure Git'
         run: |
-          git config user.name "Diennea[bot]"
-          git config user.email "172403682+diennea-bot@users.noreply.github.com"
+            git config user.name "${APP_SLUG}[bot]"
+            git config user.email "${USER_ID}+${APP_SLUG}[bot]`@users.noreply.github.com`"
+            gh auth setup-git
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          USER_ID: ${{ steps.get-user-id.outputs.user-id }}
 
       - name: 'Verify Git remote'
         run: |
@@ -91,7 +113,7 @@ jobs:
       - if: ${{ inputs.bump == 'major' || inputs.bump == 'minor' }}
         name: 'Create ${{ inputs.bump }} release branch ${{ steps.compute_versions.outputs.branch_name }}'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           ./mvnw release:clean release:branch \
               -DbranchName=${{ steps.compute_versions.outputs.branch_name }} \
@@ -103,10 +125,22 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ steps.compute_versions.outputs.branch_name }}
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
+          fetch-depth: 0
+
+      - if: ${{ inputs.bump == 'major' || inputs.bump == 'minor' }}
+        name: 'Reconfigure Git after branch checkout'
+        run: |
+          git config user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          gh auth setup-git
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: 'Prepare release ${{ inputs.bump }} version ${{ steps.compute_versions.outputs.release_version }} on branch ${{ steps.compute_versions.outputs.branch_name }}'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           ./mvnw release:clean release:prepare \
               -DreleaseVersion=${{ steps.compute_versions.outputs.release_version }} \
@@ -115,13 +149,15 @@ jobs:
 
       - name: 'Perform release'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           ./mvnw release:perform
 
       - name: 'Create GitHub Release'
         id: create_release
         uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           tag_name: ${{ steps.compute_versions.outputs.tag }}
           name: Release ${{ steps.compute_versions.outputs.release_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,14 +31,6 @@ jobs:
           client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           permission-contents: write
-          permission-packages: write
-
-      - name: 'Get GitHub App User ID'
-        id: get-user-id
-        run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
 
       - name: 'Checkout ${{ github.ref_name }} branch'
         uses: actions/checkout@v6
@@ -55,18 +47,16 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
           server-id: github
-          server-username: ${{ github.actor }}
-          server-password: ${{ steps.app-token.outputs.token }}
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
 
       - name: 'Configure Git'
         run: |
-            git config user.name "${APP_SLUG}[bot]"
-            git config user.email "${USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+            git config user.name "diennea-bot"
+            git config user.email "172403682+diennea-bot@users.noreply.github.com"
             gh auth setup-git
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-          USER_ID: ${{ steps.get-user-id.outputs.user-id }}
 
       - name: 'Verify Git remote'
         run: |
@@ -135,8 +125,8 @@ jobs:
       - if: ${{ inputs.bump == 'major' || inputs.bump == 'minor' }}
         name: 'Reconfigure Git after branch checkout'
         run: |
-          git config user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          git config user.name 'diennea-bot'
+          git config user.email '172403682+diennea-bot@users.noreply.github.com'
           gh auth setup-git
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -152,7 +142,7 @@ jobs:
 
       - name: 'Perform release'
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./mvnw release:perform
 
@@ -160,7 +150,7 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v2
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.compute_versions.outputs.tag }}
           name: Release ${{ steps.compute_versions.outputs.release_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
       - name: 'Configure Git'
         run: |
             git config user.name "${APP_SLUG}[bot]"
-            git config user.email "${USER_ID}+${APP_SLUG}[bot]`@users.noreply.github.com`"
+            git config user.email "${USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
             gh auth setup-git
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
+          persist-credentials: true
+          fetch-depth: 0
 
       - name: 'Set up JDK 21'
         uses: actions/setup-java@v5
@@ -41,10 +43,10 @@ jobs:
           git config user.name "Diennea[bot]"
           git config user.email "172403682+diennea-bot@users.noreply.github.com"
 
-      - name: 'Inject machine user SSH key into SSH agent'
-        uses: webfactory/ssh-agent@v0.9.1
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: 'Verify Git remote'
+        run: |
+          git remote -v
+          git config --get remote.origin.url
 
       - id: compute_versions
         name: 'Compute versions and branch name'

--- a/pom.xml
+++ b/pom.xml
@@ -71,10 +71,10 @@
     </modules>
 
     <scm>
-        <url>git@github.com:diennea/carapaceproxy.git</url>
+        <url>https://github.com/diennea/carapaceproxy</url>
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
-        <tag>release/2.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
Repairs the `Maven release` workflow so a release runs end-to-end (it previously failed at the deploy step) and cleans up how the release authenticates and attributes its commits.

### How the release authenticates (the core change)
The release needs two different credentials, and one token can't cover both:

- **Git pushes** to the protected `master` / `release/*` branches use a **GitHub App token** — it can bypass branch protection and attributes the release commits to a bot identity.
- **The Maven deploy and the GitHub Release** use the Actions **`GITHUB_TOKEN`**. This is required: the GitHub Packages Maven registry rejects GitHub App tokens, so only a PAT or `GITHUB_TOKEN` authenticates there. Published artifacts and the release show as `github-actions[bot]`.

### Other release fixes
- **`setup-java` credentials** — `server-username`/`server-password` take environment-variable *names*, not values; the previous literal values resolved to an empty password and a 401 on deploy.
- **`pom.xml` SCM** switched to the HTTPS URL with `<tag>HEAD`, so `maven-release-plugin` pushes over HTTPS (matching the token auth) instead of SSH.
- **Commit author** set to `diennea-bot`; the shared Git identity + credential-helper setup is extracted into a local composite action (`.github/actions/configure-git`), defined once and reused by both checkouts.

### Also in this PR (CI hygiene)
Pinned all external actions to commit SHAs, bumped `test-reporter` / `upload-artifact` / `action-gh-release` to their Node 24 majors, added a paths filter so PR validation skips non-code changes, and set `persist-credentials: false` on the read-only checkouts.