### PR TITLE
Fix config save stripping backslashes from property values

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationStore.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/ConfigurationStore.java
@@ -20,14 +20,17 @@
 package org.carapaceproxy.configstore;
 
 import herddb.utils.BooleanHolder;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
 import java.security.KeyPair;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
 import org.carapaceproxy.core.RuntimeServerConfiguration;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 
@@ -43,12 +46,28 @@ public interface ConfigurationStore extends AutoCloseable {
 
     String PROPERTY_VALUES_SEPARATOR = ",";
 
+    /**
+     * Serialize the configuration as a {@link Properties}-format string.
+     * <br>
+     * The output must round-trip through {@link Properties#load(java.io.Reader)} without altering values,
+     * so it is generated with {@link Properties#store(java.io.Writer, String)}, which escapes backslashes
+     * and other special characters.
+     *
+     * @return the configuration properties, one per line, sorted by key
+     */
     default String toStringConfiguration() {
-        Set<String> props = new TreeSet<>();
-        forEach((k, v) -> props.add(k + "=" + v));
-        StringBuilder builder = new StringBuilder();
-        props.forEach(p -> builder.append(p).append("\n"));
-        return builder.toString();
+        final Properties props = new Properties();
+        forEach(props::setProperty);
+        final StringWriter writer = new StringWriter();
+        try {
+            props.store(writer, null);
+        } catch (IOException impossible) {
+            throw new UncheckedIOException(impossible);
+        }
+        return writer.toString().lines()
+                .filter(line -> !line.startsWith("#")) // drop the timestamp comment store() always writes
+                .sorted()
+                .collect(Collectors.joining("\n", "", "\n"));
     }
 
     String getProperty(String key, String defaultValue);

--- a/carapace-server/src/test/java/org/carapaceproxy/api/ConnectionPoolsResourceTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/ConnectionPoolsResourceTest.java
@@ -191,6 +191,29 @@ public class ConnectionPoolsResourceTest extends UseAdminServer {
     }
 
     @Test
+    public void testRegexDomainSurvivesSubsequentSaves() throws Exception {
+        configureAndStartServer();
+        final var regexDomain = "(\\Qhost.example\\E|\\Qother.example\\E)";
+        try (final var client = new RawHttpClient("localhost", 8761)) {
+            final var pool = buildConnectionPoolBean();
+            pool.setDomain(regexDomain);
+            final var response = client.post(CONNECTION_POOLS_PATH, null, pool, credentials);
+            assertThat(response.getStatusLine(), containsString(CREATED));
+            assertThat(server.getCurrentConfiguration().getConnectionPools().get(ALTERNATIVE_EXAMPLE_COM).getDomain(), is(regexDomain));
+
+            // any further save re-serializes the whole configuration: the regex pool must not lose its backslashes
+            final var otherPool = buildConnectionPoolBean();
+            otherPool.setId(DEFAULT_EXAMPLE_ORG);
+            final var putResponse = client.put(CONNECTION_POOLS_PATH + "/" + DEFAULT_EXAMPLE_ORG, null, otherPool, credentials);
+            assertThat(putResponse.getStatusLine(), containsString(OK));
+
+            final var result = client.get(CONNECTION_POOLS_PATH + "/" + ALTERNATIVE_EXAMPLE_COM, credentials);
+            final var resultBean = MAPPER.readValue(result.getBodyString(), ConnectionPoolsResource.ConnectionPoolBean.class);
+            assertThat(resultBean.getDomain(), is(regexDomain));
+        }
+    }
+
+    @Test
     public void testDelete() throws Exception {
         configureAndStartServer();
         try (final var client = new RawHttpClient("localhost", 8761)) {

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreTest.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.carapaceproxy.api.ConfigResource;
 import org.carapaceproxy.server.certificates.DynamicCertificateState;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.utils.TestUtils;
@@ -85,6 +86,29 @@ public class ConfigurationStoreTest {
         } else {
             store = newStore;
         }
+    }
+
+    @Test
+    @Parameters({"in-memory", "db"})
+    public void testToStringConfigurationPreservesBackslashes(String type) throws Exception {
+        this.type = type;
+
+        final String domain = "(\\Qhost.example\\E|\\Qother.example\\E)";
+        final String matcher = "regexp .*\\.example\\.com and header host web\\d+";
+        Properties props = new Properties();
+        props.setProperty("connectionpool.1.domain", domain);
+        props.setProperty("route.5.match", matcher);
+        updateConfigStore(props);
+
+        // round-trip through the same parse path used by rewriteConfiguration and /api/config/apply
+        ConfigurationStore reloaded = ConfigResource.buildStore(store.toStringConfiguration());
+        assertThat(reloaded.getProperty("connectionpool.1.domain", null), is(domain));
+        assertThat(reloaded.getProperty("route.5.match", null), is(matcher));
+
+        // a second round-trip must be stable too
+        ConfigurationStore reloadedTwice = ConfigResource.buildStore(reloaded.toStringConfiguration());
+        assertThat(reloadedTwice.getProperty("connectionpool.1.domain", null), is(domain));
+        assertThat(reloadedTwice.getProperty("route.5.match", null), is(matcher));
     }
 
     @Test


### PR DESCRIPTION
# Problem

Every config save re-serializes the whole configuration as raw `key=value` text and re-parses it with `Properties.load()`, which treats `\` as an escape and silently drops it. 

Thus, any backslash-bearing value is corrupted: a connection-pool domain like `(\Qhost.example\E)` becomes `(Qhost.exampleE)`, the regex stops matching, and traffic silently falls back to the default pool. Both the connection-pool CRUD API and the config editor hit this path.

# Implementation

Make the round-trip symmetric: `toStringConfiguration()` now serializes with `Properties.store()`, which escapes values exactly as `load()` expects. The timestamp comment `store()` prepends is stripped and lines are kept sorted, preserving the deterministic dump format. 

Fixes #608 #468