### PR TITLE
Upgrade the cluster stack, and replace the abandoned lz4

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -158,7 +158,34 @@
                     <groupId>net.jpountz.lz4</groupId>
                     <artifactId>lz4</artifactId>
                 </exclusion>
+                <!-- BK 4.16 pulls log4j; project uses Logback via SLF4J -->
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+                <!-- io_uring natives make Reactor Netty pick io_uring over our epoll event loops -->
+                <exclusion>
+                    <groupId>io.netty.incubator</groupId>
+                    <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <!-- BK references these classes unconditionally; only the natives are unwanted -->
+            <groupId>io.netty.incubator</groupId>
+            <artifactId>netty-incubator-transport-classes-io_uring</artifactId>
+            <version>0.0.21.Final</version>
+        </dependency>
+        <dependency>
+            <!-- needed by the BK embedded server; HerdDB test-scopes it away -->
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.11.0</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>at.yawk.lz4</groupId>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -153,7 +153,17 @@
                     <artifactId>commons-logging</artifactId>
                     <groupId>commons-logging</groupId>
                 </exclusion>
+                <!-- Abandoned since 2014, replaced by at.yawk.lz4:lz4-java -->
+                <exclusion>
+                    <groupId>net.jpountz.lz4</groupId>
+                    <artifactId>lz4</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+            <version>1.11.2</version>
         </dependency>
         <dependency>
             <!-- needed at runtime by the AWS SDK apache-client's httpclient -->

--- a/carapace-server/src/main/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandler.java
@@ -19,6 +19,7 @@
  */
 package org.carapaceproxy.cluster.impl;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
@@ -29,6 +30,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -37,11 +39,10 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.api.ACLProvider;
 import org.apache.curator.framework.imps.DefaultACLProvider;
-import org.apache.curator.framework.recipes.cache.ChildData;
-import org.apache.curator.framework.recipes.cache.PathChildrenCache;
-import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
-import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
+import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
 import org.apache.curator.framework.recipes.locks.InterProcessMutex;
+import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.utils.ZookeeperFactory;
 import org.apache.zookeeper.CreateMode;
@@ -76,7 +77,7 @@ public class ZooKeeperGroupMembershipHandler implements GroupMembershipHandler, 
     private final CuratorFramework client;
     private final String peerId; // of the local one
     private final Map<String, String> peerInfo; // of the local one
-    private final CopyOnWriteArrayList<PathChildrenCache> watchedEvents = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<CuratorCache> watchedEvents = new CopyOnWriteArrayList<>();
     private final ConcurrentHashMap<String, InterProcessMutex> mutexes = new ConcurrentHashMap<>();
     private final ExecutorService callbacksExecutor = Executors.newSingleThreadExecutor();
 
