### PR TITLE
Bump acme4j from 3.4.0 to 5.1.0

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/ACMEClient.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/ACMEClient.java
@@ -167,10 +167,12 @@ public class ACMEClient {
         if (status == Status.VALID) {
             // The authorization is already valid. No need to process a challenge.
             // or the challenge is already verified, there's no need to execute it again.
-        } else if (status != Status.INVALID) {
+            return status;
+        }
+        if (status != Status.INVALID) {
             challenge.fetch();
         }
-        return status;
+        return challenge.getStatus();
     }
 
     /**
@@ -197,10 +199,12 @@ public class ACMEClient {
         Status status = order.getStatus();
         if (status == Status.VALID) {
             LOG.info("Order has been completed.");
-        } else if (status != Status.INVALID) {
+            return status;
+        }
+        if (status != Status.INVALID) {
             order.fetch();
         }
-        return status;
+        return order.getStatus();
     }
 
     public Certificate fetchCertificateForOrder(Order order) throws AcmeException {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/ACMEClient.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/ACMEClient.java
@@ -170,7 +170,7 @@ public class ACMEClient {
             // The authorization is already valid. No need to process a challenge.
             // or the challenge is already verified, there's no need to execute it again.
         } else if (status != Status.INVALID) {
-            challenge.update();
+            challenge.fetch();
         }
         return status;
     }
@@ -200,7 +200,7 @@ public class ACMEClient {
         if (status == Status.VALID) {
             LOG.info("Order has been completed.");
         } else if (status != Status.INVALID) {
-            order.update();
+            order.fetch();
         }
         return status;
     }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/ACMEClient.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/ACMEClient.java
@@ -136,8 +136,7 @@ public class ACMEClient {
      * @return {@link Http01Challenge} to verify
      */
     private Http01Challenge httpChallenge(Authorization auth) throws AcmeException {
-        Http01Challenge challenge = auth.findChallenge(Http01Challenge.TYPE)
-                .map(Http01Challenge.class::cast)
+        Http01Challenge challenge = auth.findChallenge(Http01Challenge.class)
                 .orElseThrow(() -> new AcmeException("Found no " + Http01Challenge.TYPE + " challenge, don't know what to do..."));
         LOG.debug("It must be reachable at: http://{}/.well-known/acme-challenge/{}",
                 auth.getIdentifier().getDomain(), challenge.getToken()
@@ -157,8 +156,7 @@ public class ACMEClient {
      */
     public Challenge dnsChallenge(Authorization auth) throws AcmeException {
         Dns01Challenge challenge = auth
-                .findChallenge(Dns01Challenge.TYPE)
-                .map(Dns01Challenge.class::cast)
+                .findChallenge(Dns01Challenge.class)
                 .orElseThrow(() -> new AcmeException("Found no " + Dns01Challenge.TYPE + " challenge, don't know what to do..."));
         LOG.info("DNS-challenge _acme-challenge.{}. to save as TXT-record with content {}", auth.getIdentifier().getDomain(), challenge.getDigest());
         return challenge;

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/ACMEClientTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/ACMEClientTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.carapaceproxy.server.certificates;
+
+import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import java.util.List;
+import org.junit.Test;
+import org.shredzone.acme4j.Identifier;
+import org.shredzone.acme4j.Order;
+import org.shredzone.acme4j.Status;
+import org.shredzone.acme4j.challenge.Challenge;
+import org.shredzone.acme4j.util.KeyPairUtils;
+
+public class ACMEClientTest {
+
+    private final ACMEClient client = new ACMEClient(KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE), true);
+
+    @Test
+    public void testCheckResponseForChallengeReturnsRefreshedStatus() throws Exception {
+        Challenge challenge = mock(Challenge.class);
+        when(challenge.getStatus()).thenReturn(Status.PROCESSING, Status.VALID);
+
+        assertEquals(Status.VALID, client.checkResponseForChallenge(challenge));
+        verify(challenge).fetch();
+    }
+
+    @Test
+    public void testCheckResponseForChallengeSkipsFetchWhenAlreadyValid() throws Exception {
+        Challenge challenge = mock(Challenge.class);
+        when(challenge.getStatus()).thenReturn(Status.VALID);
+
+        assertEquals(Status.VALID, client.checkResponseForChallenge(challenge));
+        verify(challenge, never()).fetch();
+    }
+
+    @Test
+    public void testCheckResponseForChallengeSkipsFetchWhenInvalid() throws Exception {
+        Challenge challenge = mock(Challenge.class);
+        when(challenge.getStatus()).thenReturn(Status.INVALID);
+
+        assertEquals(Status.INVALID, client.checkResponseForChallenge(challenge));
+        verify(challenge, never()).fetch();
+    }
+
+    @Test
+    public void testCheckResponseForOrderReturnsRefreshedStatus() throws Exception {
+        Order order = mockOrder();
+        when(order.getStatus()).thenReturn(Status.PROCESSING, Status.VALID);
+
+        assertEquals(Status.VALID, client.checkResponseForOrder(order));
+        verify(order).fetch();
+    }
+
+    @Test
+    public void testCheckResponseForOrderSkipsFetchWhenAlreadyValid() throws Exception {
+        Order order = mockOrder();
+        when(order.getStatus()).thenReturn(Status.VALID);
+
+        assertEquals(Status.VALID, client.checkResponseForOrder(order));
+        verify(order, never()).fetch();
+    }
+
+    @Test
+    public void testCheckResponseForOrderSkipsFetchWhenInvalid() throws Exception {
+        Order order = mockOrder();
+        when(order.getStatus()).thenReturn(Status.INVALID);
+
+        assertEquals(Status.INVALID, client.checkResponseForOrder(order));
+        verify(order, never()).fetch();
+    }
+
+    private static Order mockOrder() {
+        Order order = mock(Order.class);
+        when(order.getIdentifiers()).thenReturn(List.of(Identifier.dns("example.com")));
+        return order;
+    }
+}

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
@@ -338,7 +338,7 @@ public class DynamicCertificatesManagerTest {
         ));
         when(session.connect()).thenReturn(conn);
         when(login.getSession()).thenReturn(session);
-        when(login.getKeyPair()).thenReturn(KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE));
+        when(login.getPublicKey()).thenReturn(KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE).getPublic());
 
         Dns01Challenge c = mock(Dns01Challenge.class);
         when(c.getDigest()).thenReturn("");
