### PR TITLE
Bump Jackson from 2.14.3 to 2.22.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
 
         <libs.jetty>9.4.57.v20241219</libs.jetty>
         <libs.jersey>2.35</libs.jersey>
-        <libs.jackson>2.14.3</libs.jackson>
+        <libs.jackson>2.22.2</libs.jackson>
         <libs.javassist>3.27.0-GA</libs.javassist>
         <libs.slf4j>2.0.18</libs.slf4j>
         <libs.logback>1.5.38</libs.logback>


### PR DESCRIPTION
# Problem

Six open Dependabot alerts on jackson-core and jackson-databind, ranging from moderate (SSRF via `InetSocketAddress` deserialization, case-insensitive `@JsonIgnoreProperties` bypass) to high (async parser `maxNumberLength` bypass, `BasicPolymorphicTypeValidator` array subtype bypass, polymorphic type parameter bypass, deeply nested data stack overflow). The oldest has been open for eight months.

All six are fixed in jackson-databind 2.18.9 or earlier; the current pin is 2.14.3.

# Implementation

Bumps `libs.jackson` from 2.14.3 to 2.22.2 (latest), which updates the `jackson-bom` import and aligns jackson-core, jackson-databind, jackson-annotations, and jackson-module-jaxb-annotations in one go.

Jackson's [versioning policy](https://github.com/FasterXML/jackson/blob/main/VERSIONING.md) guarantees backwards compatibility within 2.x. The only behavioural change worth noting is `StreamReadConstraints` defaults added in 2.15 (max number length 1000, max nesting depth 1000, max string length 20M), none of which affect the small config JSON this project parses.

The three APIs the codebase uses (`ObjectMapper`, `JsonProcessingException`, `TypeReference`) are unchanged across all intermediate versions. Java 8 baseline is maintained throughout; Java 21 is fully supported.

Transitive consumers are all BOM-managed and unaffected:
- jersey-media-json-jackson 2.35 (was requesting 2.12.2, already overridden)
- HerdDB internals (were requesting 2.10/2.11, already overridden)
- AWS SDK `third-party-jackson-core` (shaded, independent)