### PR TITLE
fix: match request.uri on the forwarded path (absolute-form ACL bypass)

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequest.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequest.java
@@ -143,7 +143,12 @@ public class ProxyRequest implements MatchingContext {
             return request.requestHeaders().get(name.substring(HEADERS_SUBSTRING_INDEX), "");
         }
         return switch (name) {
-            case PROPERTY_URI -> request.uri();
+            // Match on the same normalized path that is forwarded to the backend
+            // (see getUri()). Using the raw request.uri() here would let an
+            // absolute-form request target (scheme://authority/path) bypass a
+            // path-anchored route/ACL: the matcher would see "http://host/path"
+            // while the backend receives just "/path".
+            case PROPERTY_URI -> getUri();
             case PROPERTY_METHOD -> request.method().name();
             case PROPERTY_CONTENT_TYPE -> request.requestHeaders().get(HttpHeaderNames.CONTENT_TYPE, "");
             case PROPERTY_LISTENER_IPADDRESS -> getLocalAddress().getAddress().getHostAddress();

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequest.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequest.java
@@ -195,7 +195,7 @@ public class ProxyRequest implements MatchingContext {
                 uri = "/";
             }
         } else {
-            int pos = uri.indexOf(request.fullPath());
+            int pos = uri.indexOf(fullPath);
             if (pos > 0) {
                 uri = uri.substring(pos);
             }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/requestmatcher/RequestMatcherTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/requestmatcher/RequestMatcherTest.java
@@ -48,6 +48,7 @@ public class RequestMatcherTest {
     public void test() throws Exception {
         HttpServerRequest serverRequest = mock(HttpServerRequest.class);
         when(serverRequest.uri()).thenReturn("/test.html");
+        when(serverRequest.fullPath()).thenReturn("/test.html");
         when(serverRequest.method()).thenReturn(HttpMethod.GET);
         when(serverRequest.scheme()).thenReturn("https");
         when(serverRequest.protocol()).thenReturn("HTTP/2");
@@ -304,5 +305,24 @@ public class RequestMatcherTest {
             RequestMatcher matcher = new RequestMatchParser("listener.ipaddress = \"127.0.1.2\"").parse();
             assertFalse(matcher.matches(request));
         }
+    }
+
+    @Test
+    public void testAbsoluteFormRequestTargetMatchesPathRule() throws Exception {
+        // An absolute-form request target (scheme://authority/path) is valid HTTP/1.1 and
+        // is forwarded to the backend as just "/path" (see ProxyRequest.getUri()). A
+        // path-anchored route/ACL must therefore still match on "/path"; otherwise it can
+        // be bypassed by sending the same request in absolute form.
+        HttpServerRequest serverRequest = mock(HttpServerRequest.class);
+        when(serverRequest.uri()).thenReturn("http://victim.example/admin/secret");
+        when(serverRequest.fullPath()).thenReturn("/admin/secret");
+        when(serverRequest.method()).thenReturn(HttpMethod.GET);
+        when(serverRequest.scheme()).thenReturn("http");
+        when(serverRequest.protocol()).thenReturn("HTTP/1.1");
+
+        ProxyRequest request = new ProxyRequest(serverRequest, null, null);
+
+        RequestMatcher matcher = new RequestMatchParser("request.uri ~ \"/admin/.*\"").parse();
+        assertTrue(matcher.matches(request));
     }
 }


### PR DESCRIPTION
No linked issue — found by reviewing the request-matching vs. forwarding paths.

## Summary (security)

A route/ACL written against `request.uri` can be **bypassed by sending the request in absolute-form**, because the matcher and the backend evaluate two different views of the request path.

- The matcher property `request.uri` returns the raw `request.uri()` — for an absolute-form request target this is `http://host/path` (`ProxyRequest.getProperty`, `PROPERTY_URI`).
- The value actually **forwarded to the backend** is the normalized path from `getUri()`, which strips the `scheme://authority` prefix — i.e. just `/path` (`ProxyRequest.getUri()`, used at `ProxyRequestsManager.forward()`).
- `RegexpRequestMatcher` uses **full-match** semantics (`Pattern.matcher(...).matches()`).

So a path-anchored deny rule does not match the absolute form and is skipped:

```
# operator intends to block /admin
route.0.match  = request.uri ~ "/admin/.*"     # -> deny (403)
route.1.match  = all                            # -> proxy to backend
```

```
GET http://victim.example/admin/secret HTTP/1.1     # absolute-form, valid HTTP/1.1
Host: victim.example
```

- The matcher sees `http://victim.example/admin/secret`; the regex `/admin/.*` under `.matches()` must match the whole string (which starts with `http`), so **route 0 does not match** → the deny is skipped.
- The request falls through to route 1 (`all`) → PROXY. `getUri()` strips the scheme prefix, so the backend receives `GET /admin/secret` — **the resource the ACL was meant to block.**

**Impact:** CWE-436 (interpretation conflict between proxy and backend) / CWE-863 (incorrect authorization). Any deployment that uses a path-anchored `request.uri` rule as an access-control boundary is affected.

## Fix

Make the `request.uri` matcher property return `getUri()` — the same normalized path that is forwarded — so the matcher and the backend can never disagree. This is a **no-op for normal origin-form requests** (there `getUri()` equals `request.uri()`); it only changes the absolute-form case.

## Testing

Added `RequestMatcherTest.testAbsoluteFormRequestTargetMatchesPathRule`, which asserts that an absolute-form request target still matches a path-anchored rule (`request.uri ~ "/admin/.*"`). It fails before the change and passes after. The existing `RequestMatcherTest` still passes (its request mock now also stubs `fullPath()`, which a real reactor-netty request always provides). Verified on a full Java 21 Maven build; no new checkstyle violations.