@@ -185,7 +186,7 @@ public class ZooKeeperGroupMembershipHandler implements GroupMembershipHandler, 
             if (exists != null) {
                 byte[] data = client.getData().forPath(path); // Should be at least an empty Map.
                 if (data != null) {
-                    return MAPPER.readValue(new ByteArrayInputStream(data), Map.class);
+                    return MAPPER.readValue(new ByteArrayInputStream(data), new TypeReference<>() {});
                 }
             }
         } catch (Exception ex) {
@@ -201,31 +202,46 @@ public class ZooKeeperGroupMembershipHandler implements GroupMembershipHandler, 
             final String eventpath = "/proxy/events/" + eventId;
 
             LOG.info("watching {}", path);
-            PathChildrenCache cache = new PathChildrenCache(client, path, true);
-            // hold a strong reference to the PathChildrenCache
+            CuratorCache cache = CuratorCache.build(client, path);
             watchedEvents.add(cache);
-            cache.getListenable().addListener((PathChildrenCacheListener) (CuratorFramework cf, PathChildrenCacheEvent pcce) -> {
-                LOG.info("ZK event {} at {}", pcce, path);
-                ChildData data = pcce.getData();
-                if (data != null && eventpath.equals(data.getPath())) {
-                    byte[] content = data.getData();
-                    LOG.info("ZK event content {}", new String(content, StandardCharsets.UTF_8));
-                    if (content != null) {
-                        Map<String, Object> info = MAPPER.readValue(new ByteArrayInputStream(content), Map.class);
-                        String origin = info.remove("origin") + "";
-                        if (peerId.equals(origin)) {
-                            LOG.info("discard self originated event {}", origin);
-                        } else {
-                            LOG.info("handle event {}", info);
-                            callback.eventFired(eventId, info);
+            final CountDownLatch initialized = new CountDownLatch(1);
+            CuratorCacheListener listener = CuratorCacheListener.builder()
+                    .forCreatesAndChanges((oldNode, node) -> {
+                        LOG.info("ZK event at {}", node.getPath());
+                        if (eventpath.equals(node.getPath())) {
+                            byte[] content = node.getData();
+                            LOG.info("ZK event content {}", new String(content, StandardCharsets.UTF_8));
+                            try {
+                                Map<String, Object> info = MAPPER
+                                        .readValue(new ByteArrayInputStream(content), new TypeReference<>() {});
+                                String origin = info.remove("origin") + "";
+                                if (peerId.equals(origin)) {
+                                    LOG.info("discard self originated event {}", origin);
+                                } else {
+                                    LOG.info("handle event {}", info);
+                                    callback.eventFired(eventId, info);
+                                }
+                            } catch (Exception ex) {
+                                LOG.error("Cannot process ZK event at {}", eventpath, ex);
+                            }
                         }
-                    }
-                } else if (pcce.getType() == PathChildrenCacheEvent.Type.CONNECTION_RECONNECTED) {
+                    })
+                    .forInitialized(initialized::countDown)
+                    // skip the replay of pre-existing nodes on start, like the old BUILD_INITIAL_CACHE did
+                    .afterInitialized()
+                    .build();
+            cache.listenable().addListener(listener, callbacksExecutor);
+            client.getConnectionStateListenable().addListener((cf, state) -> {
+                if (state == ConnectionState.RECONNECTED) {
                     callback.reconnected();
                 }
             }, callbacksExecutor);
-            cache.start(PathChildrenCache.StartMode.BUILD_INITIAL_CACHE);
-
+            cache.start();
+            // wait for the initial population, so events fired after this method returns are never lost
+            initialized.await();
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(ex);
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
@@ -281,6 +297,8 @@ public class ZooKeeperGroupMembershipHandler implements GroupMembershipHandler, 
 
     @Override
     public void stop() {
+        watchedEvents.forEach(CuratorCache::close);
+        watchedEvents.clear();
         client.close();
         callbacksExecutor.shutdown();
     }

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/HerdDBConfigurationStore.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/HerdDBConfigurationStore.java
@@ -52,7 +52,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.bookkeeper.stats.StatsProvider;
 import org.carapaceproxy.server.certificates.DynamicCertificateState;
 import org.carapaceproxy.server.config.AcmeProviderConfiguration;
 import org.carapaceproxy.utils.StringUtils;
@@ -164,8 +164,8 @@ public class HerdDBConfigurationStore implements ConfigurationStore {
     private final HerdDBEmbeddedDataSource datasource;
 
     public HerdDBConfigurationStore(ConfigurationStore staticConfiguration,
-                                    boolean cluster, String zkAddress, File baseDir, StatsLogger statsLogger) {
-        this.datasource = buildDatasource(staticConfiguration, cluster, zkAddress, baseDir, statsLogger);
+                                    boolean cluster, String zkAddress, File baseDir, StatsProvider statsProvider) {
+        this.datasource = buildDatasource(staticConfiguration, cluster, zkAddress, baseDir, statsProvider);
         loadCurrentConfiguration();
     }
 
@@ -189,7 +189,7 @@ public class HerdDBConfigurationStore implements ConfigurationStore {
     }
 
     private HerdDBEmbeddedDataSource buildDatasource(ConfigurationStore staticConfiguration,
-                                                     boolean cluster, String zkAddress, File baseDir, StatsLogger statsLogger) {
+                                                     boolean cluster, String zkAddress, File baseDir, StatsProvider statsProvider) {
         Properties props = new Properties();
 
         if (cluster) {
@@ -214,7 +214,7 @@ public class HerdDBConfigurationStore implements ConfigurationStore {
 
         LOG.info("HerdDB datasource configuration: {}", props);
         HerdDBEmbeddedDataSource ds = new HerdDBEmbeddedDataSource(props);
-        ds.setStatsLogger(statsLogger);
+        ds.setStatsProvider(statsProvider);
         if (cluster) {
             ds.setWaitForTableSpace("herd");
             ds.setWaitForTableSpaceTimeout(TIMEOUT_WAIT_FOR_TABLE_SPACE);

--- a/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
@@ -67,7 +67,6 @@ import javax.servlet.DispatcherType;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.carapaceproxy.api.ApplicationConfig;
@@ -133,8 +132,6 @@ public class HttpProxyServer implements AutoCloseable {
 
     @Getter
     private final ContentsCache cache;
-    private final StatsLogger mainLogger;
-
     @Getter
     private final File basePath;
 
@@ -244,7 +241,6 @@ public class HttpProxyServer implements AutoCloseable {
     public HttpProxyServer(final EndpointMapper.Factory mapperFactory, File basePath) throws ConfigurationNotValidException {
         // metrics
         this.statsProvider = new PrometheusMetricsProvider();
-        this.mainLogger = this.statsProvider.getStatsLogger("");
         this.prometheusRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
         this.prometheusRegistry.config().meterFilter(new PrometheusRenameFilter());
         Metrics.globalRegistry.add(this.prometheusRegistry);
@@ -542,7 +538,7 @@ public class HttpProxyServer implements AutoCloseable {
                 }
                 break;
             case "database":
-                this.dynamicConfigurationStore = new HerdDBConfigurationStore(bootConfigurationStore, cluster, zkAddress, basePath, mainLogger);
+                this.dynamicConfigurationStore = new HerdDBConfigurationStore(bootConfigurationStore, cluster, zkAddress, basePath, statsProvider);
                 break;
             default:
                 throw new ConfigurationNotValidException("invalid config.type='" + dynamicConfigurationType + "', only 'file' and 'database' are supported");

--- a/carapace-server/src/test/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandlerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandlerTest.java
@@ -238,6 +238,60 @@ public class ZooKeeperGroupMembershipHandlerTest {
     }
 
     @Test
+    public void testWatchEventNotFiredOnStartupForExistingNode() throws Exception {
+        try (TestingServer testingServer = new TestingServer(2229, tmpDir.newFolder())) {
+            testingServer.start();
+            try (ZooKeeperGroupMembershipHandler peer1 = new ZooKeeperGroupMembershipHandler(testingServer.getConnectString(),
+                    6000, false /*acl */, peerId1, Collections.EMPTY_MAP, new Properties())) {
+                peer1.start();
+
+                AtomicInteger eventFired2 = new AtomicInteger();
+                try (ZooKeeperGroupMembershipHandler peer2 = new ZooKeeperGroupMembershipHandler(testingServer.getConnectString(),
+                        6000, false /*acl */, peerId2, Collections.EMPTY_MAP, new Properties())) {
+                    peer2.start();
+                    peer2.watchEvent("foo", new GroupMembershipHandler.EventCallback() {
+                        @Override
+                        public void eventFired(String eventId, Map<String, Object> data) {
+                            eventFired2.incrementAndGet();
+                        }
+
+                        @Override
+                        public void reconnected() {
+                        }
+                    });
+                    // leave a persistent /proxy/events/foo node behind, originated by peer1
+                    peer1.fireEvent("foo", null);
+                    TestUtils.waitForCondition(() -> eventFired2.get() >= 1, 100);
+                }
+
+                // simulate a restart of peer2: the stale event node must not fire the callback
+                eventFired2.set(0);
+                try (ZooKeeperGroupMembershipHandler peer2 = new ZooKeeperGroupMembershipHandler(testingServer.getConnectString(),
+                        6000, false /*acl */, peerId2, Collections.EMPTY_MAP, new Properties())) {
+                    peer2.start();
+                    peer2.watchEvent("foo", new GroupMembershipHandler.EventCallback() {
+                        @Override
+                        public void eventFired(String eventId, Map<String, Object> data) {
+                            eventFired2.incrementAndGet();
+                        }
+
+                        @Override
+                        public void reconnected() {
+                        }
+                    });
+                    Thread.sleep(2000); // give the initial cache population time to replay
+                    assertEquals(0, eventFired2.get());
+
+                    // live events must still be delivered after initialization
+                    peer1.fireEvent("foo", null);
+                    TestUtils.waitForCondition(() -> eventFired2.get() >= 1, 100);
+                    assertTrue(eventFired2.get() >= 1);
+                }
+            }
+        }
+    }
+
+    @Test
     public void testPeerInfo() throws Exception {
         try (TestingServer testingServer = new TestingServer(2229, tmpDir.newFolder());) {
             testingServer.start();

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreTest.java
@@ -39,7 +39,7 @@ import java.util.Properties;
 import java.util.Set;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
-import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.stats.NullStatsProvider;
 import org.carapaceproxy.api.ConfigResource;
 import org.carapaceproxy.server.certificates.DynamicCertificateState;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
@@ -86,7 +86,7 @@ public class ConfigurationStoreTest {
                 props.put("db.admin.username", "theusername");
                 props.put("db.admin.password", "thepassword");
                 newStore = new PropertiesConfigurationStore(props);
-                store = new HerdDBConfigurationStore(newStore, false, null, tmpDir.getRoot(), NullStatsLogger.INSTANCE);
+                store = new HerdDBConfigurationStore(newStore, false, null, tmpDir.getRoot(), new NullStatsProvider());
             }
             store.commitConfiguration(newStore);
         } else {
@@ -349,7 +349,7 @@ public class ConfigurationStoreTest {
 
         PropertiesConfigurationStore propertiesConfigurationStore = new PropertiesConfigurationStore(props);
 
-        store = new HerdDBConfigurationStore(propertiesConfigurationStore, false, null, tmpDir.getRoot(), NullStatsLogger.INSTANCE);
+        store = new HerdDBConfigurationStore(propertiesConfigurationStore, false, null, tmpDir.getRoot(), new NullStatsProvider());
 
         // Check applied configuration (loaded from empty db NB: passed configuration is ignored)
         assertEquals("", store.getProperty("certificate.0.hostname", ""));
@@ -395,7 +395,7 @@ public class ConfigurationStoreTest {
         props = new Properties();
         props.put("db.jdbc.url", "jdbc:herddb:localhost");
         propertiesConfigurationStore = new PropertiesConfigurationStore(props);
-        store = new HerdDBConfigurationStore(propertiesConfigurationStore, false, null, tmpDir.getRoot(), NullStatsLogger.INSTANCE);
+        store = new HerdDBConfigurationStore(propertiesConfigurationStore, false, null, tmpDir.getRoot(), new NullStatsProvider());
         checkConfiguration();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -102,12 +102,12 @@
         <libs.caffeine>3.0.5</libs.caffeine>
         <libs.antlr>4.3.1</libs.antlr>
 
-        <libs.bookkeeper>4.14.3</libs.bookkeeper>
+        <libs.bookkeeper>4.16.3</libs.bookkeeper>
         <libs.zookkeeper>3.8.6</libs.zookkeeper>
         <libs.curator>5.2.0</libs.curator>
         <libs.prometheus>0.16.0</libs.prometheus>
         <libs.micrometer>1.14.14</libs.micrometer>
-        <libs.herddb>0.26.1</libs.herddb>
+        <libs.herddb>0.28.0</libs.herddb>
 
         <libs.commons.codec>1.17.1</libs.commons.codec>
         <libs.httpcore>4.4.16</libs.httpcore>

--- a/pom.xml
+++ b/pom.xml
@@ -475,6 +475,18 @@
                         <configuration>
                             <rules>
                                 <banDependencyManagementScope />
+                                <requireSameVersions>
+                                    <dependencies>
+                                        <dependency>org.apache.bookkeeper</dependency>
+                                        <dependency>org.apache.bookkeeper.stats</dependency>
+                                        <dependency>org.apache.bookkeeper.http</dependency>
+                                    </dependencies>
+                                </requireSameVersions>
+                                <requireSameVersions>
+                                    <dependencies>
+                                        <dependency>org.apache.zookeeper</dependency>
+                                    </dependencies>
+                                </requireSameVersions>
                                 <banDuplicatePomDependencyVersions />
                                 <banDynamicVersions>
                                     <ignores>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <libs.caffeine>3.0.5</libs.caffeine>
         <libs.antlr>4.3.1</libs.antlr>
 
-        <libs.bookkeeper>4.14.8</libs.bookkeeper>
+        <libs.bookkeeper>4.14.3</libs.bookkeeper>
         <libs.zookkeeper>3.8.6</libs.zookkeeper>
         <libs.curator>5.2.0</libs.curator>
         <libs.prometheus>0.16.0</libs.prometheus>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
 
         <libs.bookkeeper>4.16.3</libs.bookkeeper>
         <libs.zookkeeper>3.8.6</libs.zookkeeper>
-        <libs.curator>5.2.0</libs.curator>
+        <libs.curator>5.9.0</libs.curator>
         <libs.prometheus>0.16.0</libs.prometheus>
         <libs.micrometer>1.14.14</libs.micrometer>
         <libs.herddb>0.28.0</libs.herddb>


### PR DESCRIPTION
Closes #633.

Three Dependabot alerts on the clustering stack, none fixable with a plain bump:

- `net.jpountz.lz4:lz4` (GHSA-vqf4-7m7x-wgfc, GHSA-cmp6-m4wj-q63q): no release since 2014, no patched version exists. Replaced with the maintained fork `at.yawk.lz4:lz4-java`.
- BookKeeper GHSA-gxq5-79m2-gvvq: fixed by HerdDB 0.28.0, which brings BookKeeper 4.16.3.

Before the upgrade, `libs.bookkeeper` pointed at 4.14.8 but only governed `bookkeeper-stats-api` and `prometheus-metrics-provider`; the rest of the family came from HerdDB at 4.14.3, so two BookKeeper releases coexisted. `dependencyConvergence` compares versions of a single artifact, not of a family, so it cannot flag this. The first two commits align the pin with the version HerdDB pulls and add a `requireSameVersions` enforcer rule for the BookKeeper and ZooKeeper families.

Also in the PR: Curator 5.2.0 to 5.9.0, and the group membership handler moves off the deprecated `PathChildrenCache` onto `CuratorCache`.

Adjustments that BookKeeper 4.16 required:

- It ships io_uring natives, whose presence alone makes Reactor Netty pick io_uring channels over our epoll event loops; every listener bind fails on Linux. Natives excluded, classes kept (BookKeeper references them unconditionally).
- Its embedded server needs commons-cli, which HerdDB declares with test scope; now declared directly.
- It pulls log4j, bridged through SLF4J instead.

One behavioral note on `CuratorCache`: it replays pre-existing nodes on start, unlike the old `BUILD_INITIAL_CACHE`. Without `afterInitialized()` a restart would re-fire a stale configuration-change event and reload configuration for nothing. `watchEvent` also waits for the initial population, so events fired right after registration cannot fall into the startup window. A restart test covers both.

## Why HerdDB 0.28.0 and not 0.29.0

0.29.0 moves to ZooKeeper 3.9, whose client enables FIPS mode by default, and FIPS forbids DIGEST-MD5, the mechanism our cluster ACLs authenticate with:

```
WARN  ZooKeeperSaslClient - Client will not use DIGEST-MD5 as SASL mechanism, because FIPS mode is enabled.
ERROR ClientCnxn - SASL authentication with Zookeeper Quorum member failed.
javax.security.sasl.SaslException: saslClient failed to initialize properly: it's null.
```

Any deployment using `zookeeper.acl` with SASL digest credentials would break the same way `ZookKeeperACLTest` does. ZooKeeper stays on 3.8.6, newest of its line, no open advisories. The 3.9 move needs its own issue and a SASL decision.

Six commits, merge with rebase, not squash.