### PR TITLE
Collect test coverage with JaCoCo

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -397,6 +397,16 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <!-- JavaCC-generated parser classes live in the .parser subpackage; hand-written matchers in requestmatcher/ are kept -->
+                    <excludes>
+                        <exclude>**/requestmatcher/parser/*.class</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,8 @@
     </distributionManagement>
 
     <properties>
+        <!-- Keeps @{argLine} resolvable when JaCoCo does not run -->
+        <argLine></argLine>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <toolchain.java.version>21</toolchain.java.version>
         <maven.compiler.release>${toolchain.java.version}</maven.compiler.release>
@@ -346,6 +348,7 @@
                         <reuseForks>false</reuseForks>
                         <trimStackTrace>false</trimStackTrace>
                         <argLine>
+                            @{argLine}
                             --add-opens java.base/java.io=ALL-UNNAMED
                             --add-opens java.base/java.lang=ALL-UNNAMED
                             --add-opens java.base/java.util=ALL-UNNAMED
@@ -424,6 +427,26 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <!-- Bound here so every module gets the agent -->
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.15</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>


### PR DESCRIPTION
Closes #637.

`jacoco-maven-plugin` **0.8.15** with the goals on their default phases, `prepare-agent` at `initialize` and `report` at `verify`, so `./mvnw verify` writes `target/site/jacoco` and `./mvnw test` stays as light as it is now.

The plugin is bound in the parent rather than in `carapace-server` alone, so every module reports its own coverage as soon as it has tests. An aggregate report is a different thing: JaCoCo's `report-aggregate` wants a module dedicated to it, which is a layout decision and not this.

Only `carapace-server` configures anything, the exclusion of the JavaCC-generated parser classes, which live one package below the hand-written matchers.

> [!NOTE]
> `report` runs at `verify`, and PR validation runs `./mvnw -B test`, so CI produces no report yet.
> I've not decided yet which tool to use to ingest the coverage reports, so for now it's fine like that.