### PR TITLE
Bump Netty to 4.1.137, Reactor Netty to 1.2.18, Micrometer to 1.17.1 and AWS SDK to 2.45.1

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -157,12 +157,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <!-- needed at runtime by the AWS SDK apache-client's httpclient -->
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -130,6 +130,7 @@
             </exclusions>
         </dependency>
         <dependency>
+            <!-- Prometheus client 0.x API, which BookKeeper still requires; see #625 -->
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
         </dependency>

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/HttpTestUtils.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/HttpTestUtils.java
@@ -47,7 +47,6 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
-import org.apache.commons.codec.binary.Base64;
 
 /**
  * HTTPs utilities
@@ -484,17 +483,6 @@ public class HttpTestUtils {
         }
         if (con.getConnectTimeout() <= 0) {
             con.setConnectTimeout(60 * 1000); // 1 min
-        }
-    }
-
-    public static void setBasicCredentials(String httpProxyUsername, String httpProxyPassword, URLConnection con) {
-
-        if (httpProxyUsername != null && httpProxyUsername.length() > 0) {
-            String pHeader = "Authorization";
-            String sstr = httpProxyUsername + ":" + httpProxyPassword;
-
-            String secret = "Basic " + Base64.encodeBase64String(sstr.getBytes(StandardCharsets.UTF_8));
-            con.addRequestProperty(pHeader, secret);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <libs.zookkeeper>3.8.6</libs.zookkeeper>
         <libs.curator>5.2.0</libs.curator>
         <libs.prometheus>0.16.0</libs.prometheus>
-        <libs.micrometer>1.14.14</libs.micrometer>
+        <libs.micrometer>1.17.1</libs.micrometer>
         <libs.herddb>0.26.1</libs.herddb>
 
         <libs.commons.codec>1.17.1</libs.commons.codec>

--- a/pom.xml
+++ b/pom.xml
@@ -94,8 +94,8 @@
         <maven.compiler.release>${toolchain.java.version}</maven.compiler.release>
         <javacc-maven-plugin.version>2.4</javacc-maven-plugin.version>
 
-        <libs.projectreactor>2024.0.6</libs.projectreactor>
-        <libs.netty>4.1.121.Final</libs.netty>
+        <libs.projectreactor>2024.0.18</libs.projectreactor>
+        <libs.netty>4.1.137.Final</libs.netty>
         <libs.acme4j>5.1.0</libs.acme4j>
         <libs.bouncycastle>1.84</libs.bouncycastle>
         <libs.awssdk>2.32.16</libs.awssdk>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <libs.netty>4.1.137.Final</libs.netty>
         <libs.acme4j>5.1.0</libs.acme4j>
         <libs.bouncycastle>1.84</libs.bouncycastle>
-        <libs.awssdk>2.32.16</libs.awssdk>
+        <libs.awssdk>2.45.1</libs.awssdk>
         <libs.caffeine>3.0.5</libs.caffeine>
         <libs.antlr>4.3.1</libs.antlr>
 


### PR DESCRIPTION
Closes #631.

Four commits, that I recommend to merge with rebase, not by squashing. 

The first two are the bump #631 asks for, both POM only:

- `netty-bom` **4.1.121.Final** → **4.1.137.Final** and `reactor-bom` **2024.0.6** → **2024.0.18** (Reactor Netty 1.2.18, Reactor Core 3.7.19, netty-tcnative 2.0.81.Final)
- `micrometer-bom` **1.14.14** → **1.17.1**

That closes all 41 alerts. Each Netty advisory lists a fixed release for both maintained lines, one for 4.1 and one for 4.2; among the 39 that affect us, the highest 4.1 release required is 4.1.137.Final, which is also the newest of that line.

Micrometer was bumped because GHSA-g3pr-3p32-fp23 was fixed in 1.15.12 and 1.16.6, but not on 1.14.x. Version 1.17.1 is past every affected range.

## Why Netty 4.1 and not 4.2

The AWS SDK is still built against Netty 4.1: 2.54.4, its latest release, declares netty 4.1.137.Final. `Route53Client` builds a `Route53AsyncClient`, so `netty-nio-client` sits on the ACME DNS-01 path, and running it under a Netty it was never built against is a combination our tests cannot judge.

Netty 4.2 also changes two behaviours that deserve their own review: client-side TLS endpoint identification starts defaulting to HTTPS, so backend certificates get verified against the configured host, and the default channel allocator moves from pooled to adaptive.

## The AWS SDK side

Two commits, and the first is cleanup that came up while reading its POM entry. `commons-codec` was declared in `carapace-server` with a comment about the SDK's HTTP client, but `apache-client` declares it on its own, and the only reference to it in our code was `HttpTestUtils.setBasicCredentials`, a helper with no caller since it arrived in 2017. The helper and the declaration are gone, and the managed version stays in the parent POM for the transitive users.

The second takes the opportunity the Netty bump creates: #627 had to stop at 2.32.16 because newer SDK releases were built against Netty 4.1.123 or later, and 4.1.137 lifts that ceiling. Thirteen minors of fixes on the client that manages the ACME DNS-01 records.

The bump didn't reach latest 2.54.4, because from 2.46.0 the SDK swaps its sync transport for `apache5-client`, whose HttpClient 5.6.4 would meet the 5.1.3 that Avatica pulls in through HerdDB. That collision needs either a pin or an exclusion, and the decision reads better once the cluster stack upgrade has settled the HttpClient 4 side.