@@ -465,7 +465,7 @@ public class DynamicCertificatesManagerTest {
         ));
         when(session.connect()).thenReturn(conn);
         when(login.getSession()).thenReturn(session);
-        when(login.getKeyPair()).thenReturn(KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE));
+        when(login.getPublicKey()).thenReturn(KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE).getPublic());
 
         // challenges
         when(ac.checkResponseForChallenge(any())).thenReturn(runCase.equals("challenge_failed")? INVALID : VALID);
@@ -594,7 +594,7 @@ public class DynamicCertificatesManagerTest {
         Session session = mock(Session.class);
         when(session.connect()).thenReturn(mock(Connection.class));
         when(login.getSession()).thenReturn(session);
-        when(login.getKeyPair()).thenReturn(KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE));
+        when(login.getPublicKey()).thenReturn(KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE).getPublic());
 
         Http01Challenge c = mock(Http01Challenge.class);
         when(c.getToken()).thenReturn("");

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 
         <libs.projectreactor>2024.0.6</libs.projectreactor>
         <libs.netty>4.1.121.Final</libs.netty>
-        <libs.acme4j>3.5.0</libs.acme4j>
+        <libs.acme4j>4.0.0</libs.acme4j>
         <libs.bouncycastle>1.84</libs.bouncycastle>
         <libs.awssdk>2.17.113</libs.awssdk>
         <libs.caffeine>3.0.5</libs.caffeine>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 
         <libs.projectreactor>2024.0.6</libs.projectreactor>
         <libs.netty>4.1.121.Final</libs.netty>
