### PR TITLE
Fix broken SpotBugs analysis

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -90,10 +90,6 @@
             <exclusions>
                 <!-- Excluding unnecessary annotations that are bundled in multiple versions by libraries -->
                 <exclusion>
-                    <groupId>org.checkerframework</groupId>
-                    <artifactId>checker-qual</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.google.errorprone</groupId>
                     <artifactId>error_prone_annotations</artifactId>
                 </exclusion>
@@ -144,10 +140,6 @@
             <version>${libs.herddb}</version>
             <exclusions>
                 <!-- Excluding unnecessary annotations that are bundled in multiple versions by libraries -->
-                <exclusion>
-                    <groupId>org.checkerframework</groupId>
-                    <artifactId>checker-qual</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>com.google.errorprone</groupId>
                     <artifactId>error_prone_annotations</artifactId>
@@ -247,10 +239,6 @@
             <exclusions>
                 <!-- Excluding unnecessary annotations that are bundled in multiple versions by libraries -->
                 <exclusion>
-                    <groupId>org.checkerframework</groupId>
-                    <artifactId>checker-qual</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.google.code.findbugs</groupId>
                     <artifactId>jsr305</artifactId>
                 </exclusion>
@@ -269,7 +257,7 @@
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
-            <version>${libs.spotbugsannotations}</version>
+            <version>${libs.spotbugs}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -122,8 +122,10 @@
         <libs.slf4j>2.0.16</libs.slf4j>
         <libs.logback>1.5.35</libs.logback>
         <libs.guava>33.3.1-jre</libs.guava>
+        <libs.checkerqual>3.43.0</libs.checkerqual>
         <libs.lombok>1.18.32</libs.lombok>
-        <libs.spotbugsannotations>4.5.3</libs.spotbugsannotations>
+        <libs.spotbugs>4.10.3</libs.spotbugs>
+        <libs.spotbugs.plugin>4.10.3.0</libs.spotbugs.plugin>
         <libs.protobuf>3.25.5</libs.protobuf>
 
         <!-- test dependecies -->
@@ -133,8 +135,6 @@
         <libs.powermock>2.0.9</libs.powermock>
         <libs.objenesis>3.0.1</libs.objenesis>
         <libs.hamcrest>3.0</libs.hamcrest>
-
-        <libs.asm>9.4</libs.asm>
     </properties>
 
     <dependencyManagement>
@@ -190,6 +190,11 @@
                 <type>pom</type>
             </dependency>
             <!-- Individual dependencies -->
+            <dependency>
+                <groupId>org.checkerframework</groupId>
+                <artifactId>checker-qual</artifactId>
+                <version>${libs.checkerqual}</version>
+            </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
@@ -312,19 +317,12 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>4.8.6.4</version>
+                    <version>${libs.spotbugs.plugin}</version>
                     <configuration>
                         <effort>Max</effort>
                         <maxHeap>4096</maxHeap>
                         <fork>true</fork>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.ow2.asm</groupId>
-                            <artifactId>asm</artifactId>
-                            <version>${libs.asm}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -473,7 +471,6 @@
                                     <excludes>
                                         <exclude>org.bouncycastle:*</exclude>
                                         <!-- Excluding unnecessary annotations that are bundled in multiple versions by libraries -->
-                                        <exclude>org.checkerframework</exclude>
                                         <exclude>com.google.errorprone</exclude>
                                         <exclude>com.google.code.findbugs</exclude>
                                         <!-- Clashes with org.hamcrest:hamcrest -->


### PR DESCRIPTION
Fixes #618

Since the Java 21 upgrade, `spotbugs:check` fails with `NoClassesFoundToAnalyzeException`: the root `pom.xml` forces the SpotBugs plugin's `org.ow2.asm:asm` to 9.4, which cannot parse Java 21 bytecode (class file major version 65), so every class is silently skipped before analysis starts.

The override dates back to 2018, when it served to upgrade the ASM bundled by the old plugin; today it does the opposite, downgrading it. It also pinned only the core `asm` artifact, leaving `asm-tree`/`asm-analysis`/`asm-commons`/`asm-util` at the bundled version — a mixed ASM tree that SpotBugs docs never sanction.

Changes:

- Remove the `org.ow2.asm:asm` override and the `libs.asm` property; the plugin manages a coherent ASM tree through its own `asm-bom`.
- Bump `spotbugs-maven-plugin` 4.8.6.4 → 4.10.3.0 (`libs.spotbugs.plugin`) and align `spotbugs-annotations` 4.5.3 → 4.10.3 (`libs.spotbugs`); the plugin version derives from `libs.spotbugs`, so the two can't drift again.
- Un-ban `checker-qual`, which Guava annotations reference, so the analysis no longer reports missing classes; its version is pinned in `dependencyManagement` because Guava, Caffeine and HerdDB request diverging versions.

With this change, `spotbugs:spotbugs` completes successfully (engine 4.10.3, zero analysis errors) and `spotbugs:check` fails only because of the 198 pre-existing findings, no longer with an exception.

