### PR TITLE
build: upgrade javacc-maven-plugin from 2.4 to 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
         <libs.awssdk>2.17.113</libs.awssdk>
         <libs.caffeine>3.0.5</libs.caffeine>
         <libs.antlr>4.3.1</libs.antlr>
+        <libs.javacc>7.0.13</libs.javacc>
 
         <libs.bookkeeper>4.14.8</libs.bookkeeper>
         <libs.zookkeeper>3.8.6</libs.zookkeeper>
@@ -371,6 +372,13 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>javacc-maven-plugin</artifactId>
                     <version>${javacc-maven-plugin.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>net.java.dev.javacc</groupId>
+                            <artifactId>javacc</artifactId>
+                            <version>${libs.javacc}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <toolchain.java.version>21</toolchain.java.version>
         <maven.compiler.release>${toolchain.java.version}</maven.compiler.release>
-        <javacc-maven-plugin.version>3.0.1</javacc-maven-plugin.version>
+        <javacc-maven-plugin.version>3.2.0</javacc-maven-plugin.version>
 
         <libs.projectreactor>2024.0.6</libs.projectreactor>
         <libs.netty>4.1.121.Final</libs.netty>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <toolchain.java.version>21</toolchain.java.version>
         <maven.compiler.release>${toolchain.java.version}</maven.compiler.release>
-        <javacc-maven-plugin.version>2.4</javacc-maven-plugin.version>
+        <javacc-maven-plugin.version>2.6</javacc-maven-plugin.version>
 
         <libs.projectreactor>2024.0.6</libs.projectreactor>
         <libs.netty>4.1.121.Final</libs.netty>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <toolchain.java.version>21</toolchain.java.version>
         <maven.compiler.release>${toolchain.java.version}</maven.compiler.release>
-        <javacc-maven-plugin.version>2.6</javacc-maven-plugin.version>
+        <javacc-maven-plugin.version>3.0.1</javacc-maven-plugin.version>
 
         <libs.projectreactor>2024.0.6</libs.projectreactor>
         <libs.netty>4.1.121.Final</libs.netty>


### PR DESCRIPTION
Upgrades the generator behind the request-matcher DSL to recent JavaCC version. 

Closes #561

> [!NOTE]
> JavaCC 8 exists, shipped under new coordinates (`org.javacc:core`, `org.javacc.generator:java` 8.1.0) and driven by its own rewritten plugin (`org.javacc.plugin:javacc-maven-plugin` 3.8.0).
> 
> Though, both were published only a few months ago, and as far as I can tell it ships with a different configuration model.
> 
> This PR stays on the 7.x line and leaves the v8 migration to a dedicated issue.

## What changed

`javacc-maven-plugin` was stuck on a version from Maven 2-era.

One commit per plugin generation, so each transition is bisectable:

| Plugin | JavaCC | Notable change |
|---|---|---|
| 2.4 → 2.6 | 4.0 → 5.0 | generator only |
| 2.6 → 3.0.1 | 5.0 → 7.0.12 | Maven 3 rewrite: annotation mojos, `javacc.` property prefix, grammar `options {}` no longer overridden |
| 3.0.1 → 3.2.0 | 7.0.12 → 7.0.13 | thread-safe mojos, Doxia 2.0, grammars read with configured encoding |
| — | 7.0.13 pinned | generator version was invisible in the POM; now a plugin dependency |

Grammar was unchanged, as 7.0.13 accepts it as-is.

Generated code stays under `target/`. Deltas on generated code are cosmetic.