-        <libs.acme4j>5.0.0</libs.acme4j>
+        <libs.acme4j>5.1.0</libs.acme4j>
         <libs.bouncycastle>1.84</libs.bouncycastle>
         <libs.awssdk>2.17.113</libs.awssdk>
         <libs.caffeine>3.0.5</libs.caffeine>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 
         <libs.projectreactor>2024.0.6</libs.projectreactor>
         <libs.netty>4.1.121.Final</libs.netty>
-        <libs.acme4j>4.0.0</libs.acme4j>
+        <libs.acme4j>5.0.0</libs.acme4j>
         <libs.bouncycastle>1.84</libs.bouncycastle>
         <libs.awssdk>2.17.113</libs.awssdk>
         <libs.caffeine>3.0.5</libs.caffeine>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 
         <libs.projectreactor>2024.0.6</libs.projectreactor>
         <libs.netty>4.1.121.Final</libs.netty>
-        <libs.acme4j>3.4.0</libs.acme4j>
+        <libs.acme4j>3.5.0</libs.acme4j>
         <libs.bouncycastle>1.84</libs.bouncycastle>
         <libs.awssdk>2.17.113</libs.awssdk>
         <libs.caffeine>3.0.5</libs.caffeine>

--- a/pom.xml
+++ b/pom.xml
@@ -119,8 +119,8 @@
         <libs.jersey>2.35</libs.jersey>
         <libs.jackson>2.14.3</libs.jackson>
         <libs.javassist>3.27.0-GA</libs.javassist>
-        <libs.slf4j>2.0.16</libs.slf4j>
-        <libs.logback>1.5.35</libs.logback>
+        <libs.slf4j>2.0.18</libs.slf4j>
+        <libs.logback>1.5.38</libs.logback>
         <libs.guava>33.3.1-jre</libs.guava>
         <libs.checkerqual>3.43.0</libs.checkerqual>
         <libs.lombok>1.18.32</libs.lombok>


### PR DESCRIPTION
## Implementation

Part of #536.

> [!NOTE]
> #620 builds on this branch. Merge this one first, with rebase.

Upgrades acme4j from 3.4.0 (two years old) to the latest 5.1.0, as groundwork for supporting custom ACME providers: newer acme4j versions are where provider-related features and fixes land, so the bump comes first as an isolated change.

Aligns also related dependencies: 

- slf4j 2.0.16 bumped to 2.0.18
- logback 1.5.35 bumped to 1.5.38

The transitive jose4j (0.9.6) and BouncyCastle (1.84, managed) versions are unchanged.

The upgrade is staged with one commit per upstream release, please merge it with rebase, so the history stays bisectable if needed.

## Details

- with **3.5.0**, also replaces the deprecated `update()` with `fetch()` on challenge and order polling in `ACMEClient`, as recommended by the [acme4j migration guide](https://shredzone.org/maven/acme4j/migration.html) before moving to 4.x (`update()` is removed there).
- with **4.0.0** no code changes were needed. Notable upstream changes: `Session` is now thread-safe with a shared `HttpClient`, default network timeout raised from 10s to 30s, new Java 17 baseline (we build on 21).
- with **5.0.0**, `Login.getKeyPair()` was removed upstream as a security precaution; only `Login.getPublicKey()` is exposed now, and the challenge digest computation relies on it. Tests stub `getPublicKey()` accordingly.
- with **5.1.0** no code changes were needed.

> [!CAUTION]
> CI mocks the ACME boundary, so live issuance is not exercised by tests; the 4.0.0 connector rewrite is the main area to watch. A real HTTP-01 renewal (or a local run against [Pebble](https://github.com/letsencrypt/pebble)) might be a meaningful end-to-end check.