### PR TITLE
Adopt AssertJ as the single assertion library

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -158,6 +158,11 @@
                     <artifactId>commons-logging</artifactId>
                     <groupId>commons-logging</groupId>
                 </exclusion>
+                <!-- A test mock, pulled at compile scope, whose bundled json-path shadows the real one: see #485 -->
+                <exclusion>
+                    <groupId>org.herddb</groupId>
+                    <artifactId>herddb-mock</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -297,8 +297,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -307,6 +307,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/carapace-server/src/test/java/org/carapaceproxy/ApplyConfigurationIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/ApplyConfigurationIT.java
@@ -302,8 +302,7 @@ public class ApplyConfigurationIT {
         try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, newFolder(tmpDir, "junit"));) {
             server.configureAtBoot(new PropertiesConfigurationStore(props("filter.1.type", "add-x-forwarded-for")));
             server.start();
-            assertThat(server.getFilters()).hasSize(1);
-            assertThat(server.getFilters().get(0)).isInstanceOf(XForwardedForRequestFilter.class);
+            assertThat(server.getFilters()).hasExactlyElementsOfTypes(XForwardedForRequestFilter.class);
 
             // add a filter
             reloadConfiguration(server, props(Map.of(
@@ -311,14 +310,11 @@ public class ApplyConfigurationIT {
                     "filter.2.type", "match-user-regexp"
             )));
 
-            assertThat(server.getFilters()).hasSize(2);
-            assertThat(server.getFilters().get(0)).isInstanceOf(XForwardedForRequestFilter.class);
-            assertThat(server.getFilters().get(1)).isInstanceOf(RegexpMapUserIdFilter.class);
+            assertThat(server.getFilters()).hasExactlyElementsOfTypes(XForwardedForRequestFilter.class, RegexpMapUserIdFilter.class);
 
             // remove a filter
             reloadConfiguration(server, props("filter.2.type", "match-user-regexp"));
-            assertThat(server.getFilters()).hasSize(1);
-            assertThat(server.getFilters().get(0)).isInstanceOf(RegexpMapUserIdFilter.class);
+            assertThat(server.getFilters()).hasExactlyElementsOfTypes(RegexpMapUserIdFilter.class);
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/ApplyConfigurationIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/ApplyConfigurationIT.java
@@ -24,21 +24,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.fail;
 import static org.carapaceproxy.utils.ApacheHttpUtils.createHttpClientWithDisabledSSLValidation;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.aMapWithSize;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.anEmptyMap;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -79,7 +68,7 @@ public class ApplyConfigurationIT {
     public File tmpDir;
 
     @BeforeEach
-    public void setupWireMock() {
+    void setupWireMock() {
         wireMockRule.stubFor(get(urlEqualTo("/index.html?redir"))
                 .willReturn(aResponse()
                         .withStatus(HttpStatus.SC_OK)
@@ -91,7 +80,7 @@ public class ApplyConfigurationIT {
     }
 
     @Test
-    public void testChangeListenersConfig() throws Exception {
+    void changeListenersConfig() throws Exception {
         try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, newFolder(tmpDir, "junit"));) {
             server.configureAtBoot(new PropertiesConfigurationStore(propsWithMapper(Map.of(
                     "aws.accesskey", "accesskey",
@@ -177,27 +166,27 @@ public class ApplyConfigurationIT {
             testIt(1423, true, true);
 
             // listener with wrong tls version
-            final IllegalStateException e = assertThrows(IllegalStateException.class, () ->
+            final IllegalStateException e = assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() ->
                     reloadConfiguration(server, propsWithMapperAndCertificate(defaultCertificate, Map.of(
-                    "listener.1.host", "localhost",
-                    "listener.1.port", "1423",
-                    "listener.1.ssl", "true",
-                    "listener.1.sslprotocols", "TLSUNKNOWN"
-            ))));
+                            "listener.1.host", "localhost",
+                            "listener.1.port", "1423",
+                            "listener.1.ssl", "true",
+                            "listener.1.sslprotocols", "TLSUNKNOWN"
+                    )))).actual();
             Throwable cause = e.getCause();
-            assertThat(cause, instanceOf(ConfigurationNotValidException.class));
-            assertThat(cause.getMessage(), containsString("Unsupported SSL Protocols"));
+            assertThat(cause).isInstanceOf(ConfigurationNotValidException.class);
+            assertThat(cause.getMessage()).contains("Unsupported SSL Protocols");
         }
     }
 
     @Test
-    public void testReloadMapper() throws Exception {
+    void reloadMapper() throws Exception {
         try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, newFolder(tmpDir, "junit"));) {
             server.configureAtBoot(new PropertiesConfigurationStore(new Properties()));
             server.start();
 
-            assertThat(server.getMapper(), instanceOf(StandardEndpointMapper.class));
-            assertThat(server.getMapper().getBackends(), is(anEmptyMap()));
+            assertThat(server.getMapper()).isInstanceOf(StandardEndpointMapper.class);
+            assertThat(server.getMapper().getBackends()).isEmpty();
 
             // add backend
             reloadConfiguration(server, props(Map.of(
@@ -206,11 +195,10 @@ public class ApplyConfigurationIT {
                     "backend.1.port", "4213",
                     "backend.1.enabled", "true"
             )));
-            assertThat(server.getMapper(), instanceOf(StandardEndpointMapper.class));
-            assertThat(server.getMapper().getBackends(), allOf(
-                    is(aMapWithSize(1)),
-                    hasKey("foo")
-            ));
+            assertThat(server.getMapper()).isInstanceOf(StandardEndpointMapper.class);
+            assertThat(server.getMapper().getBackends())
+                    .hasSize(1)
+                    .containsKey("foo");
 
             // add second backend
             reloadConfiguration(server, props(Map.of(
@@ -224,12 +212,11 @@ public class ApplyConfigurationIT {
                     "backend.2.enabled", "true"
             )));
 
-            assertThat(server.getMapper(), instanceOf(StandardEndpointMapper.class));
-            assertThat(server.getMapper().getBackends(), allOf(
-                    is(aMapWithSize(2)),
-                    hasKey("foo"),
-                    hasKey("bar")
-            ));
+            assertThat(server.getMapper()).isInstanceOf(StandardEndpointMapper.class);
+            assertThat(server.getMapper().getBackends())
+                    .hasSize(2)
+                    .containsKey("foo")
+                    .containsKey("bar");
 
             // remove first backend
             reloadConfiguration(server, props(Map.of(
@@ -239,11 +226,10 @@ public class ApplyConfigurationIT {
                     "backend.2.enabled", "true"
             )));
 
-            assertThat(server.getMapper(), instanceOf(StandardEndpointMapper.class));
-            assertThat(server.getMapper().getBackends(), allOf(
-                    is(aMapWithSize(1)),
-                    hasKey("bar")
-            ));
+            assertThat(server.getMapper()).isInstanceOf(StandardEndpointMapper.class);
+            assertThat(server.getMapper().getBackends())
+                    .hasSize(1)
+                    .containsKey("bar");
         }
     }
 
@@ -259,7 +245,7 @@ public class ApplyConfigurationIT {
     }
 
     @Test
-    public void testUserRealm() throws Exception {
+    void userRealm() throws Exception {
 
         // Default UserRealm
         try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, newFolder(tmpDir, "junit"))) {
@@ -267,15 +253,15 @@ public class ApplyConfigurationIT {
             server.start();
 
             UserRealm realm = server.getRealm();
-            assertThat(realm, is(instanceOf(SimpleUserRealm.class)));
+            assertThat(realm).isInstanceOf(SimpleUserRealm.class);
 
             // default user with auth always valid
             SimpleUserRealm userRealm = (SimpleUserRealm) server.getRealm();
-            assertThat(userRealm.listUsers(), hasSize(1));
+            assertThat(userRealm.listUsers()).hasSize(1);
 
-            assertNotNull(userRealm.login("test_0", "anypass0"));
-            assertNotNull(userRealm.login("test_1", "anypass1"));
-            assertNotNull(userRealm.login("test_2", "anypass2"));
+            assertThat(userRealm.login("test_0", "anypass0")).isNotNull();
+            assertThat(userRealm.login("test_1", "anypass1")).isNotNull();
+            assertThat(userRealm.login("test_2", "anypass2")).isNotNull();
         }
 
         // TestUserRealm
@@ -288,13 +274,13 @@ public class ApplyConfigurationIT {
             server.start();
 
             UserRealm realm = server.getRealm();
-            assertThat(realm, is(instanceOf(TestUserRealm.class)));
+            assertThat(realm).isInstanceOf(TestUserRealm.class);
 
             TestUserRealm userRealm = (TestUserRealm) server.getRealm();
-            assertThat(userRealm.listUsers(), hasSize(2));
-            assertNotNull(userRealm.login("test1", "pass1"));
-            assertNotNull(userRealm.login("test2", "pass2"));
-            assertNull(userRealm.login("test1", "pass3")); // wrong pass
+            assertThat(userRealm.listUsers()).hasSize(2);
+            assertThat(userRealm.login("test1", "pass1")).isNotNull();
+            assertThat(userRealm.login("test2", "pass2")).isNotNull();
+            assertThat(userRealm.login("test1", "pass3")).isNull(); // wrong pass
 
             // Add new user
             reloadConfiguration(server, props(Map.of(
@@ -305,19 +291,19 @@ public class ApplyConfigurationIT {
             )));
 
             userRealm = (TestUserRealm) server.getRealm(); // realm re-created at each configuration reload
-            assertThat(userRealm.listUsers(), hasSize(3));
-            assertNotNull(userRealm.login("test3", "pass3"));
+            assertThat(userRealm.listUsers()).hasSize(3);
+            assertThat(userRealm.login("test3", "pass3")).isNotNull();
         }
     }
 
     @SuppressWarnings("deprecation")
     @Test
-    public void testChangeFiltersConfiguration() throws Exception {
+    void changeFiltersConfiguration() throws Exception {
         try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, newFolder(tmpDir, "junit"));) {
             server.configureAtBoot(new PropertiesConfigurationStore(props("filter.1.type", "add-x-forwarded-for")));
             server.start();
-            assertThat(server.getFilters(), hasSize(1));
-            assertThat(server.getFilters().get(0), instanceOf(XForwardedForRequestFilter.class));
+            assertThat(server.getFilters()).hasSize(1);
+            assertThat(server.getFilters().get(0)).isInstanceOf(XForwardedForRequestFilter.class);
 
             // add a filter
             reloadConfiguration(server, props(Map.of(
@@ -325,14 +311,14 @@ public class ApplyConfigurationIT {
                     "filter.2.type", "match-user-regexp"
             )));
 
-            assertThat(server.getFilters(), hasSize(2));
-            assertThat(server.getFilters().get(0), is(instanceOf(XForwardedForRequestFilter.class)));
-            assertThat(server.getFilters().get(1), is(instanceOf(RegexpMapUserIdFilter.class)));
+            assertThat(server.getFilters()).hasSize(2);
+            assertThat(server.getFilters().get(0)).isInstanceOf(XForwardedForRequestFilter.class);
+            assertThat(server.getFilters().get(1)).isInstanceOf(RegexpMapUserIdFilter.class);
 
             // remove a filter
             reloadConfiguration(server, props("filter.2.type", "match-user-regexp"));
-            assertThat(server.getFilters(), hasSize(1));
-            assertThat(server.getFilters().get(0), is(instanceOf(RegexpMapUserIdFilter.class)));
+            assertThat(server.getFilters()).hasSize(1);
+            assertThat(server.getFilters().get(0)).isInstanceOf(RegexpMapUserIdFilter.class);
         }
     }
 
@@ -341,15 +327,15 @@ public class ApplyConfigurationIT {
     }
 
     @Test
-    public void testChangeBackendHealthManagerConfiguration() throws Exception {
+    void changeBackendHealthManagerConfiguration() throws Exception {
         try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, newFolder(tmpDir, "junit"));) {
             server.configureAtBoot(new PropertiesConfigurationStore(props("healthmanager.connecttimeout", "9479")));
             server.start();
-            assertEquals(9479, server.getBackendHealthManager().getConnectTimeout());
+            assertThat(server.getBackendHealthManager().getConnectTimeout()).isEqualTo(9479);
 
             // change configuration
             reloadConfiguration(server, props("healthmanager.connecttimeout", "9233"));
-            assertEquals(9233, server.getBackendHealthManager().getConnectTimeout());
+            assertThat(server.getBackendHealthManager().getConnectTimeout()).isEqualTo(9233);
         }
     }
 
@@ -368,7 +354,7 @@ public class ApplyConfigurationIT {
                 final String responseBody = new String(response.getEntity().getContent().readAllBytes(), UTF_8);
 
                 System.out.println("RES FOR: " + url + " -> " + responseBody);
-                assertEquals("it <b>works</b> !!", responseBody);
+                assertThat(responseBody).isEqualTo("it <b>works</b> !!");
 
                 if (!ok && statusCode == HttpStatus.SC_OK) {
                     fail("Expecting an error for port " + port);

--- a/carapace-server/src/test/java/org/carapaceproxy/BigUploadIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/BigUploadIT.java
@@ -23,8 +23,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -62,21 +61,21 @@ public class BigUploadIT {
     private HttpProxyServer server;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         final TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.getPort());
         server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir);
         server.start();
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         if (server != null) {
             server.close();
         }
     }
 
     @Test
-    public void testProxyReturns503OnBackendConnectionDrop() {
+    void proxyReturns503OnBackendConnectionDrop() {
         wireMockRule.stubFor(post(urlEqualTo("/index.html"))
                 // backend server abruptly closes the connection while the client is sending a large upload
                 .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER).withFixedDelay(2000)));
@@ -93,8 +92,8 @@ public class BigUploadIT {
                 .assertNext(tuple -> {
                     final HttpClientResponse response = tuple.getT1();
                     final String body = tuple.getT2();
-                    assertEquals(503, response.status().code());
-                    assertTrue(body.contains("Service Unavailable"));
+                    assertThat(response.status().code()).isEqualTo(503);
+                    assertThat(body).contains("Service Unavailable");
                 })
                 .verifyComplete();
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/ConcurrentClientsIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/ConcurrentClientsIT.java
@@ -30,12 +30,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.function.Function;
 import org.carapaceproxy.core.HttpProxyServer;
-import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.utils.TestEndpointMapper;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
@@ -55,8 +54,8 @@ public class ConcurrentClientsIT {
     public File tmpDir;
 
     @ParameterizedTest
-    @CsvSource({"true", "false"})
-    public void testClients(final boolean concurrent) throws ConfigurationNotValidException, InterruptedException, IOException {
+    @ValueSource(booleans = {true, false})
+    void clients(final boolean concurrent) throws Exception {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(200)

--- a/carapace-server/src/test/java/org/carapaceproxy/ConcurrentClientsIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/ConcurrentClientsIT.java
@@ -53,7 +53,7 @@ public class ConcurrentClientsIT {
     @TempDir
     public File tmpDir;
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "concurrent={0}")
     @ValueSource(booleans = {true, false})
     void clients(final boolean concurrent) throws Exception {
         stubFor(get(urlEqualTo("/index.html"))

--- a/carapace-server/src/test/java/org/carapaceproxy/DatabaseConfigurationIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/DatabaseConfigurationIT.java
@@ -20,10 +20,7 @@ package org.carapaceproxy;
 
  */
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -47,7 +44,7 @@ public class DatabaseConfigurationIT {
     public File tmpDir;
 
     @Test
-    public void testBootWithDatabaseStore() throws Exception {
+    void bootWithDatabaseStore() throws Exception {
 
         try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, newFolder(tmpDir, "junit"))) {
 
@@ -59,7 +56,7 @@ public class DatabaseConfigurationIT {
             server.configureAtBoot(new PropertiesConfigurationStore(configuration));
 
             server.start();
-            assertThat(server.getDynamicConfigurationStore(), instanceOf(HerdDBConfigurationStore.class));
+            assertThat(server.getDynamicConfigurationStore()).isInstanceOf(HerdDBConfigurationStore.class);
 
         }
 
@@ -81,41 +78,41 @@ public class DatabaseConfigurationIT {
         try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, newFolder(tmpDir, "junit"))) {
             server.configureAtBoot(new PropertiesConfigurationStore(dbBootConfig(dbDir)));
             server.start();
-            assertInstanceOf(HerdDBConfigurationStore.class, server.getDynamicConfigurationStore());
+            assertThat(server.getDynamicConfigurationStore()).isInstanceOf(HerdDBConfigurationStore.class);
 
             server.applyDynamicConfigurationFromAPI(new PropertiesConfigurationStore(
                     filters("filter.1.type", XForwardedForRequestFilter.TYPE)));
-            assertEquals(1, server.getFilters().size());
-            assertInstanceOf(XForwardedForRequestFilter.class, server.getFilters().get(0));
+            assertThat(server.getFilters()).hasSize(1);
+            assertThat(server.getFilters().get(0)).isInstanceOf(XForwardedForRequestFilter.class);
 
             server.applyDynamicConfigurationFromAPI(new PropertiesConfigurationStore(filters(
                     "filter.1.type", XForwardedForRequestFilter.TYPE,
                     "filter.2.type", RegexpMapUserIdFilter.TYPE)));
-            assertEquals(2, server.getFilters().size());
-            assertInstanceOf(XForwardedForRequestFilter.class, server.getFilters().get(0));
-            assertInstanceOf(RegexpMapUserIdFilter.class, server.getFilters().get(1));
+            assertThat(server.getFilters()).hasSize(2);
+            assertThat(server.getFilters().get(0)).isInstanceOf(XForwardedForRequestFilter.class);
+            assertThat(server.getFilters().get(1)).isInstanceOf(RegexpMapUserIdFilter.class);
         }
 
         // Boot #2: the two filters must have persisted; then reduce to a single filter.
         try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, newFolder(tmpDir, "junit"))) {
             server.configureAtBoot(new PropertiesConfigurationStore(dbBootConfig(dbDir)));
-            assertEquals(2, server.getFilters().size());
-            assertInstanceOf(XForwardedForRequestFilter.class, server.getFilters().get(0));
-            assertInstanceOf(RegexpMapUserIdFilter.class, server.getFilters().get(1));
+            assertThat(server.getFilters()).hasSize(2);
+            assertThat(server.getFilters().get(0)).isInstanceOf(XForwardedForRequestFilter.class);
+            assertThat(server.getFilters().get(1)).isInstanceOf(RegexpMapUserIdFilter.class);
 
             server.start();
 
             server.applyDynamicConfigurationFromAPI(new PropertiesConfigurationStore(
                     filters("filter.1.type", RegexpMapUserIdFilter.TYPE)));
-            assertEquals(1, server.getFilters().size());
-            assertInstanceOf(RegexpMapUserIdFilter.class, server.getFilters().get(0));
+            assertThat(server.getFilters()).hasSize(1);
+            assertThat(server.getFilters().get(0)).isInstanceOf(RegexpMapUserIdFilter.class);
         }
 
         // Boot #3: the single remaining filter must have persisted.
         try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, newFolder(tmpDir, "junit"))) {
             server.configureAtBoot(new PropertiesConfigurationStore(dbBootConfig(dbDir)));
-            assertEquals(1, server.getFilters().size());
-            assertInstanceOf(RegexpMapUserIdFilter.class, server.getFilters().get(0));
+            assertThat(server.getFilters()).hasSize(1);
+            assertThat(server.getFilters().get(0)).isInstanceOf(RegexpMapUserIdFilter.class);
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/DatabaseConfigurationIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/DatabaseConfigurationIT.java
@@ -82,37 +82,30 @@ public class DatabaseConfigurationIT {
 
             server.applyDynamicConfigurationFromAPI(new PropertiesConfigurationStore(
                     filters("filter.1.type", XForwardedForRequestFilter.TYPE)));
-            assertThat(server.getFilters()).hasSize(1);
-            assertThat(server.getFilters().get(0)).isInstanceOf(XForwardedForRequestFilter.class);
+            assertThat(server.getFilters()).hasExactlyElementsOfTypes(XForwardedForRequestFilter.class);
 
             server.applyDynamicConfigurationFromAPI(new PropertiesConfigurationStore(filters(
                     "filter.1.type", XForwardedForRequestFilter.TYPE,
                     "filter.2.type", RegexpMapUserIdFilter.TYPE)));
-            assertThat(server.getFilters()).hasSize(2);
-            assertThat(server.getFilters().get(0)).isInstanceOf(XForwardedForRequestFilter.class);
-            assertThat(server.getFilters().get(1)).isInstanceOf(RegexpMapUserIdFilter.class);
+            assertThat(server.getFilters()).hasExactlyElementsOfTypes(XForwardedForRequestFilter.class, RegexpMapUserIdFilter.class);
         }
 
         // Boot #2: the two filters must have persisted; then reduce to a single filter.
         try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, newFolder(tmpDir, "junit"))) {
             server.configureAtBoot(new PropertiesConfigurationStore(dbBootConfig(dbDir)));
-            assertThat(server.getFilters()).hasSize(2);
-            assertThat(server.getFilters().get(0)).isInstanceOf(XForwardedForRequestFilter.class);
-            assertThat(server.getFilters().get(1)).isInstanceOf(RegexpMapUserIdFilter.class);
+            assertThat(server.getFilters()).hasExactlyElementsOfTypes(XForwardedForRequestFilter.class, RegexpMapUserIdFilter.class);
 
             server.start();
 
             server.applyDynamicConfigurationFromAPI(new PropertiesConfigurationStore(
                     filters("filter.1.type", RegexpMapUserIdFilter.TYPE)));
-            assertThat(server.getFilters()).hasSize(1);
-            assertThat(server.getFilters().get(0)).isInstanceOf(RegexpMapUserIdFilter.class);
+            assertThat(server.getFilters()).hasExactlyElementsOfTypes(RegexpMapUserIdFilter.class);
         }
 
         // Boot #3: the single remaining filter must have persisted.
         try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, newFolder(tmpDir, "junit"))) {
             server.configureAtBoot(new PropertiesConfigurationStore(dbBootConfig(dbDir)));
-            assertThat(server.getFilters()).hasSize(1);
-            assertThat(server.getFilters().get(0)).isInstanceOf(RegexpMapUserIdFilter.class);
+            assertThat(server.getFilters()).hasExactlyElementsOfTypes(RegexpMapUserIdFilter.class);
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/MaintenanceModeIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/MaintenanceModeIT.java
@@ -4,8 +4,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -28,7 +27,7 @@ public class MaintenanceModeIT extends UseAdminServer {
     private Properties config;
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
 
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
@@ -86,26 +85,26 @@ public class MaintenanceModeIT extends UseAdminServer {
                 .build();
 
         HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-        assertEquals("it <b>works</b> !!", response.body());
+        assertThat(response.body()).isEqualTo("it <b>works</b> !!");
 
         //enable maintenance mode
         config.put("carapace.maintenancemode.enabled", "true");
         changeDynamicConfiguration(config);
         HttpResponse<String> response2 = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-        assertEquals(500, response2.statusCode());
-        assertTrue(response2.body().contains("Maintenance in progress"));
+        assertThat(response2.statusCode()).isEqualTo(500);
+        assertThat(response2.body()).contains("Maintenance in progress");
 
         //disable maintenance mode
         config.put("carapace.maintenancemode.enabled", "false");
         changeDynamicConfiguration(config);
         HttpResponse<String> response3 = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-        assertEquals("it <b>works</b> !!", response3.body());
+        assertThat(response3.body()).isEqualTo("it <b>works</b> !!");
 
     }
 
 
     @Test
-    public void maintenanceModeApiTest() throws Exception {
+    void maintenanceModeApiTest() throws Exception {
 
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
@@ -163,7 +162,7 @@ public class MaintenanceModeIT extends UseAdminServer {
                 .build();
 
         HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-        assertEquals("it <b>works</b> !!", response.body());
+        assertThat(response.body()).isEqualTo("it <b>works</b> !!");
 
         // ENABLE MAINTENANCE MODE VIA API
         HttpRequest enableMaintenanceRequest = HttpRequest.newBuilder()
@@ -174,12 +173,12 @@ public class MaintenanceModeIT extends UseAdminServer {
                 .build();
 
         HttpResponse<String> enableMaintenanceModeResponse = httpClient.send(enableMaintenanceRequest, HttpResponse.BodyHandlers.ofString());
-        assertEquals("{\"ok\":true,\"error\":\"\"}", enableMaintenanceModeResponse.body());
+        assertThat(enableMaintenanceModeResponse.body()).isEqualTo("{\"ok\":true,\"error\":\"\"}");
 
         HttpResponse<String> response2 = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
-        assertEquals(500, response2.statusCode());
-        assertTrue(response2.body().contains("Maintenance in progress"));
+        assertThat(response2.statusCode()).isEqualTo(500);
+        assertThat(response2.body()).contains("Maintenance in progress");
 
         //DISABLE MAINTENANCE MODE VIA API
         HttpRequest disableMaintenanceModeRequest = HttpRequest.newBuilder()
@@ -190,10 +189,10 @@ public class MaintenanceModeIT extends UseAdminServer {
                 .build();
 
         HttpResponse<String> disableMaintenanceModeResponse = httpClient.send(disableMaintenanceModeRequest, HttpResponse.BodyHandlers.ofString());
-        assertEquals("{\"ok\":false,\"error\":\"\"}", disableMaintenanceModeResponse.body());
+        assertThat(disableMaintenanceModeResponse.body()).isEqualTo("{\"ok\":false,\"error\":\"\"}");
 
         HttpResponse<String> response3 = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-        assertEquals("it <b>works</b> !!", response3.body());
+        assertThat(response3.body()).isEqualTo("it <b>works</b> !!");
 
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/MaintenanceModeIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/MaintenanceModeIT.java
@@ -1,5 +1,6 @@
 package org.carapaceproxy;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -173,7 +174,7 @@ public class MaintenanceModeIT extends UseAdminServer {
                 .build();
 
         HttpResponse<String> enableMaintenanceModeResponse = httpClient.send(enableMaintenanceRequest, HttpResponse.BodyHandlers.ofString());
-        assertThat(enableMaintenanceModeResponse.body()).isEqualTo("{\"ok\":true,\"error\":\"\"}");
+        assertThatJson(enableMaintenanceModeResponse.body()).isEqualTo("{ok: true, error: ''}");
 
         HttpResponse<String> response2 = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
@@ -189,7 +190,8 @@ public class MaintenanceModeIT extends UseAdminServer {
                 .build();
 
         HttpResponse<String> disableMaintenanceModeResponse = httpClient.send(disableMaintenanceModeRequest, HttpResponse.BodyHandlers.ofString());
-        assertThat(disableMaintenanceModeResponse.body()).isEqualTo("{\"ok\":false,\"error\":\"\"}");
+        // ok is the maintenance-mode state the call left behind, not whether the call succeeded
+        assertThatJson(disableMaintenanceModeResponse.body()).isEqualTo("{ok: false, error: ''}");
 
         HttpResponse<String> response3 = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         assertThat(response3.body()).isEqualTo("it <b>works</b> !!");

--- a/carapace-server/src/test/java/org/carapaceproxy/RawClientIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/RawClientIT.java
@@ -29,15 +29,12 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_FORWARDED_STRATEGY;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
 import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.STATIC;
 import static org.carapaceproxy.utils.RawHttpClient.consumeHttpResponseInput;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static reactor.netty.http.HttpProtocol.HTTP11;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -108,7 +105,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,7 +126,7 @@ public class RawClientIT {
     private String testName;
 
     @BeforeEach
-    public void dumpTestName(TestInfo testInfo) {
+    void dumpTestName(TestInfo testInfo) {
         Optional<Method> testMethod = testInfo.getTestMethod();
         if (testMethod.isPresent()) {
             this.testName = testMethod.get().getName();
@@ -138,12 +135,12 @@ public class RawClientIT {
     }
 
     @AfterEach
-    public void dumpTestNameEnd() {
+    void dumpTestNameEnd() {
         LOG.info("End {}", testName);
     }
 
     @Test
-    public void clientsKeepAliveSimpleTest() throws Exception {
+    void clientsKeepAliveSimpleTest() throws Exception {
 
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
@@ -160,14 +157,12 @@ public class RawClientIT {
 
                 String s = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n").getBodyString();
                 System.out.println("s:" + s);
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
 
-                try {
+                assertThatThrownBy(() -> {
                     String s2 = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n").getBodyString();
                     System.out.println("response2: " + s2);
-                    fail();
-                } catch (IOException ok) {
-                }
+                }).isInstanceOf(IOException.class);
 
             }
 
@@ -175,7 +170,7 @@ public class RawClientIT {
 
                 String s = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString();
                 System.out.println("s3:" + s);
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
 
                 // this is needed for Travis, that runs with 1 vCPU!
                 // without this sleep the connection pool is not able to reuse the connection (this appears to the
@@ -184,13 +179,13 @@ public class RawClientIT {
 
                 String s2 = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString();
                 System.out.println("s4:" + s2);
-                assertEquals("it <b>works</b> !!", s2);
+                assertThat(s2).isEqualTo("it <b>works</b> !!");
             }
         }
     }
 
     @Test
-    public void testManyInflightRequests() throws Exception {
+    void manyInflightRequests() throws Exception {
 
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
@@ -202,7 +197,7 @@ public class RawClientIT {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir)) {
             server.start();
             int port = server.getLocalPort();
-            assertTrue(port > 0);
+            assertThat(port).isGreaterThan(0);
 
             List<RawHttpClient> clients = new ArrayList<>();
             for (int i = 0; i < 20; i++) {
@@ -218,7 +213,7 @@ public class RawClientIT {
     }
 
     @Test
-    public void testKeepAliveTimeout() throws Exception {
+    void keepAliveTimeout() throws Exception {
         final RawHttpServer httpServer = new RawHttpServer(new HttpServlet() {
             public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
                 response.setContentType("text/html");
@@ -234,7 +229,7 @@ public class RawClientIT {
             try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir)) {
                 server.start();
                 int port = server.getLocalPort();
-                assertTrue(port > 0);
+                assertThat(port).isGreaterThan(0);
 
                 try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                     for (int j = 0; j < 2; j++) {
@@ -251,7 +246,7 @@ public class RawClientIT {
     }
 
     @Test
-    public void testEmptyDataFromServer() throws Exception {
+    void emptyDataFromServer() throws Exception {
         final RawHttpServer httpServer = new RawHttpServer(new HttpServlet() {
             public void doGet(HttpServletRequest request, HttpServletResponse response) {
             }
@@ -262,7 +257,7 @@ public class RawClientIT {
             try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir)) {
                 server.start();
                 int port = server.getLocalPort();
-                assertTrue(port > 0);
+                assertThat(port).isGreaterThan(0);
 
                 try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                     for (int j = 0; j < 2; j++) {
@@ -278,7 +273,7 @@ public class RawClientIT {
     }
 
     @Test
-    public void testServerRequestContinue() throws Exception {
+    void serverRequestContinue() throws Exception {
         AtomicBoolean responseEnabled = new AtomicBoolean();
         final int dummyServerPort = 8086;
         try (DummyServer server = new DummyServer("localhost", dummyServerPort, responseEnabled)) {
@@ -294,7 +289,7 @@ public class RawClientIT {
                 proxy.getProxyRequestsManager().reloadConfiguration(proxy.getCurrentConfiguration(), mapper.getBackends().values());
                 proxy.start();
                 int port = proxy.getLocalPort();
-                assertTrue(port > 0);
+                assertThat(port).isGreaterThan(0);
 
                 AtomicBoolean failed = new AtomicBoolean();
                 AtomicBoolean c2go = new AtomicBoolean();
@@ -372,7 +367,7 @@ public class RawClientIT {
                     ex.shutdown();
                     ex.awaitTermination(1, TimeUnit.MINUTES);
                 }
-                assertThat(failed.get(), is(false));
+                assertThat(failed.get()).isFalse();
             }
         }
     }
@@ -477,7 +472,7 @@ public class RawClientIT {
     }
 
     @Test
-    public void testMultiClientTimeout() throws Exception {
+    void multiClientTimeout() throws Exception {
         stubFor(post(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -502,7 +497,7 @@ public class RawClientIT {
             proxy.getProxyRequestsManager().reloadConfiguration(proxy.getCurrentConfiguration(), mapper.getBackends().values());
             proxy.start();
             int port = proxy.getLocalPort();
-            assertTrue(port > 0);
+            assertThat(port).isGreaterThan(0);
 
             AtomicBoolean failed = new AtomicBoolean();
             AtomicBoolean c2go = new AtomicBoolean();
@@ -567,12 +562,12 @@ public class RawClientIT {
                 ex.shutdown();
                 ex.awaitTermination(1, TimeUnit.MINUTES);
             }
-            assertThat(failed.get(), is(false));
+            assertThat(failed.get()).isFalse();
         }
     }
 
     @Test
-    public void testInvalidUriChars() throws Exception {
+    void invalidUriChars() throws Exception {
         stubFor(get(UrlPattern.ANY)
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -587,14 +582,14 @@ public class RawClientIT {
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.executeRequest("GET /index[1].html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n").getBodyString();
                 System.out.println("s:" + s);
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
             }
         }
     }
 
     @ParameterizedTest
-    @CsvSource({"http", "https"})
-    public void testClosedProxy(String scheme) throws Exception {
+    @ValueSource(strings = {"http", "https"})
+    void closedProxy(String scheme) throws Exception {
         TestUtils.deployResource("localhost.p12", tmpDir);
 
         // Proxy requests have to use "localhost:port" as endpoint instead of the one in the url (ex yahoo.com)
@@ -616,9 +611,9 @@ public class RawClientIT {
                                 .withHeader("Content-Length", "it <b>works</b> !!".length() + "")
                                 .withBody("it <b>works</b> !!")));
                 String s = client.executeRequest("GET " + scheme + "://yahoo.com/index.html?p1=v1&p2=https://localhost/index.html?p=1 HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString();
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
                 s = client.get("/index.html?p1=v1&p2=https://localhost/index.html?p=1").getBodyString();
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
 
                 stubFor(get("/index.html")
                         .willReturn(aResponse()
@@ -627,9 +622,9 @@ public class RawClientIT {
                                 .withHeader("Content-Length", "it <b>works</b> !!".length() + "")
                                 .withBody("it <b>works</b> !!")));
                 s = client.executeRequest("GET " + scheme + "://yahoo.com/index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString();
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
                 s = client.get("/index.html").getBodyString();
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
 
                 stubFor(get("/?p1=v1&p2=https://localhost/index.html?p=1")
                         .withQueryParams(Map.of("p1", equalTo("v1"), "p2", equalTo("https://localhost/index.html?p=1")))
@@ -639,13 +634,13 @@ public class RawClientIT {
                                 .withHeader("Content-Length", "it <b>works</b> !!".length() + "")
                                 .withBody("it <b>works</b> !!")));
                 s = client.executeRequest("GET " + scheme + "://yahoo.com/?p1=v1&p2=https://localhost/index.html?p=1 HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString();
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
                 s = client.get("/?p1=v1&p2=https://localhost/index.html?p=1").getBodyString();
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
                 s = client.executeRequest("GET " + scheme + "://yahoo.com?p1=v1&p2=https://localhost/index.html?p=1 HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString();
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
                 s = client.get("?p1=v1&p2=https://localhost/index.html?p=1").getBodyString();
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
 
                 stubFor(get("/")
                         .willReturn(aResponse()
@@ -654,17 +649,17 @@ public class RawClientIT {
                                 .withHeader("Content-Length", "it <b>works</b> !!".length() + "")
                                 .withBody("it <b>works</b> !!")));
                 s = client.executeRequest("GET " + scheme + "://yahoo.com/ HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString();
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
                 s = client.get("/").getBodyString();
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
                 s = client.executeRequest("GET " + scheme + "://yahoo.com HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString();
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
             }
         }
     }
 
     @Test
-    public void testCookies() throws Exception {
+    void cookies() throws Exception {
         stubFor(get("/index.html")
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -682,14 +677,14 @@ public class RawClientIT {
                         + "\r\n" + HttpHeaderNames.COOKIE + ": requestCookie=requestValue; requestCookie2=requestValue2"
                         + "\r\nConnection: close\r\n\r\n"
                 );
-                assertEquals("it <b>works</b> !!", resp.getBodyString());
+                assertThat(resp.getBodyString()).isEqualTo("it <b>works</b> !!");
 
                 // cookies from server
                 List<String> headerSetCookie = resp.getHeaderLines().stream()
                         .filter(h -> h.toLowerCase().contains("set-cookie"))
                         .toList();
-                assertThat(headerSetCookie.size(), is(1));
-                assertThat(headerSetCookie.getFirst(), is("set-cookie: responseCookie=responseValue; responseCookie2=responseValue2\r\n"));
+                assertThat(headerSetCookie).hasSize(1);
+                assertThat(headerSetCookie).first().isEqualTo("set-cookie: responseCookie=responseValue; responseCookie2=responseValue2\r\n");
             }
         }
 
@@ -698,8 +693,8 @@ public class RawClientIT {
                 .getFirst()
                 .getHeaders()
                 .getHeader(HttpHeaderNames.COOKIE.toString());
-        assertThat(headerCookie.values().size(), is(1));
-        assertThat(headerCookie.values().getFirst(), is("requestCookie=requestValue; requestCookie2=requestValue2"));
+        assertThat(headerCookie.values()).hasSize(1);
+        assertThat(headerCookie.values()).first().isEqualTo("requestCookie=requestValue; requestCookie2=requestValue2");
     }
 
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/RawClientIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/RawClientIT.java
@@ -197,7 +197,6 @@ public class RawClientIT {
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir)) {
             server.start();
             int port = server.getLocalPort();
-            assertThat(port).isGreaterThan(0);
 
             List<RawHttpClient> clients = new ArrayList<>();
             for (int i = 0; i < 20; i++) {
@@ -229,7 +228,6 @@ public class RawClientIT {
             try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir)) {
                 server.start();
                 int port = server.getLocalPort();
-                assertThat(port).isGreaterThan(0);
 
                 try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                     for (int j = 0; j < 2; j++) {
@@ -257,7 +255,6 @@ public class RawClientIT {
             try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir)) {
                 server.start();
                 int port = server.getLocalPort();
-                assertThat(port).isGreaterThan(0);
 
                 try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                     for (int j = 0; j < 2; j++) {
@@ -289,7 +286,6 @@ public class RawClientIT {
                 proxy.getProxyRequestsManager().reloadConfiguration(proxy.getCurrentConfiguration(), mapper.getBackends().values());
                 proxy.start();
                 int port = proxy.getLocalPort();
-                assertThat(port).isGreaterThan(0);
 
                 AtomicBoolean failed = new AtomicBoolean();
                 AtomicBoolean c2go = new AtomicBoolean();
@@ -497,7 +493,6 @@ public class RawClientIT {
             proxy.getProxyRequestsManager().reloadConfiguration(proxy.getCurrentConfiguration(), mapper.getBackends().values());
             proxy.start();
             int port = proxy.getLocalPort();
-            assertThat(port).isGreaterThan(0);
 
             AtomicBoolean failed = new AtomicBoolean();
             AtomicBoolean c2go = new AtomicBoolean();

--- a/carapace-server/src/test/java/org/carapaceproxy/RawClientIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/RawClientIT.java
@@ -587,7 +587,7 @@ public class RawClientIT {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "scheme={0}")
     @ValueSource(strings = {"http", "https"})
     void closedProxy(String scheme) throws Exception {
         TestUtils.deployResource("localhost.p12", tmpDir);

--- a/carapace-server/src/test/java/org/carapaceproxy/RequestSmugglingVulnerabilityIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/RequestSmugglingVulnerabilityIT.java
@@ -8,7 +8,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -45,7 +45,7 @@ public class RequestSmugglingVulnerabilityIT {
 
 
     @Test
-    public void testCL0AttackGoesThrough() throws Exception {
+    void cl0AttackGoesThrough() throws Exception {
         stubFor(post(urlEqualTo("/legitimate"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -73,13 +73,13 @@ public class RequestSmugglingVulnerabilityIT {
                         \r
                         """);
                 List<LoggedRequest> adminRequests = findAll(getRequestedFor(urlEqualTo("/admin")));
-                assertEquals(0, adminRequests.size(), "Smuggled request should NOT reach backend (secure behavior)");
+                assertThat(adminRequests).as("Smuggled request should NOT reach backend (secure behavior)").isEmpty();
             }
         }
     }
 
     @Test
-    public void testCLTEAttackGoesThrough() throws Exception {
+    void clteAttackGoesThrough() throws Exception {
         stubFor(post(urlEqualTo("/search"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -113,13 +113,13 @@ public class RequestSmugglingVulnerabilityIT {
                         \r
                         """);
                 List<LoggedRequest> adminRequests = findAll(postRequestedFor(urlEqualTo("/admin/delete")));
-                assertEquals(0, adminRequests.size(), "Smuggled request should NOT reach backend (secure behavior)");
+                assertThat(adminRequests).as("Smuggled request should NOT reach backend (secure behavior)").isEmpty();
             }
         }
     }
 
     @Test
-    public void testNormalRequestWorks() throws Exception {
+    void normalRequestWorks() throws Exception {
         stubFor(get(urlEqualTo("/normal"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -136,10 +136,10 @@ public class RequestSmugglingVulnerabilityIT {
                         Connection: close\r
                         \r
                         """);
-                assertEquals(200, getStatusCode(response), "Normal request should succeed");
-                assertEquals("NORMAL_RESPONSE", response.getBodyString(), "Should receive expected response");
+                assertThat(getStatusCode(response)).as("Normal request should succeed").isEqualTo(200);
+                assertThat(response.getBodyString()).as("Should receive expected response").isEqualTo("NORMAL_RESPONSE");
                 List<LoggedRequest> requests = findAll(getRequestedFor(urlEqualTo("/normal")));
-                assertEquals(1, requests.size(), "Exactly one request should reach backend");
+                assertThat(requests).as("Exactly one request should reach backend").hasSize(1);
             }
         }
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/SimpleHTTPProxyIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/SimpleHTTPProxyIT.java
@@ -24,11 +24,11 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_FORWARDED_STRATEGY;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
 import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.STATIC;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 import static reactor.netty.http.HttpProtocol.HTTP11;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -68,7 +68,7 @@ public class SimpleHTTPProxyIT {
     public File tmpDir;
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
 
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.getPort());
         EndpointKey key = new EndpointKey("localhost", wireMockRule.getPort());
@@ -78,17 +78,15 @@ public class SimpleHTTPProxyIT {
             int port = server.getLocalPort();
 
             // not found
-            try {
+            assertThatThrownBy(() -> {
                 String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index.html?not-found"), StandardCharsets.UTF_8);
                 System.out.println("s:" + s);
-                fail();
-            } catch (FileNotFoundException ok) {
-            }
+            }).isInstanceOf(FileNotFoundException.class);
         }
     }
 
     @Test
-    public void testSsl() throws Exception {
+    void ssl() throws Exception {
 
         HttpTestUtils.overrideJvmWideHttpsVerifier();
 
@@ -111,24 +109,22 @@ public class SimpleHTTPProxyIT {
             int port = server.getLocalPort();
 
             // not found
-            try {
+            assertThatThrownBy(() -> {
                 String s = IOUtils.toString(URI.create("https://localhost:" + port + "/index.html?not-found"), StandardCharsets.UTF_8);
                 System.out.println("s:" + s);
-                fail();
-            } catch (FileNotFoundException ok) {
-            }
+            }).isInstanceOf(FileNotFoundException.class);
 
             // proxy
             {
                 String s = IOUtils.toString(URI.create("https://localhost:" + port + "/index.html?redir"), StandardCharsets.UTF_8);
                 System.out.println("s:" + s);
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
             }
         }
     }
 
     @Test
-    public void testEndpointDown() throws Exception {
+    void endpointDown() throws Exception {
 
         int badPort = TestUtils.getFreePort();
 
@@ -141,7 +137,7 @@ public class SimpleHTTPProxyIT {
 
             HttpTestUtils.ResourceInfos result = HttpTestUtils.downloadFromUrl(URI.create("http://localhost:" + port + "/index.html").toURL(),
                     new ByteArrayOutputStream(), Collections.singletonMap("return_errors", "true"));
-            assertEquals(503, result.responseCode);
+            assertThat(result.responseCode).isEqualTo(503);
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/SimpleHTTPProxyIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/SimpleHTTPProxyIT.java
@@ -81,7 +81,8 @@ public class SimpleHTTPProxyIT {
             assertThatThrownBy(() -> {
                 String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index.html?not-found"), StandardCharsets.UTF_8);
                 System.out.println("s:" + s);
-            }).isInstanceOf(FileNotFoundException.class);
+            }).isInstanceOf(FileNotFoundException.class)
+                    .hasMessageContaining("/index.html?not-found");
         }
     }
 
@@ -112,7 +113,8 @@ public class SimpleHTTPProxyIT {
             assertThatThrownBy(() -> {
                 String s = IOUtils.toString(URI.create("https://localhost:" + port + "/index.html?not-found"), StandardCharsets.UTF_8);
                 System.out.println("s:" + s);
-            }).isInstanceOf(FileNotFoundException.class);
+            }).isInstanceOf(FileNotFoundException.class)
+                    .hasMessageContaining("/index.html?not-found");
 
             // proxy
             {

--- a/carapace-server/src/test/java/org/carapaceproxy/api/AuthenticationAPIServerIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/AuthenticationAPIServerIT.java
@@ -61,12 +61,12 @@ class AuthenticationAPIServerIT extends UseAdminServer {
 
     private void assertHeaderNotContains(HttpResponse resp, String header) {
         List<String> lines = resp.getHeaderLines();
-        assertThat(lines).noneMatch(h -> h.contains(header));
+        assertThat(lines).noneSatisfy(h -> assertThat(h).contains(header));
     }
 
     private void assertHeaderContains(HttpResponse resp, String header) {
         List<String> lines = resp.getHeaderLines();
-        assertThat(lines).anyMatch(h -> h.contains(header));
+        assertThat(lines).anySatisfy(h -> assertThat(h).contains(header));
     }
 
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/api/AuthenticationAPIServerIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/AuthenticationAPIServerIT.java
@@ -27,19 +27,16 @@ import org.carapaceproxy.utils.RawHttpClient.BasicAuthCredentials;
 import org.carapaceproxy.utils.RawHttpClient.HttpResponse;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *
  * @author enrico.olivelli
  */
-public class AuthenticationAPIServerIT extends UseAdminServer {
+class AuthenticationAPIServerIT extends UseAdminServer {
 
     @Test
-    public void testUnauthorizedRequests() throws Exception {
+    void unauthorizedRequests() throws Exception {
         Properties prop = new Properties(HTTP_ADMIN_SERVER_CONFIG);
 
         prop.put("userrealm.class", "org.carapaceproxy.utils.TestUserRealm");
@@ -58,18 +55,18 @@ public class AuthenticationAPIServerIT extends UseAdminServer {
             BasicAuthCredentials credentials = new BasicAuthCredentials("wrongtest1", "wrongtest1"); // not valid credentials
             HttpResponse resp = client.get("/api/up", credentials);
             assertHeaderContains(resp, "WWW-Authenticate");
-            assertThat(resp.getBodyString(), containsString(HttpServletResponse.SC_UNAUTHORIZED + ""));
+            assertThat(resp.getBodyString()).contains(HttpServletResponse.SC_UNAUTHORIZED + "");
         }
     }
 
     private void assertHeaderNotContains(HttpResponse resp, String header) {
         List<String> lines = resp.getHeaderLines();
-        assertFalse(lines.stream().anyMatch(h -> h.contains(header)));
+        assertThat(lines).noneMatch(h -> h.contains(header));
     }
 
     private void assertHeaderContains(HttpResponse resp, String header) {
         List<String> lines = resp.getHeaderLines();
-        assertTrue(lines.stream().anyMatch(h -> h.contains(header)));
+        assertThat(lines).anyMatch(h -> h.contains(header));
     }
 
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/api/ClusterReconfigIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/ClusterReconfigIT.java
@@ -19,8 +19,7 @@
  */
 package org.carapaceproxy.api;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,10 +28,10 @@ import org.apache.curator.test.TestingServer;
 import org.carapaceproxy.utils.RawHttpClient;
 import org.junit.jupiter.api.Test;
 
-public class ClusterReconfigIT extends UseAdminServer {
+class ClusterReconfigIT extends UseAdminServer {
 
     @Test
-    public void testReconfigInClusterMode() throws Exception {
+    void reconfigInClusterMode() throws Exception {
         try (TestingServer testingServer = new TestingServer(2229, tmpDir);) {
             testingServer.start();
             Properties configuration = new Properties(HTTP_ADMIN_SERVER_CONFIG);
@@ -54,15 +53,15 @@ public class ClusterReconfigIT extends UseAdminServer {
                         + "Authorization: Basic " + credentials.toBase64() + "\r\n"
                         + "\r\n"
                         + body);
-                assertTrue(resp.isOk());
+                assertThat(resp.isOk()).isTrue();
             }
 
             // restart, same "static" configuration
             stopServer();
             buildNewServer();
             startServer(configuration);
-            assertEquals(8000, server.getCurrentConfiguration().getConnectTimeout());
-            assertEquals(25, server.getBackendHealthManager().getPeriod());
+            assertThat(server.getCurrentConfiguration().getConnectTimeout()).isEqualTo(8000);
+            assertThat(server.getBackendHealthManager().getPeriod()).isEqualTo(25);
             try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
                 String body = "connectionsmanager.connecttimeout=9000\n"
                         + "healthmanager.period=30";
@@ -73,16 +72,16 @@ public class ClusterReconfigIT extends UseAdminServer {
                         + "Authorization: Basic " + credentials.toBase64() + "\r\n"
                         + "\r\n"
                         + body);
-                assertTrue(resp.isOk());
+                assertThat(resp.isOk()).isTrue();
             }
-            assertEquals(9000, server.getCurrentConfiguration().getConnectTimeout());
-            assertEquals(30, server.getBackendHealthManager().getPeriod());
+            assertThat(server.getCurrentConfiguration().getConnectTimeout()).isEqualTo(9000);
+            assertThat(server.getBackendHealthManager().getPeriod()).isEqualTo(30);
             // restart, same "static" confguration
             stopServer();
             buildNewServer();
             startServer(configuration);
-            assertEquals(9000, server.getCurrentConfiguration().getConnectTimeout());
-            assertEquals(30, server.getBackendHealthManager().getPeriod());
+            assertThat(server.getCurrentConfiguration().getConnectTimeout()).isEqualTo(9000);
+            assertThat(server.getBackendHealthManager().getPeriod()).isEqualTo(30);
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/api/ConfigResourceIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/ConfigResourceIT.java
@@ -19,11 +19,7 @@
  */
 package org.carapaceproxy.api;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,15 +32,15 @@ import org.junit.jupiter.api.Test;
  *
  * @author enrico.olivelli
  */
-public class ConfigResourceIT extends UseAdminServer {
+class ConfigResourceIT extends UseAdminServer {
 
-    @Test
     // 0) Dumping of start-up configuration
     // 1) applying of dynamic configuration
     // 2) dumping of the current configuration
     // 3) updating+applying dumped configuration
     // 4) dumping updated configuration
-    public void testDynamicConfigurationDumpingAndApplying() throws Exception {
+    @Test
+    void dynamicConfigurationDumpingAndApplying() throws Exception {
         Properties configuration = new Properties(HTTP_ADMIN_SERVER_CONFIG);
         configuration.put("config.type", "database");
         configuration.put("db.jdbc.url", "jdbc:herddb:localhost");
@@ -58,7 +54,7 @@ public class ConfigResourceIT extends UseAdminServer {
             RawHttpClient.HttpResponse resp = client.get("/api/config", credentials);
             dumpedToReApply = resp.getBodyString();
             System.out.println("CONFIG:" + dumpedToReApply);
-            assertFalse(dumpedToReApply.contains("dynamiccertificatesmanager"));
+            assertThat(dumpedToReApply).doesNotContain("dynamiccertificatesmanager");
 
             // 1) Applying
             String body = "dynamiccertificatesmanager.period=45\n"
@@ -75,13 +71,13 @@ public class ConfigResourceIT extends UseAdminServer {
                     + "Authorization: Basic " + credentials.toBase64() + "\r\n"
                     + "\r\n"
                     + body);
-            assertTrue(resp.isOk());
+            assertThat(resp.isOk()).isTrue();
 
             // 2) Dumping + check
             resp = client.get("/api/config", credentials);
             dumpedToReApply = resp.getBodyString();
             System.out.println("CONFIG:" + dumpedToReApply);
-            assertThat(dumpedToReApply, containsString(body));
+            assertThat(dumpedToReApply).contains(body);
 
             // 3) Update config file + re-Applying
             dumpedToReApply = dumpedToReApply.replace("dynamiccertificatesmanager.period=45", "dynamiccertificatesmanager.period=30");
@@ -98,18 +94,18 @@ public class ConfigResourceIT extends UseAdminServer {
                     + "Authorization: Basic " + credentials.toBase64() + "\r\n"
                     + "\r\n"
                     + dumpedToReApply);
-            assertTrue(resp.isOk());
+            assertThat(resp.isOk()).isTrue();
 
             // 4) Dumping + check
             resp = client.get("/api/config", credentials);
             System.out.println("CONFIG:" + resp.getBodyString());
-            assertThat(resp.getBodyString(), containsString(dumpedToReApply));
+            assertThat(resp.getBodyString()).contains(dumpedToReApply);
         }
         stopServer();
     }
 
     @Test
-    public void testReconfig() throws Exception {
+    void reconfig() throws Exception {
         Properties configuration = new Properties(HTTP_ADMIN_SERVER_CONFIG);
 
         configuration.put("config.type", "database");
@@ -127,15 +123,15 @@ public class ConfigResourceIT extends UseAdminServer {
                     + "Authorization: Basic " + credentials.toBase64() + "\r\n"
                     + "\r\n"
                     + body);
-            assertTrue(resp.isOk());
+            assertThat(resp.isOk()).isTrue();
         }
 
         // restart, same "static" configuration
         stopServer();
         buildNewServer();
         startServer(configuration);
-        assertEquals(8000, server.getCurrentConfiguration().getConnectTimeout());
-        assertEquals(25, server.getBackendHealthManager().getPeriod());
+        assertThat(server.getCurrentConfiguration().getConnectTimeout()).isEqualTo(8000);
+        assertThat(server.getBackendHealthManager().getPeriod()).isEqualTo(25);
 
         try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             String body = "connectionsmanager.connecttimeout=9000\n"
@@ -147,16 +143,16 @@ public class ConfigResourceIT extends UseAdminServer {
                     + "Authorization: Basic " + credentials.toBase64() + "\r\n"
                     + "\r\n"
                     + body);
-            assertTrue(resp.isOk());
+            assertThat(resp.isOk()).isTrue();
         }
-        assertEquals(9000, server.getCurrentConfiguration().getConnectTimeout());
-        assertEquals(30, server.getBackendHealthManager().getPeriod());
+        assertThat(server.getCurrentConfiguration().getConnectTimeout()).isEqualTo(9000);
+        assertThat(server.getBackendHealthManager().getPeriod()).isEqualTo(30);
         // restart, same "static" confguration
         stopServer();
         buildNewServer();
         startServer(configuration);
-        assertEquals(9000, server.getCurrentConfiguration().getConnectTimeout());
-        assertEquals(30, server.getBackendHealthManager().getPeriod());
+        assertThat(server.getCurrentConfiguration().getConnectTimeout()).isEqualTo(9000);
+        assertThat(server.getBackendHealthManager().getPeriod()).isEqualTo(30);
     }
 
 

--- a/carapace-server/src/test/java/org/carapaceproxy/api/ConnectionPoolsResourceIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/ConnectionPoolsResourceIT.java
@@ -142,20 +142,8 @@ public class ConnectionPoolsResourceIT extends UseAdminServer {
             final var config = server.getCurrentConfiguration();
             assertThat(config.getConnectionPools()).containsOnlyKeys(DEFAULT_EXAMPLE_ORG, ALTERNATIVE_EXAMPLE_COM);
             final var newConnectionPool = config.getConnectionPools().get(ALTERNATIVE_EXAMPLE_COM);
-            assertThat(newConnectionPool.getId()).isEqualTo(ALTERNATIVE_EXAMPLE_COM);
-            assertThat(newConnectionPool.getDomain()).isEqualTo(ALTERNATIVE_EXAMPLE_COM);
-            assertThat(newConnectionPool.getMaxConnectionsPerEndpoint()).isEqualTo(MAX_CONNECTIONS_PER_ENDPOINT * 3);
-            assertThat(newConnectionPool.getBorrowTimeout()).isEqualTo(BORROW_TIMEOUT);
-            assertThat(newConnectionPool.getConnectTimeout()).isEqualTo(CONNECT_TIMEOUT);
-            assertThat(newConnectionPool.getStuckRequestTimeout()).isEqualTo(STUCK_REQUEST_TIMEOUT);
-            assertThat(newConnectionPool.getIdleTimeout()).isEqualTo(IDLE_TIMEOUT);
-            assertThat(newConnectionPool.getMaxLifeTime()).isEqualTo(MAX_LIFE_TIME);
-            assertThat(newConnectionPool.getDisposeTimeout()).isEqualTo(DISPOSE_TIMEOUT);
-            assertThat(newConnectionPool.getKeepaliveIdle()).isEqualTo(KEEPALIVE_IDLE);
-            assertThat(newConnectionPool.getKeepaliveInterval()).isEqualTo(KEEPALIVE_INTERVAL);
-            assertThat(newConnectionPool.getKeepaliveCount()).isEqualTo(KEEPALIVE_COUNT);
-            assertThat(newConnectionPool.isKeepAlive()).isTrue();
-            assertThat(newConnectionPool.isEnabled()).isTrue();
+            // the applied configuration must be exactly the bean that was sent
+            assertThat(newConnectionPool).usingRecursiveComparison().isEqualTo(pool);
         }
     }
 
@@ -170,20 +158,8 @@ public class ConnectionPoolsResourceIT extends UseAdminServer {
             final var config = server.getCurrentConfiguration();
             assertThat(config.getConnectionPools()).containsOnlyKeys(DEFAULT_EXAMPLE_ORG);
             final var newConnectionPool = config.getConnectionPools().get(DEFAULT_EXAMPLE_ORG);
-            assertThat(newConnectionPool.getId()).isEqualTo(DEFAULT_EXAMPLE_ORG);
-            assertThat(newConnectionPool.getDomain()).isEqualTo(ALTERNATIVE_EXAMPLE_COM);
-            assertThat(newConnectionPool.getMaxConnectionsPerEndpoint()).isEqualTo(MAX_CONNECTIONS_PER_ENDPOINT * 3);
-            assertThat(newConnectionPool.getBorrowTimeout()).isEqualTo(BORROW_TIMEOUT);
-            assertThat(newConnectionPool.getConnectTimeout()).isEqualTo(CONNECT_TIMEOUT);
-            assertThat(newConnectionPool.getStuckRequestTimeout()).isEqualTo(STUCK_REQUEST_TIMEOUT);
-            assertThat(newConnectionPool.getIdleTimeout()).isEqualTo(IDLE_TIMEOUT);
-            assertThat(newConnectionPool.getMaxLifeTime()).isEqualTo(MAX_LIFE_TIME);
-            assertThat(newConnectionPool.getDisposeTimeout()).isEqualTo(DISPOSE_TIMEOUT);
-            assertThat(newConnectionPool.getKeepaliveIdle()).isEqualTo(KEEPALIVE_IDLE);
-            assertThat(newConnectionPool.getKeepaliveInterval()).isEqualTo(KEEPALIVE_INTERVAL);
-            assertThat(newConnectionPool.getKeepaliveCount()).isEqualTo(KEEPALIVE_COUNT);
-            assertThat(newConnectionPool.isKeepAlive()).isTrue();
-            assertThat(newConnectionPool.isEnabled()).isTrue();
+            // the applied configuration must be exactly the bean that was sent
+            assertThat(newConnectionPool).usingRecursiveComparison().isEqualTo(pool);
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/api/ConnectionPoolsResourceIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/ConnectionPoolsResourceIT.java
@@ -4,9 +4,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -110,120 +109,120 @@ public class ConnectionPoolsResourceIT extends UseAdminServer {
     }
 
     @Test
-    public void testGetSingle() throws Exception {
+    void getSingle() throws Exception {
         configureAndStartServer();
         try (final var client = new RawHttpClient("localhost", 8761)) {
             final var defaultResult = client.get(CONNECTION_POOLS_PATH + "/*", credentials);
             final var defaultResultBean = MAPPER.readValue(defaultResult.getBodyString(), ConnectionPoolsResource.ConnectionPoolBean.class);
-            assertThat(defaultResultBean.getId(), is("*"));
-            assertThat(defaultResultBean.getDomain(), is("*"));
-            assertThat(defaultResultBean.getMaxConnectionsPerEndpoint(), is(MAX_CONNECTIONS_PER_ENDPOINT));
+            assertThat(defaultResultBean.getId()).isEqualTo("*");
+            assertThat(defaultResultBean.getDomain()).isEqualTo("*");
+            assertThat(defaultResultBean.getMaxConnectionsPerEndpoint()).isEqualTo(MAX_CONNECTIONS_PER_ENDPOINT);
 
             final var result = client.get(CONNECTION_POOLS_PATH + "/" + DEFAULT_EXAMPLE_ORG, credentials);
             final var resultBean = MAPPER.readValue(result.getBodyString(), ConnectionPoolsResource.ConnectionPoolBean.class);
-            assertThat(resultBean.getId(), is(DEFAULT_EXAMPLE_ORG));
-            assertThat(resultBean.getDomain(), is(DEFAULT_EXAMPLE_ORG));
-            assertThat(resultBean.getMaxConnectionsPerEndpoint(), is(MAX_CONNECTIONS_PER_ENDPOINT * 2));
+            assertThat(resultBean.getId()).isEqualTo(DEFAULT_EXAMPLE_ORG);
+            assertThat(resultBean.getDomain()).isEqualTo(DEFAULT_EXAMPLE_ORG);
+            assertThat(resultBean.getMaxConnectionsPerEndpoint()).isEqualTo(MAX_CONNECTIONS_PER_ENDPOINT * 2);
         }
     }
 
     @Test
-    public void testGetAll() throws Exception {
+    void getAll() throws Exception {
         configureAndStartServer();
 
         try (final var client = new RawHttpClient("localhost", 8761)) {
             final var result = client.get(CONNECTION_POOLS_PATH, credentials);
             final var resultMap = MAPPER.readValue(result.getBodyString(), new MapTypeReference());
-            assertThat(resultMap.keySet(), is(Set.of("*", DEFAULT_EXAMPLE_ORG)));
+            assertThat(resultMap.keySet()).isEqualTo(Set.of("*", DEFAULT_EXAMPLE_ORG));
         }
     }
 
     @Test
-    public void testPostNewConnectionPool() throws Exception {
+    void postNewConnectionPool() throws Exception {
         configureAndStartServer();
         try (final var client = new RawHttpClient("localhost", 8761)) {
             final var pool = buildConnectionPoolBean();
             final var response = client.post(CONNECTION_POOLS_PATH, null, pool, credentials);
-            assertThat(response.getStatusLine(), containsString(CREATED));
+            assertThat(response.getStatusLine()).contains(CREATED);
             final var config = server.getCurrentConfiguration();
-            assertThat(config.getConnectionPools().keySet(), is(Set.of(DEFAULT_EXAMPLE_ORG, ALTERNATIVE_EXAMPLE_COM)));
+            assertThat(config.getConnectionPools().keySet()).isEqualTo(Set.of(DEFAULT_EXAMPLE_ORG, ALTERNATIVE_EXAMPLE_COM));
             final var newConnectionPool = config.getConnectionPools().get(ALTERNATIVE_EXAMPLE_COM);
-            assertThat(newConnectionPool.getId(), is(ALTERNATIVE_EXAMPLE_COM));
-            assertThat(newConnectionPool.getDomain(), is(ALTERNATIVE_EXAMPLE_COM));
-            assertThat(newConnectionPool.getMaxConnectionsPerEndpoint(), is(MAX_CONNECTIONS_PER_ENDPOINT * 3));
-            assertThat(newConnectionPool.getBorrowTimeout(), is(BORROW_TIMEOUT));
-            assertThat(newConnectionPool.getConnectTimeout(), is(CONNECT_TIMEOUT));
-            assertThat(newConnectionPool.getStuckRequestTimeout(), is(STUCK_REQUEST_TIMEOUT));
-            assertThat(newConnectionPool.getIdleTimeout(), is(IDLE_TIMEOUT));
-            assertThat(newConnectionPool.getMaxLifeTime(), is(MAX_LIFE_TIME));
-            assertThat(newConnectionPool.getDisposeTimeout(), is(DISPOSE_TIMEOUT));
-            assertThat(newConnectionPool.getKeepaliveIdle(), is(KEEPALIVE_IDLE));
-            assertThat(newConnectionPool.getKeepaliveInterval(), is(KEEPALIVE_INTERVAL));
-            assertThat(newConnectionPool.getKeepaliveCount(), is(KEEPALIVE_COUNT));
-            assertThat(newConnectionPool.isKeepAlive(), is(true));
-            assertThat(newConnectionPool.isEnabled(), is(true));
+            assertThat(newConnectionPool.getId()).isEqualTo(ALTERNATIVE_EXAMPLE_COM);
+            assertThat(newConnectionPool.getDomain()).isEqualTo(ALTERNATIVE_EXAMPLE_COM);
+            assertThat(newConnectionPool.getMaxConnectionsPerEndpoint()).isEqualTo(MAX_CONNECTIONS_PER_ENDPOINT * 3);
+            assertThat(newConnectionPool.getBorrowTimeout()).isEqualTo(BORROW_TIMEOUT);
+            assertThat(newConnectionPool.getConnectTimeout()).isEqualTo(CONNECT_TIMEOUT);
+            assertThat(newConnectionPool.getStuckRequestTimeout()).isEqualTo(STUCK_REQUEST_TIMEOUT);
+            assertThat(newConnectionPool.getIdleTimeout()).isEqualTo(IDLE_TIMEOUT);
+            assertThat(newConnectionPool.getMaxLifeTime()).isEqualTo(MAX_LIFE_TIME);
+            assertThat(newConnectionPool.getDisposeTimeout()).isEqualTo(DISPOSE_TIMEOUT);
+            assertThat(newConnectionPool.getKeepaliveIdle()).isEqualTo(KEEPALIVE_IDLE);
+            assertThat(newConnectionPool.getKeepaliveInterval()).isEqualTo(KEEPALIVE_INTERVAL);
+            assertThat(newConnectionPool.getKeepaliveCount()).isEqualTo(KEEPALIVE_COUNT);
+            assertThat(newConnectionPool.isKeepAlive()).isTrue();
+            assertThat(newConnectionPool.isEnabled()).isTrue();
         }
     }
 
     @Test
-    public void testPutConnectionPoolModifications() throws Exception {
+    void putConnectionPoolModifications() throws Exception {
         configureAndStartServer();
         try (final var client = new RawHttpClient("localhost", 8761)) {
             final var pool = buildConnectionPoolBean();
             pool.setId(DEFAULT_EXAMPLE_ORG);
             final var response = client.put(CONNECTION_POOLS_PATH + "/" + DEFAULT_EXAMPLE_ORG, null, pool, credentials);
-            assertThat(response.getStatusLine(), containsString(OK));
+            assertThat(response.getStatusLine()).contains(OK);
             final var config = server.getCurrentConfiguration();
-            assertThat(config.getConnectionPools().keySet(), is(Set.of(DEFAULT_EXAMPLE_ORG)));
+            assertThat(config.getConnectionPools().keySet()).isEqualTo(Set.of(DEFAULT_EXAMPLE_ORG));
             final var newConnectionPool = config.getConnectionPools().get(DEFAULT_EXAMPLE_ORG);
-            assertThat(newConnectionPool.getId(), is(DEFAULT_EXAMPLE_ORG));
-            assertThat(newConnectionPool.getDomain(), is(ALTERNATIVE_EXAMPLE_COM));
-            assertThat(newConnectionPool.getMaxConnectionsPerEndpoint(), is(MAX_CONNECTIONS_PER_ENDPOINT * 3));
-            assertThat(newConnectionPool.getBorrowTimeout(), is(BORROW_TIMEOUT));
-            assertThat(newConnectionPool.getConnectTimeout(), is(CONNECT_TIMEOUT));
-            assertThat(newConnectionPool.getStuckRequestTimeout(), is(STUCK_REQUEST_TIMEOUT));
-            assertThat(newConnectionPool.getIdleTimeout(), is(IDLE_TIMEOUT));
-            assertThat(newConnectionPool.getMaxLifeTime(), is(MAX_LIFE_TIME));
-            assertThat(newConnectionPool.getDisposeTimeout(), is(DISPOSE_TIMEOUT));
-            assertThat(newConnectionPool.getKeepaliveIdle(), is(KEEPALIVE_IDLE));
-            assertThat(newConnectionPool.getKeepaliveInterval(), is(KEEPALIVE_INTERVAL));
-            assertThat(newConnectionPool.getKeepaliveCount(), is(KEEPALIVE_COUNT));
-            assertThat(newConnectionPool.isKeepAlive(), is(true));
-            assertThat(newConnectionPool.isEnabled(), is(true));
+            assertThat(newConnectionPool.getId()).isEqualTo(DEFAULT_EXAMPLE_ORG);
+            assertThat(newConnectionPool.getDomain()).isEqualTo(ALTERNATIVE_EXAMPLE_COM);
+            assertThat(newConnectionPool.getMaxConnectionsPerEndpoint()).isEqualTo(MAX_CONNECTIONS_PER_ENDPOINT * 3);
+            assertThat(newConnectionPool.getBorrowTimeout()).isEqualTo(BORROW_TIMEOUT);
+            assertThat(newConnectionPool.getConnectTimeout()).isEqualTo(CONNECT_TIMEOUT);
+            assertThat(newConnectionPool.getStuckRequestTimeout()).isEqualTo(STUCK_REQUEST_TIMEOUT);
+            assertThat(newConnectionPool.getIdleTimeout()).isEqualTo(IDLE_TIMEOUT);
+            assertThat(newConnectionPool.getMaxLifeTime()).isEqualTo(MAX_LIFE_TIME);
+            assertThat(newConnectionPool.getDisposeTimeout()).isEqualTo(DISPOSE_TIMEOUT);
+            assertThat(newConnectionPool.getKeepaliveIdle()).isEqualTo(KEEPALIVE_IDLE);
+            assertThat(newConnectionPool.getKeepaliveInterval()).isEqualTo(KEEPALIVE_INTERVAL);
+            assertThat(newConnectionPool.getKeepaliveCount()).isEqualTo(KEEPALIVE_COUNT);
+            assertThat(newConnectionPool.isKeepAlive()).isTrue();
+            assertThat(newConnectionPool.isEnabled()).isTrue();
         }
     }
 
     @Test
-    public void testRegexDomainSurvivesSubsequentSaves() throws Exception {
+    void regexDomainSurvivesSubsequentSaves() throws Exception {
         configureAndStartServer();
         final var regexDomain = "(\\Qhost.example\\E|\\Qother.example\\E)";
         try (final var client = new RawHttpClient("localhost", 8761)) {
             final var pool = buildConnectionPoolBean();
             pool.setDomain(regexDomain);
             final var response = client.post(CONNECTION_POOLS_PATH, null, pool, credentials);
-            assertThat(response.getStatusLine(), containsString(CREATED));
-            assertThat(server.getCurrentConfiguration().getConnectionPools().get(ALTERNATIVE_EXAMPLE_COM).getDomain(), is(regexDomain));
+            assertThat(response.getStatusLine()).contains(CREATED);
+            assertThat(server.getCurrentConfiguration().getConnectionPools().get(ALTERNATIVE_EXAMPLE_COM).getDomain()).isEqualTo(regexDomain);
 
             // any further save re-serializes the whole configuration: the regex pool must not lose its backslashes
             final var otherPool = buildConnectionPoolBean();
             otherPool.setId(DEFAULT_EXAMPLE_ORG);
             final var putResponse = client.put(CONNECTION_POOLS_PATH + "/" + DEFAULT_EXAMPLE_ORG, null, otherPool, credentials);
-            assertThat(putResponse.getStatusLine(), containsString(OK));
+            assertThat(putResponse.getStatusLine()).contains(OK);
 
             final var result = client.get(CONNECTION_POOLS_PATH + "/" + ALTERNATIVE_EXAMPLE_COM, credentials);
             final var resultBean = MAPPER.readValue(result.getBodyString(), ConnectionPoolsResource.ConnectionPoolBean.class);
-            assertThat(resultBean.getDomain(), is(regexDomain));
+            assertThat(resultBean.getDomain()).isEqualTo(regexDomain);
         }
     }
 
     @Test
-    public void testDelete() throws Exception {
+    void delete() throws Exception {
         configureAndStartServer();
         try (final var client = new RawHttpClient("localhost", 8761)) {
             final var response = client.delete(CONNECTION_POOLS_PATH + "/" + DEFAULT_EXAMPLE_ORG, credentials);
-            assertThat(response.getStatusLine(), containsString(OK));
+            assertThat(response.getStatusLine()).contains(OK);
             final var config = server.getCurrentConfiguration();
-            assertThat(config.getConnectionPools().isEmpty(), is(true));
+            assertThat(config.getConnectionPools()).isEmpty();
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/api/ConnectionPoolsResourceIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/ConnectionPoolsResourceIT.java
@@ -4,15 +4,15 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import java.io.File;
 import java.io.IOException;
-import java.util.Map;
+import net.javacrumbs.jsonunit.core.Option;
 import java.util.Properties;
 import java.util.Set;
 import javax.ws.rs.core.Response;
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class ConnectionPoolsResourceIT extends UseAdminServer {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final String CONNECTION_POOLS_PATH = "/api/connectionpools";
     private static final String CREATED = String.valueOf(Response.Status.CREATED.getStatusCode());
     private static final String OK = String.valueOf(Response.Status.OK.getStatusCode());
@@ -113,16 +112,13 @@ public class ConnectionPoolsResourceIT extends UseAdminServer {
         configureAndStartServer();
         try (final var client = new RawHttpClient("localhost", 8761)) {
             final var defaultResult = client.get(CONNECTION_POOLS_PATH + "/*", credentials);
-            final var defaultResultBean = MAPPER.readValue(defaultResult.getBodyString(), ConnectionPoolsResource.ConnectionPoolBean.class);
-            assertThat(defaultResultBean.getId()).isEqualTo("*");
-            assertThat(defaultResultBean.getDomain()).isEqualTo("*");
-            assertThat(defaultResultBean.getMaxConnectionsPerEndpoint()).isEqualTo(MAX_CONNECTIONS_PER_ENDPOINT);
+            assertThatJson(defaultResult.getBodyString()).when(Option.IGNORING_EXTRA_FIELDS).isEqualTo(json(
+                    "{id: '*', domain: '*', maxConnectionsPerEndpoint: %d}".formatted(MAX_CONNECTIONS_PER_ENDPOINT)));
 
             final var result = client.get(CONNECTION_POOLS_PATH + "/" + DEFAULT_EXAMPLE_ORG, credentials);
-            final var resultBean = MAPPER.readValue(result.getBodyString(), ConnectionPoolsResource.ConnectionPoolBean.class);
-            assertThat(resultBean.getId()).isEqualTo(DEFAULT_EXAMPLE_ORG);
-            assertThat(resultBean.getDomain()).isEqualTo(DEFAULT_EXAMPLE_ORG);
-            assertThat(resultBean.getMaxConnectionsPerEndpoint()).isEqualTo(MAX_CONNECTIONS_PER_ENDPOINT * 2);
+            assertThatJson(result.getBodyString()).when(Option.IGNORING_EXTRA_FIELDS).isEqualTo(json(
+                    "{id: '%s', domain: '%s', maxConnectionsPerEndpoint: %d}"
+                            .formatted(DEFAULT_EXAMPLE_ORG, DEFAULT_EXAMPLE_ORG, MAX_CONNECTIONS_PER_ENDPOINT * 2)));
         }
     }
 
@@ -132,8 +128,7 @@ public class ConnectionPoolsResourceIT extends UseAdminServer {
 
         try (final var client = new RawHttpClient("localhost", 8761)) {
             final var result = client.get(CONNECTION_POOLS_PATH, credentials);
-            final var resultMap = MAPPER.readValue(result.getBodyString(), new MapTypeReference());
-            assertThat(resultMap.keySet()).isEqualTo(Set.of("*", DEFAULT_EXAMPLE_ORG));
+            assertThatJson(result.getBodyString()).isObject().containsOnlyKeys("*", DEFAULT_EXAMPLE_ORG);
         }
     }
 
@@ -210,8 +205,8 @@ public class ConnectionPoolsResourceIT extends UseAdminServer {
             assertThat(putResponse.getStatusLine()).contains(OK);
 
             final var result = client.get(CONNECTION_POOLS_PATH + "/" + ALTERNATIVE_EXAMPLE_COM, credentials);
-            final var resultBean = MAPPER.readValue(result.getBodyString(), ConnectionPoolsResource.ConnectionPoolBean.class);
-            assertThat(resultBean.getDomain()).isEqualTo(regexDomain);
+            // only the domain matters here; it is a regex, so it is compared as a string and not parsed as JSON
+            assertThatJson(result.getBodyString()).node("domain").isString().isEqualTo(regexDomain);
         }
     }
 
@@ -245,7 +240,5 @@ public class ConnectionPoolsResourceIT extends UseAdminServer {
         return pool;
     }
 
-    private static class MapTypeReference extends TypeReference<Map<String, ConnectionPoolsResource.ConnectionPoolBean>> {
-    }
 
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/api/ConnectionPoolsResourceIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/ConnectionPoolsResourceIT.java
@@ -140,7 +140,7 @@ public class ConnectionPoolsResourceIT extends UseAdminServer {
             final var response = client.post(CONNECTION_POOLS_PATH, null, pool, credentials);
             assertThat(response.getStatusLine()).contains(CREATED);
             final var config = server.getCurrentConfiguration();
-            assertThat(config.getConnectionPools().keySet()).isEqualTo(Set.of(DEFAULT_EXAMPLE_ORG, ALTERNATIVE_EXAMPLE_COM));
+            assertThat(config.getConnectionPools()).containsOnlyKeys(DEFAULT_EXAMPLE_ORG, ALTERNATIVE_EXAMPLE_COM);
             final var newConnectionPool = config.getConnectionPools().get(ALTERNATIVE_EXAMPLE_COM);
             assertThat(newConnectionPool.getId()).isEqualTo(ALTERNATIVE_EXAMPLE_COM);
             assertThat(newConnectionPool.getDomain()).isEqualTo(ALTERNATIVE_EXAMPLE_COM);
@@ -168,7 +168,7 @@ public class ConnectionPoolsResourceIT extends UseAdminServer {
             final var response = client.put(CONNECTION_POOLS_PATH + "/" + DEFAULT_EXAMPLE_ORG, null, pool, credentials);
             assertThat(response.getStatusLine()).contains(OK);
             final var config = server.getCurrentConfiguration();
-            assertThat(config.getConnectionPools().keySet()).isEqualTo(Set.of(DEFAULT_EXAMPLE_ORG));
+            assertThat(config.getConnectionPools()).containsOnlyKeys(DEFAULT_EXAMPLE_ORG);
             final var newConnectionPool = config.getConnectionPools().get(DEFAULT_EXAMPLE_ORG);
             assertThat(newConnectionPool.getId()).isEqualTo(DEFAULT_EXAMPLE_ORG);
             assertThat(newConnectionPool.getDomain()).isEqualTo(ALTERNATIVE_EXAMPLE_COM);

--- a/carapace-server/src/test/java/org/carapaceproxy/api/MetricsEndpointsIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/MetricsEndpointsIT.java
@@ -23,7 +23,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import java.io.IOException;
@@ -120,7 +121,7 @@ public class MetricsEndpointsIT extends UseAdminServer {
             .build();
 
     @Test
-    public void bothEndpointsExposeMetrics() throws Exception {
+    void bothEndpointsExposeMetrics() throws Exception {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -153,11 +154,11 @@ public class MetricsEndpointsIT extends UseAdminServer {
 
         // traverse the proxy once, so that the listener and Reactor Netty publish their meters
         final HttpResponse<String> response = httpGet(URI.create("http://localhost:" + listenerPort + "/index.html"));
-        assertEquals(200, response.statusCode());
-        assertEquals("it <b>works</b> !!", response.body());
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isEqualTo("it <b>works</b> !!");
 
-        assertEquals(EXPECTED_METRICS, metricNames("/metrics"), "metrics exposed by /metrics changed");
-        assertEquals(EXPECTED_MICROMETRICS, metricNames("/micrometrics"), "metrics exposed by /micrometrics changed");
+        assertThat(metricNames("/metrics")).as("metrics exposed by /metrics changed").isEqualTo(EXPECTED_METRICS);
+        assertThat(metricNames("/micrometrics")).as("metrics exposed by /micrometrics changed").isEqualTo(EXPECTED_MICROMETRICS);
     }
 
     /**
@@ -170,7 +171,7 @@ public class MetricsEndpointsIT extends UseAdminServer {
      */
     private static Set<String> metricNames(final String path) throws IOException, InterruptedException {
         final HttpResponse<String> response = httpGet(URI.create("http://localhost:" + DEFAULT_ADMIN_PORT + path));
-        assertEquals(200, response.statusCode(), "could not scrape " + path);
+        assertThat(response.statusCode()).as("could not scrape " + path).isEqualTo(200);
         return response.body().lines()
                 .filter(line -> line.startsWith("# TYPE "))
                 .map(line -> line.split(" ")[2])

--- a/carapace-server/src/test/java/org/carapaceproxy/api/StartAPIServerIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/StartAPIServerIT.java
@@ -41,7 +41,6 @@ import java.nio.file.Files;
 import java.security.KeyPair;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -484,7 +483,7 @@ public class StartAPIServerIT extends UseAdminServer {
             serialNumber = certificate.getSerialNumber().toString(16).toUpperCase();
             expiringDate = certificate.getNotAfter().toString();
             byte[] chain2 = createKeystore(originalChain, endUserKeyPair.getPrivate());
-            assertThat(Arrays.equals(chain1, chain2)).isFalse();
+            assertThat(chain1).isNotEqualTo(chain2);
             resp = uploadCertificate(manualDomain, null, chain2, client, credentials);
             s = resp.getBodyString();
             assertThat(s).contains("SUCCESS");

--- a/carapace-server/src/test/java/org/carapaceproxy/api/StartAPIServerIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/StartAPIServerIT.java
@@ -53,6 +53,7 @@ import org.carapaceproxy.configstore.CertificateData;
 import org.carapaceproxy.configstore.ConfigurationStore;
 import org.carapaceproxy.server.certificates.DynamicCertificateState;
 import org.carapaceproxy.server.certificates.DynamicCertificatesManager;
+import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.filters.RegexpMapSessionIdFilter;
 import org.carapaceproxy.server.filters.RegexpMapUserIdFilter;
 import org.carapaceproxy.server.filters.XForwardedForRequestFilter;
@@ -326,7 +327,9 @@ public class StartAPIServerIT extends UseAdminServer {
         File nowrite = newFolder(tmpDir, "nowrite");
         nowrite.setWritable(false);
         properties.put("dynamiccertificatesmanager.localcertificates.store.path", nowrite.getAbsolutePath());
-        assertThatThrownBy(() -> startServer(properties)).isInstanceOf(Exception.class);
+        assertThatThrownBy(() -> startServer(properties))
+                .hasCauseInstanceOf(ConfigurationNotValidException.class)
+                .hasMessageContaining("Cannot write local certificates to path");
         nowrite.setWritable(true);
 
         startServer(properties);

--- a/carapace-server/src/test/java/org/carapaceproxy/api/StartAPIServerIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/StartAPIServerIT.java
@@ -606,7 +606,6 @@ public class StartAPIServerIT extends UseAdminServer {
             exc = ex;
         }
 
-        assertThat(exc).isNotNull();
         assertThat(exc.getMessage()).contains("bad response, does not start with HTTP/1.1");
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/api/StartAPIServerIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/StartAPIServerIT.java
@@ -19,6 +19,8 @@
  */
 package org.carapaceproxy.api;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.WAITING;
@@ -46,6 +48,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import javax.servlet.http.HttpServletResponse;
+import net.javacrumbs.jsonunit.core.Option;
 import org.carapaceproxy.configstore.CertificateData;
 import org.carapaceproxy.configstore.ConfigurationStore;
 import org.carapaceproxy.server.certificates.DynamicCertificateState;
@@ -129,14 +132,17 @@ public class StartAPIServerIT extends UseAdminServer {
             RawHttpClient.HttpResponse resp = client.get("/api/cache/info", credentials);
             String s = resp.getBodyString();
             System.out.println("s:" + s);
-            assertThat(s).isEqualTo("{\"result\":\"ok\",\"hits\":0,\"directMemoryUsed\":0,\"misses\":0,\"heapMemoryUsed\":0,\"totalMemoryUsed\":0,\"cachesize\":0}");
+            assertThatJson(s).isEqualTo("""
+                    {result: "ok", hits: 0, directMemoryUsed: 0, misses: 0,
+                     heapMemoryUsed: 0, totalMemoryUsed: 0, cachesize: 0}
+                    """);
         }
 
         try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             RawHttpClient.HttpResponse resp = client.get("/api/cache/flush", credentials);
             String s = resp.getBodyString();
             System.out.println("s:" + s);
-            assertThat(s).isEqualTo("{\"result\":\"ok\",\"cachesize\":0}");
+            assertThatJson(s).isEqualTo("{result: 'ok', cachesize: 0}");
         }
     }
 
@@ -148,7 +154,7 @@ public class StartAPIServerIT extends UseAdminServer {
             RawHttpClient.HttpResponse resp = client.get("/api/backends", credentials);
             String s = resp.getBodyString();
             // no backend configured
-            assertThat(s).isEqualTo("{}");
+            assertThatJson(s).isEqualTo("{}");
         }
     }
 
@@ -165,11 +171,9 @@ public class StartAPIServerIT extends UseAdminServer {
         try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             RawHttpClient.HttpResponse resp = client.get("/api/routes", credentials);
             String s = resp.getBodyString();
-            assertThat(s)
-                    .contains("id0")
-                    .contains("id-action")
-                    .contains("true")
-                    .contains(new MatchAllRequestMatcher().getDescription());
+            assertThatJson(s).when(Option.IGNORING_EXTRA_FIELDS).isArray().contains(json("""
+                    {id: "id0", action: "id-action", enabled: true, matcher: "%s"}
+                    """.formatted(new MatchAllRequestMatcher().getDescription())));
         }
     }
 
@@ -180,12 +184,12 @@ public class StartAPIServerIT extends UseAdminServer {
         try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             RawHttpClient.HttpResponse resp = client.get("/api/actions", credentials);
             String s = resp.getBodyString();
-            assertThat(s)
-                    // Default actions
-                    .contains("\"not-found\",\"type\":\"static\"")
-                    .contains("\"cache-if-possible\",\"type\":\"cache\"")
-                    .contains("\"internal-error\",\"type\":\"static\"")
-                    .contains("\"proxy-all\",\"type\":\"proxy\"");
+            // Default actions
+            assertThatJson(s).when(Option.IGNORING_EXTRA_FIELDS).isArray().contains(
+                    json("{id: 'not-found', type: 'static'}"),
+                    json("{id: 'cache-if-possible', type: 'cache'}"),
+                    json("{id: 'internal-error', type: 'static'}"),
+                    json("{id: 'proxy-all', type: 'proxy'}"));
         }
     }
 
@@ -213,12 +217,14 @@ public class StartAPIServerIT extends UseAdminServer {
 
         try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             RawHttpClient.HttpResponse resp = client.get("/api/directors", credentials);
-            final List<Map<?, ?>> s = new ObjectMapper().readValue(resp.getBody(), new TypeReference<>() {});
-            assertThat(s).hasSize(1);
-            final var id = s.get(0).get("id");
-            assertThat(id).isEqualTo("iddirector2");
-            final var backends = Set.copyOf((List<?>) s.get(0).get("backends"));
-            assertThat(backends).isEqualTo(Set.of("localhost:8086", "localhost:8087"));
+            assertThatJson(resp.getBodyString())
+                    .when(Option.IGNORING_EXTRA_FIELDS, Option.IGNORING_ARRAY_ORDER)
+                    .isArray()
+                    .containsExactly(json("""
+                            {
+                              "id": "iddirector2",
+                              "backends": ["localhost:8086", "localhost:8087"]
+                            }"""));
         }
     }
 
@@ -248,7 +254,10 @@ public class StartAPIServerIT extends UseAdminServer {
                     + "\r\n"
                     + body);
             assertThat(resp.isError()).isTrue();
-            assertThat(resp.getBodyString()).contains("Invalid integer value '20-BAD-VALUE' for parameter 'connectionsmanager.maxconnectionsperendpoint'");
+            assertThatJson(resp.getBodyString()).isEqualTo(json("""
+                    {
+                      "message": "Invalid integer value '20-BAD-VALUE' for parameter 'connectionsmanager.maxconnectionsperendpoint'"
+                    }"""));
         }
     }
 
@@ -269,11 +278,13 @@ public class StartAPIServerIT extends UseAdminServer {
             RawHttpClient.HttpResponse response = client.get("/api/listeners", credentials);
             String json = response.getBodyString();
 
-            assertThat(json)
-                    .contains("localhost")
-                    .contains("1234")
-                    .contains("127.0.0.1")
-                    .contains("9876");
+
+            // the map is keyed by "host:port", and only its values were checked before
+            assertThatJson(json).when(Option.IGNORING_EXTRA_FIELDS).isObject()
+                    .containsOnlyKeys("localhost:1234", "127.0.0.1:9876")
+                    .containsValues(
+                            json("{host: 'localhost', port: 1234}"),
+                            json("{host: '127.0.0.1', port: 9876}"));
         }
 
     }
@@ -340,33 +351,25 @@ public class StartAPIServerIT extends UseAdminServer {
             RawHttpClient.HttpResponse response = client.get("/api/certificates", credentials);
             String json = response.getBodyString();
 
-            assertThat(json)
-                    .contains("localhost")
-                    .contains("\"mode\":\"static\"")
-                    .contains("\"dynamic\":false")
-                    .contains("\"status\":\"available\"")
-                    .contains("\"sslCertificateFile\":\"" + mock1.getAbsolutePath() + "\"")
-                    .contains("\"serialNumber\":\"" + serialNumber1 + "\"")
-                    .contains("\"expiringDate\":\"" + expiringDate1 + "\"")
-                    .contains("127.0.0.1")
-                    .contains("\"mode\":\"static\"")
-                    .contains("\"dynamic\":false")
-                    .contains("\"status\":\"expired\"")
-                    .contains("\"sslCertificateFile\":\"" + mock2.getAbsolutePath() + "\"")
-                    .contains("\"serialNumber\":\"" + serialNumber2 + "\"")
-                    .contains("\"expiringDate\":\"" + expiringDate2 + "\"");
+
+            assertThatJson(json).when(Option.IGNORING_EXTRA_FIELDS).node("certificates").isArray().contains(
+                    json("""
+                         {id: "localhost", mode: "static", dynamic: false, status: "available",
+                          sslCertificateFile: "%s", serialNumber: "%s", expiringDate: "%s"}
+                         """.formatted(mock1.getAbsolutePath(), serialNumber1, expiringDate1)),
+                    json("""
+                         {id: "127.0.0.1", mode: "static", dynamic: false, status: "expired",
+                          sslCertificateFile: "%s", serialNumber: "%s", expiringDate: "%s"}
+                         """.formatted(mock2.getAbsolutePath(), serialNumber2, expiringDate2)));
 
             // single cert request to /{certId}
             response = client.get("/api/certificates/127.0.0.1", credentials);
             json = response.getBodyString();
-            assertThat(json)
-                    .doesNotContain("localhost")
-                    .contains("\"mode\":\"static\"")
-                    .contains("\"dynamic\":false")
-                    .contains("\"status\":\"expired\"")
-                    .contains("\"sslCertificateFile\":\"" + mock2.getAbsolutePath() + "\"")
-                    .contains("\"serialNumber\":\"" + serialNumber2 + "\"")
-                    .contains("\"expiringDate\":\"" + expiringDate2 + "\"");
+            assertThatJson(json).when(Option.IGNORING_EXTRA_FIELDS).node("certificates").isArray()
+                    .containsExactly(json("""
+                                          {id: "127.0.0.1", mode: "static", dynamic: false, status: "expired",
+                                           sslCertificateFile: "%s", serialNumber: "%s", expiringDate: "%s"}
+                                          """.formatted(mock2.getAbsolutePath(), serialNumber2, expiringDate2)));
         }
 
         // Acme certificate
@@ -376,43 +379,38 @@ public class StartAPIServerIT extends UseAdminServer {
             RawHttpClient.HttpResponse response = client.get("/api/certificates", credentials);
             String json = response.getBodyString();
 
-            assertThat(json)
-                    .contains(dynDomain)
-                    .contains("\"mode\":\"acme\"")
-                    .contains("\"dynamic\":true")
-                    .contains("\"status\":\"waiting\"")
-                    .contains("\"serialNumber\":\"" + serialNumber + "\"")
-                    .contains("\"expiringDate\":\"" + expiringDate + "\"");
+
+            assertThatJson(json).when(Option.IGNORING_EXTRA_FIELDS).node("certificates").isArray().contains(
+                    json("""
+                         {id: "%s", mode: "acme", dynamic: true, status: "waiting",
+                          serialNumber: "%s", expiringDate: "%s"}
+                         """.formatted(dynDomain, serialNumber, expiringDate)));
 
             // single cert request to /{certId}
             response = client.get("/api/certificates/" + dynDomain, credentials);
             json = response.getBodyString();
-            assertThat(json)
-                    .contains(dynDomain)
-                    .contains("\"mode\":\"acme\"")
-                    .contains("\"dynamic\":true")
-                    .contains("\"status\":\"waiting\"")
-                    .contains("\"serialNumber\":\"" + serialNumber + "\"")
-                    .contains("\"expiringDate\":\"" + expiringDate + "\"");
+            assertThatJson(json).when(Option.IGNORING_EXTRA_FIELDS).node("certificates").isArray().containsExactly(
+                    json("""
+                         {id: "%s", mode: "acme", dynamic: true, status: "waiting",
+                          serialNumber: "%s", expiringDate: "%s"}
+                         """.formatted(dynDomain, serialNumber, expiringDate)));
 
             // Changing dynamic certificate state
             for (DynamicCertificateState state : DynamicCertificateState.values()) {
                 man.setStateOfCertificate(dynDomain, state);
                 response = client.get("/api/certificates", credentials);
                 json = response.getBodyString();
-                assertThat(json)
-                        .contains(dynDomain)
-                        .contains("\"mode\":\"acme\"")
-                        .contains("\"dynamic\":true")
-                        .contains("\"status\":\"" + certificateStateToString(state) + "\"");
+                assertThatJson(json).when(Option.IGNORING_EXTRA_FIELDS).node("certificates").isArray().contains(
+                        json("""
+                             {id: "%s", mode: "acme", dynamic: true, status: "%s"}
+                             """.formatted(dynDomain, certificateStateToString(state))));
 
                 response = client.get("/api/certificates/" + dynDomain, credentials);
                 json = response.getBodyString();
-                assertThat(json)
-                        .contains(dynDomain)
-                        .contains("\"mode\":\"acme\"")
-                        .contains("\"dynamic\":true")
-                        .contains("\"status\":\"" + certificateStateToString(state) + "\"");
+                assertThatJson(json).when(Option.IGNORING_EXTRA_FIELDS).node("certificates").isArray().containsExactly(
+                        json("""
+                             {id: "%s", mode: "acme", dynamic: true, status: "%s"}
+                             """.formatted(dynDomain, certificateStateToString(state))));
             }
 
             // Downloading
@@ -454,24 +452,21 @@ public class StartAPIServerIT extends UseAdminServer {
             RawHttpClient.HttpResponse response = client.get("/api/certificates", credentials);
             String json = response.getBodyString();
 
-            assertThat(json)
-                    .contains(manualDomain)
-                    .contains("\"mode\":\"manual\"")
-                    .contains("\"dynamic\":true")
-                    .contains("\"status\":\"available\"")
-                    .contains("\"serialNumber\":\"" + serialNumber + "\"")
-                    .contains("\"expiringDate\":\"" + expiringDate + "\"");
+
+            assertThatJson(json).when(Option.IGNORING_EXTRA_FIELDS).node("certificates").isArray().contains(
+                    json("""
+                         {id: "%s", mode: "manual", dynamic: true, status: "available",
+                          serialNumber: "%s", expiringDate: "%s"}
+                         """.formatted(manualDomain, serialNumber, expiringDate)));
 
             // single cert request to /{certId}
             response = client.get("/api/certificates/" + manualDomain, credentials);
             json = response.getBodyString();
-            assertThat(json)
-                    .contains(manualDomain)
-                    .contains("\"mode\":\"manual\"")
-                    .contains("\"dynamic\":true")
-                    .contains("\"status\":\"available\"")
-                    .contains("\"serialNumber\":\"" + serialNumber + "\"")
-                    .contains("\"expiringDate\":\"" + expiringDate + "\"");
+            assertThatJson(json).when(Option.IGNORING_EXTRA_FIELDS).node("certificates").isArray().containsExactly(
+                    json("""
+                         {id: "%s", mode: "manual", dynamic: true, status: "available",
+                          serialNumber: "%s", expiringDate: "%s"}
+                         """.formatted(manualDomain, serialNumber, expiringDate)));
 
             // Downloading
             response = client.get("/api/certificates/" + manualDomain + "/download", credentials);
@@ -499,24 +494,21 @@ public class StartAPIServerIT extends UseAdminServer {
             response = client.get("/api/certificates", credentials);
             json = response.getBodyString();
 
-            assertThat(json)
-                    .contains(manualDomain)
-                    .contains("\"mode\":\"manual\"")
-                    .contains("\"dynamic\":true")
-                    .contains("\"status\":\"expired\"")
-                    .contains("\"serialNumber\":\"" + serialNumber + "\"")
-                    .contains("\"expiringDate\":\"" + expiringDate + "\"");
+
+            assertThatJson(json).when(Option.IGNORING_EXTRA_FIELDS).node("certificates").isArray().contains(
+                    json("""
+                         {id: "%s", mode: "manual", dynamic: true, status: "expired",
+                          serialNumber: "%s", expiringDate: "%s"}
+                         """.formatted(manualDomain, serialNumber, expiringDate)));
 
             // single cert request to /{certId}
             response = client.get("/api/certificates/" + manualDomain, credentials);
             json = response.getBodyString();
-            assertThat(json)
-                    .contains(manualDomain)
-                    .contains("\"mode\":\"manual\"")
-                    .contains("\"dynamic\":true")
-                    .contains("\"status\":\"expired\"")
-                    .contains("\"serialNumber\":\"" + serialNumber + "\"")
-                    .contains("\"expiringDate\":\"" + expiringDate + "\"");
+            assertThatJson(json).when(Option.IGNORING_EXTRA_FIELDS).node("certificates").isArray().containsExactly(
+                    json("""
+                         {id: "%s", mode: "manual", dynamic: true, status: "expired",
+                          serialNumber: "%s", expiringDate: "%s"}
+                         """.formatted(manualDomain, serialNumber, expiringDate)));
 
             // Downloading
             response = client.get("/api/certificates/" + manualDomain + "/download", credentials);
@@ -549,14 +541,15 @@ public class StartAPIServerIT extends UseAdminServer {
             RawHttpClient.HttpResponse response = client.get("/api/requestfilters", credentials);
             String json = response.getBodyString();
 
-            assertThat(json)
-                    .contains(RegexpMapUserIdFilter.TYPE)
-                    .contains("param_test_session")
-                    .contains(RegexpMapSessionIdFilter.TYPE)
-                    .contains("param_test_user")
-                    .contains(XForwardedForRequestFilter.TYPE)
-                    .contains(XTlsProtocolRequestFilter.TYPE)
-                    .contains(XTlsCipherRequestFilter.TYPE);
+
+            assertThatJson(json).inPath("$[*].type").isArray().containsExactlyInAnyOrder(
+                    RegexpMapUserIdFilter.TYPE,
+                    RegexpMapSessionIdFilter.TYPE,
+                    XForwardedForRequestFilter.TYPE,
+                    XTlsProtocolRequestFilter.TYPE,
+                    XTlsCipherRequestFilter.TYPE);
+            assertThatJson(json).inPath("$[*].values.parameterName").isArray()
+                    .contains("param_test_user", "param_test_session");
         }
     }
 
@@ -579,9 +572,8 @@ public class StartAPIServerIT extends UseAdminServer {
             RawHttpClient.HttpResponse response = client.get("/api/users/all", c);
             String json = response.getBodyString();
 
-            assertThat(json)
-                    .contains("test1")
-                    .contains("test2");
+
+            assertThatJson(json).isArray().containsExactlyInAnyOrder("test", "test1", "test2");
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/api/StartAPIServerIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/StartAPIServerIT.java
@@ -19,6 +19,8 @@
  */
 package org.carapaceproxy.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.WAITING;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
 import static org.carapaceproxy.utils.APIUtils.certificateStateToString;
@@ -26,15 +28,6 @@ import static org.carapaceproxy.utils.CertificatesTestUtils.generateSampleChain;
 import static org.carapaceproxy.utils.CertificatesTestUtils.uploadCertificate;
 import static org.carapaceproxy.utils.CertificatesUtils.KEYSTORE_PW;
 import static org.carapaceproxy.utils.CertificatesUtils.createKeystore;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -66,7 +59,6 @@ import org.carapaceproxy.server.mapper.requestmatcher.MatchAllRequestMatcher;
 import org.carapaceproxy.utils.CertificatesUtils;
 import org.carapaceproxy.utils.RawHttpClient;
 import org.carapaceproxy.utils.TestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.shredzone.acme4j.util.KeyPairUtils;
@@ -81,23 +73,23 @@ public class StartAPIServerIT extends UseAdminServer {
     public File tmpFolder;
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         startAdmin();
 
         try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             RawHttpClient.HttpResponse resp = client.get("/api/up", credentials);
             String s = resp.getBodyString();
             System.out.println("s:" + s);
-            assertEquals("ok", s);
+            assertThat(s).isEqualTo("ok");
             // API calls cannot be cached by the client (browser)
-            assertTrue(resp.getHeaderLines().contains("Cache-Control: no-cache\r\n"));
+            assertThat(resp.getHeaderLines()).contains("Cache-Control: no-cache\r\n");
             // Allow CORS
-            assertTrue(resp.getHeaderLines().contains("Access-Control-Allow-Origin: *\r\n"));
+            assertThat(resp.getHeaderLines()).contains("Access-Control-Allow-Origin: *\r\n");
         }
     }
 
     @Test
-    public void testUnauthorized() throws Exception {
+    void unauthorized() throws Exception {
         // start server with authentication and user test - test
         Properties properties = new Properties(HTTP_ADMIN_SERVER_CONFIG);
 
@@ -108,14 +100,14 @@ public class StartAPIServerIT extends UseAdminServer {
 
         try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             RawHttpClient.HttpResponse resp = client.get("/api/up", credentials);
-            assertThat(resp.getBodyString(), containsString(HttpServletResponse.SC_UNAUTHORIZED + ""));
+            assertThat(resp.getBodyString()).contains(HttpServletResponse.SC_UNAUTHORIZED + "");
         }
 
         // ok credentials
         RawHttpClient.BasicAuthCredentials correctCredentials = new RawHttpClient.BasicAuthCredentials("test", "test");
         try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             RawHttpClient.HttpResponse resp = client.get("/api/up", correctCredentials);
-            assertEquals("ok", resp.getBodyString());
+            assertThat(resp.getBodyString()).isEqualTo("ok");
         }
 
         // Add new user
@@ -125,43 +117,43 @@ public class StartAPIServerIT extends UseAdminServer {
         correctCredentials = new RawHttpClient.BasicAuthCredentials("test2", "test2");
         try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             RawHttpClient.HttpResponse resp = client.get("/api/up", correctCredentials);
-            assertEquals("ok", resp.getBodyString());
+            assertThat(resp.getBodyString()).isEqualTo("ok");
         }
     }
 
     @Test
-    public void testCache() throws Exception {
+    void cache() throws Exception {
         startAdmin();
 
         try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             RawHttpClient.HttpResponse resp = client.get("/api/cache/info", credentials);
             String s = resp.getBodyString();
             System.out.println("s:" + s);
-            assertThat(s, is("{\"result\":\"ok\",\"hits\":0,\"directMemoryUsed\":0,\"misses\":0,\"heapMemoryUsed\":0,\"totalMemoryUsed\":0,\"cachesize\":0}"));
+            assertThat(s).isEqualTo("{\"result\":\"ok\",\"hits\":0,\"directMemoryUsed\":0,\"misses\":0,\"heapMemoryUsed\":0,\"totalMemoryUsed\":0,\"cachesize\":0}");
         }
 
         try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             RawHttpClient.HttpResponse resp = client.get("/api/cache/flush", credentials);
             String s = resp.getBodyString();
             System.out.println("s:" + s);
-            assertThat(s, is("{\"result\":\"ok\",\"cachesize\":0}"));
+            assertThat(s).isEqualTo("{\"result\":\"ok\",\"cachesize\":0}");
         }
     }
 
     @Test
-    public void testBackends() throws Exception {
+    void backends() throws Exception {
         startAdmin();
 
         try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             RawHttpClient.HttpResponse resp = client.get("/api/backends", credentials);
             String s = resp.getBodyString();
             // no backend configured
-            assertEquals("{}", s);
+            assertThat(s).isEqualTo("{}");
         }
     }
 
     @Test
-    public void testRoutes() throws Exception {
+    void routes() throws Exception {
         Properties properties = new Properties(HTTP_ADMIN_SERVER_CONFIG);
         properties.put("route.0.id", "id0");
         properties.put("route.0.action", "id-action");
@@ -173,30 +165,32 @@ public class StartAPIServerIT extends UseAdminServer {
         try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             RawHttpClient.HttpResponse resp = client.get("/api/routes", credentials);
             String s = resp.getBodyString();
-            assertTrue(s.contains("id0"));
-            assertTrue(s.contains("id-action"));
-            assertTrue(s.contains("true"));
-            assertTrue(s.contains(new MatchAllRequestMatcher().getDescription()));
+            assertThat(s)
+                    .contains("id0")
+                    .contains("id-action")
+                    .contains("true")
+                    .contains(new MatchAllRequestMatcher().getDescription());
         }
     }
 
     @Test
-    public void testActions() throws Exception {
+    void actions() throws Exception {
         startAdmin();
 
         try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             RawHttpClient.HttpResponse resp = client.get("/api/actions", credentials);
             String s = resp.getBodyString();
-            // Default actions
-            assertTrue(s.contains("\"not-found\",\"type\":\"static\""));
-            assertTrue(s.contains("\"cache-if-possible\",\"type\":\"cache\""));
-            assertTrue(s.contains("\"internal-error\",\"type\":\"static\""));
-            assertTrue(s.contains("\"proxy-all\",\"type\":\"proxy\""));
+            assertThat(s)
+                    // Default actions
+                    .contains("\"not-found\",\"type\":\"static\"")
+                    .contains("\"cache-if-possible\",\"type\":\"cache\"")
+                    .contains("\"internal-error\",\"type\":\"static\"")
+                    .contains("\"proxy-all\",\"type\":\"proxy\"");
         }
     }
 
     @Test
-    public void testDirectors() throws Exception {
+    void directors() throws Exception {
         Properties properties = new Properties(HTTP_ADMIN_SERVER_CONFIG);
         properties.put("director.1.backends", "*");
         properties.put("director.1.enabled", "false");
@@ -220,16 +214,16 @@ public class StartAPIServerIT extends UseAdminServer {
         try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             RawHttpClient.HttpResponse resp = client.get("/api/directors", credentials);
             final List<Map<?, ?>> s = new ObjectMapper().readValue(resp.getBody(), new TypeReference<>() {});
-            assertThat(s.size(), is(1));
+            assertThat(s).hasSize(1);
             final var id = s.get(0).get("id");
-            assertThat(id, is("iddirector2"));
+            assertThat(id).isEqualTo("iddirector2");
             final var backends = Set.copyOf((List<?>) s.get(0).get("backends"));
-            assertThat(backends, is(Set.of("localhost:8086", "localhost:8087")));
+            assertThat(backends).isEqualTo(Set.of("localhost:8086", "localhost:8087"));
         }
     }
 
     @Test
-    public void testConfig() throws Exception {
+    void config() throws Exception {
         startAdmin();
 
         try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
@@ -242,7 +236,7 @@ public class StartAPIServerIT extends UseAdminServer {
                     + "Authorization: Basic " + credentials.toBase64() + "\r\n"
                     + "\r\n"
                     + body);
-            assertTrue(resp.isOk());
+            assertThat(resp.isOk()).isTrue();
         }
         try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
             String body = "connectionsmanager.maxconnectionsperendpoint=20-BAD-VALUE";
@@ -253,13 +247,13 @@ public class StartAPIServerIT extends UseAdminServer {
                     + "Authorization: Basic " + credentials.toBase64() + "\r\n"
                     + "\r\n"
                     + body);
-            assertTrue(resp.isError());
-            assertTrue(resp.getBodyString().contains("Invalid integer value '20-BAD-VALUE' for parameter 'connectionsmanager.maxconnectionsperendpoint'"));
+            assertThat(resp.isError()).isTrue();
+            assertThat(resp.getBodyString()).contains("Invalid integer value '20-BAD-VALUE' for parameter 'connectionsmanager.maxconnectionsperendpoint'");
         }
     }
 
     @Test
-    public void testListeners() throws Exception {
+    void listeners() throws Exception {
         Properties properties = new Properties(HTTP_ADMIN_SERVER_CONFIG);
 
         properties.put("listener.1.host", "localhost");
@@ -275,17 +269,17 @@ public class StartAPIServerIT extends UseAdminServer {
             RawHttpClient.HttpResponse response = client.get("/api/listeners", credentials);
             String json = response.getBodyString();
 
-            assertThat(json, containsString("localhost"));
-            assertThat(json, containsString("1234"));
-
-            assertThat(json, containsString("127.0.0.1"));
-            assertThat(json, containsString("9876"));
+            assertThat(json)
+                    .contains("localhost")
+                    .contains("1234")
+                    .contains("127.0.0.1")
+                    .contains("9876");
         }
 
     }
 
     @Test
-    public void testCertificates() throws Exception {
+    void certificates() throws Exception {
         final String dynDomain = "dynamic.test.tld";
         Properties properties = new Properties(HTTP_ADMIN_SERVER_CONFIG);
 
@@ -321,7 +315,7 @@ public class StartAPIServerIT extends UseAdminServer {
         File nowrite = newFolder(tmpDir, "nowrite");
         nowrite.setWritable(false);
         properties.put("dynamiccertificatesmanager.localcertificates.store.path", nowrite.getAbsolutePath());
-        assertThrows(Exception.class, () -> startServer(properties));
+        assertThatThrownBy(() -> startServer(properties)).isInstanceOf(Exception.class);
         nowrite.setWritable(true);
 
         startServer(properties);
@@ -346,32 +340,33 @@ public class StartAPIServerIT extends UseAdminServer {
             RawHttpClient.HttpResponse response = client.get("/api/certificates", credentials);
             String json = response.getBodyString();
 
-            assertThat(json, containsString("localhost"));
-            assertThat(json, containsString("\"mode\":\"static\""));
-            assertThat(json, containsString("\"dynamic\":false"));
-            assertThat(json, containsString("\"status\":\"available\""));
-            assertThat(json, containsString("\"sslCertificateFile\":\"" + mock1.getAbsolutePath() + "\""));
-            assertThat(json, containsString("\"serialNumber\":\"" + serialNumber1 + "\""));
-            assertThat(json, containsString("\"expiringDate\":\"" + expiringDate1 + "\""));
-
-            assertThat(json, containsString("127.0.0.1"));
-            assertThat(json, containsString("\"mode\":\"static\""));
-            assertThat(json, containsString("\"dynamic\":false"));
-            assertThat(json, containsString("\"status\":\"expired\""));
-            assertThat(json, containsString("\"sslCertificateFile\":\"" + mock2.getAbsolutePath() + "\""));
-            assertThat(json, containsString("\"serialNumber\":\"" + serialNumber2 + "\""));
-            assertThat(json, containsString("\"expiringDate\":\"" + expiringDate2 + "\""));
+            assertThat(json)
+                    .contains("localhost")
+                    .contains("\"mode\":\"static\"")
+                    .contains("\"dynamic\":false")
+                    .contains("\"status\":\"available\"")
+                    .contains("\"sslCertificateFile\":\"" + mock1.getAbsolutePath() + "\"")
+                    .contains("\"serialNumber\":\"" + serialNumber1 + "\"")
+                    .contains("\"expiringDate\":\"" + expiringDate1 + "\"")
+                    .contains("127.0.0.1")
+                    .contains("\"mode\":\"static\"")
+                    .contains("\"dynamic\":false")
+                    .contains("\"status\":\"expired\"")
+                    .contains("\"sslCertificateFile\":\"" + mock2.getAbsolutePath() + "\"")
+                    .contains("\"serialNumber\":\"" + serialNumber2 + "\"")
+                    .contains("\"expiringDate\":\"" + expiringDate2 + "\"");
 
             // single cert request to /{certId}
             response = client.get("/api/certificates/127.0.0.1", credentials);
             json = response.getBodyString();
-            assertThat(json, not(containsString("localhost")));
-            assertThat(json, containsString("\"mode\":\"static\""));
-            assertThat(json, containsString("\"dynamic\":false"));
-            assertThat(json, containsString("\"status\":\"expired\""));
-            assertThat(json, containsString("\"sslCertificateFile\":\"" + mock2.getAbsolutePath() + "\""));
-            assertThat(json, containsString("\"serialNumber\":\"" + serialNumber2 + "\""));
-            assertThat(json, containsString("\"expiringDate\":\"" + expiringDate2 + "\""));
+            assertThat(json)
+                    .doesNotContain("localhost")
+                    .contains("\"mode\":\"static\"")
+                    .contains("\"dynamic\":false")
+                    .contains("\"status\":\"expired\"")
+                    .contains("\"sslCertificateFile\":\"" + mock2.getAbsolutePath() + "\"")
+                    .contains("\"serialNumber\":\"" + serialNumber2 + "\"")
+                    .contains("\"expiringDate\":\"" + expiringDate2 + "\"");
         }
 
         // Acme certificate
@@ -381,39 +376,43 @@ public class StartAPIServerIT extends UseAdminServer {
             RawHttpClient.HttpResponse response = client.get("/api/certificates", credentials);
             String json = response.getBodyString();
 
-            assertThat(json, containsString(dynDomain));
-            assertThat(json, containsString("\"mode\":\"acme\""));
-            assertThat(json, containsString("\"dynamic\":true"));
-            assertThat(json, containsString("\"status\":\"waiting\""));
-            assertThat(json, containsString("\"serialNumber\":\"" + serialNumber + "\""));
-            assertThat(json, containsString("\"expiringDate\":\"" + expiringDate + "\""));
+            assertThat(json)
+                    .contains(dynDomain)
+                    .contains("\"mode\":\"acme\"")
+                    .contains("\"dynamic\":true")
+                    .contains("\"status\":\"waiting\"")
+                    .contains("\"serialNumber\":\"" + serialNumber + "\"")
+                    .contains("\"expiringDate\":\"" + expiringDate + "\"");
 
             // single cert request to /{certId}
             response = client.get("/api/certificates/" + dynDomain, credentials);
             json = response.getBodyString();
-            assertThat(json, containsString(dynDomain));
-            assertThat(json, containsString("\"mode\":\"acme\""));
-            assertThat(json, containsString("\"dynamic\":true"));
-            assertThat(json, containsString("\"status\":\"waiting\""));
-            assertThat(json, containsString("\"serialNumber\":\"" + serialNumber + "\""));
-            assertThat(json, containsString("\"expiringDate\":\"" + expiringDate + "\""));
+            assertThat(json)
+                    .contains(dynDomain)
+                    .contains("\"mode\":\"acme\"")
+                    .contains("\"dynamic\":true")
+                    .contains("\"status\":\"waiting\"")
+                    .contains("\"serialNumber\":\"" + serialNumber + "\"")
+                    .contains("\"expiringDate\":\"" + expiringDate + "\"");
 
             // Changing dynamic certificate state
             for (DynamicCertificateState state : DynamicCertificateState.values()) {
                 man.setStateOfCertificate(dynDomain, state);
                 response = client.get("/api/certificates", credentials);
                 json = response.getBodyString();
-                assertThat(json, containsString(dynDomain));
-                assertThat(json, containsString("\"mode\":\"acme\""));
-                assertThat(json, containsString("\"dynamic\":true"));
-                assertThat(json, containsString("\"status\":\"" + certificateStateToString(state) + "\""));
+                assertThat(json)
+                        .contains(dynDomain)
+                        .contains("\"mode\":\"acme\"")
+                        .contains("\"dynamic\":true")
+                        .contains("\"status\":\"" + certificateStateToString(state) + "\"");
 
                 response = client.get("/api/certificates/" + dynDomain, credentials);
                 json = response.getBodyString();
-                assertThat(json, containsString(dynDomain));
-                assertThat(json, containsString("\"mode\":\"acme\""));
-                assertThat(json, containsString("\"dynamic\":true"));
-                assertThat(json, containsString("\"status\":\"" + certificateStateToString(state) + "\""));
+                assertThat(json)
+                        .contains(dynDomain)
+                        .contains("\"mode\":\"acme\"")
+                        .contains("\"dynamic\":true")
+                        .contains("\"status\":\"" + certificateStateToString(state) + "\"");
             }
 
             // Downloading
@@ -423,7 +422,7 @@ public class StartAPIServerIT extends UseAdminServer {
             store.saveCertificate(cert);
             man.setStateOfCertificate(dynDomain, DynamicCertificateState.AVAILABLE);
             response = client.get("/api/certificates/" + dynDomain + "/download", credentials);
-            assertArrayEquals(newKeystore, response.getBody());
+            assertThat(response.getBody()).containsExactly(newKeystore);
         }
 
         // Manual certificate
@@ -435,7 +434,7 @@ public class StartAPIServerIT extends UseAdminServer {
             // Uploading trash-stuff
             RawHttpClient.HttpResponse resp = uploadCertificate(manualDomain, null, "fake-chain".getBytes(), client, credentials);
             String s = resp.getBodyString();
-            assertTrue(s.contains("ERROR"));
+            assertThat(s).contains("ERROR");
 
             // Uploading real certificate
             endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
@@ -446,36 +445,38 @@ public class StartAPIServerIT extends UseAdminServer {
             byte[] chain1 = createKeystore(originalChain, endUserKeyPair.getPrivate());
             resp = uploadCertificate(manualDomain, null, chain1, client, credentials);
             s = resp.getBodyString();
-            assertTrue(s.contains("SUCCESS"));
+            assertThat(s).contains("SUCCESS");
 
             int certsCount2 = server.getCurrentConfiguration().getCertificates().size();
-            assertEquals(certsCount + 1, certsCount2);
+            assertThat(certsCount2).isEqualTo(certsCount + 1);
 
             // full list request
             RawHttpClient.HttpResponse response = client.get("/api/certificates", credentials);
             String json = response.getBodyString();
 
-            assertThat(json, containsString(manualDomain));
-            assertThat(json, containsString("\"mode\":\"manual\""));
-            assertThat(json, containsString("\"dynamic\":true"));
-            assertThat(json, containsString("\"status\":\"available\""));
-            assertThat(json, containsString("\"serialNumber\":\"" + serialNumber + "\""));
-            assertThat(json, containsString("\"expiringDate\":\"" + expiringDate + "\""));
+            assertThat(json)
+                    .contains(manualDomain)
+                    .contains("\"mode\":\"manual\"")
+                    .contains("\"dynamic\":true")
+                    .contains("\"status\":\"available\"")
+                    .contains("\"serialNumber\":\"" + serialNumber + "\"")
+                    .contains("\"expiringDate\":\"" + expiringDate + "\"");
 
             // single cert request to /{certId}
             response = client.get("/api/certificates/" + manualDomain, credentials);
             json = response.getBodyString();
-            assertThat(json, containsString(manualDomain));
-            assertThat(json, containsString("\"mode\":\"manual\""));
-            assertThat(json, containsString("\"dynamic\":true"));
-            assertThat(json, containsString("\"status\":\"available\""));
-            assertThat(json, containsString("\"serialNumber\":\"" + serialNumber + "\""));
-            assertThat(json, containsString("\"expiringDate\":\"" + expiringDate + "\""));
+            assertThat(json)
+                    .contains(manualDomain)
+                    .contains("\"mode\":\"manual\"")
+                    .contains("\"dynamic\":true")
+                    .contains("\"status\":\"available\"")
+                    .contains("\"serialNumber\":\"" + serialNumber + "\"")
+                    .contains("\"expiringDate\":\"" + expiringDate + "\"");
 
             // Downloading
             response = client.get("/api/certificates/" + manualDomain + "/download", credentials);
             Certificate[] responseChain = CertificatesUtils.readChainFromKeystore(response.getBody());
-            assertArrayEquals(CertificatesUtils.readChainFromKeystore(chain1), responseChain);
+            assertThat(responseChain).containsExactly(CertificatesUtils.readChainFromKeystore(chain1));
 
             // Certificate updating
             // Uploading
@@ -485,46 +486,48 @@ public class StartAPIServerIT extends UseAdminServer {
             serialNumber = certificate.getSerialNumber().toString(16).toUpperCase();
             expiringDate = certificate.getNotAfter().toString();
             byte[] chain2 = createKeystore(originalChain, endUserKeyPair.getPrivate());
-            assertFalse(Arrays.equals(chain1, chain2));
+            assertThat(Arrays.equals(chain1, chain2)).isFalse();
             resp = uploadCertificate(manualDomain, null, chain2, client, credentials);
             s = resp.getBodyString();
-            assertTrue(s.contains("SUCCESS"));
+            assertThat(s).contains("SUCCESS");
 
             //  check properties (certificate) not duplicated
             int certsCount3 = server.getCurrentConfiguration().getCertificates().size();
-            assertEquals(certsCount2, certsCount3);
+            assertThat(certsCount3).isEqualTo(certsCount2);
 
             // full list request
             response = client.get("/api/certificates", credentials);
             json = response.getBodyString();
 
-            assertThat(json, containsString(manualDomain));
-            assertThat(json, containsString("\"mode\":\"manual\""));
-            assertThat(json, containsString("\"dynamic\":true"));
-            assertThat(json, containsString("\"status\":\"expired\""));
-            assertThat(json, containsString("\"serialNumber\":\"" + serialNumber + "\""));
-            assertThat(json, containsString("\"expiringDate\":\"" + expiringDate + "\""));
+            assertThat(json)
+                    .contains(manualDomain)
+                    .contains("\"mode\":\"manual\"")
+                    .contains("\"dynamic\":true")
+                    .contains("\"status\":\"expired\"")
+                    .contains("\"serialNumber\":\"" + serialNumber + "\"")
+                    .contains("\"expiringDate\":\"" + expiringDate + "\"");
 
             // single cert request to /{certId}
             response = client.get("/api/certificates/" + manualDomain, credentials);
             json = response.getBodyString();
-            assertThat(json, containsString(manualDomain));
-            assertThat(json, containsString("\"mode\":\"manual\""));
-            assertThat(json, containsString("\"dynamic\":true"));
-            assertThat(json, containsString("\"status\":\"expired\""));
-            assertThat(json, containsString("\"serialNumber\":\"" + serialNumber + "\""));
-            assertThat(json, containsString("\"expiringDate\":\"" + expiringDate + "\""));
+            assertThat(json)
+                    .contains(manualDomain)
+                    .contains("\"mode\":\"manual\"")
+                    .contains("\"dynamic\":true")
+                    .contains("\"status\":\"expired\"")
+                    .contains("\"serialNumber\":\"" + serialNumber + "\"")
+                    .contains("\"expiringDate\":\"" + expiringDate + "\"");
 
             // Downloading
             response = client.get("/api/certificates/" + manualDomain + "/download", credentials);
             Certificate[] responseChain2 = CertificatesUtils.readChainFromKeystore(response.getBody());
-            assertArrayEquals(CertificatesUtils.readChainFromKeystore(chain2), responseChain2);
+            assertThat(responseChain2).containsExactly(CertificatesUtils.readChainFromKeystore(chain2));
         }
     }
 
     @SuppressWarnings("deprecation")
     @Test
-    public void testResourcesFilter() throws Exception {
+    void resourcesFilter() throws Exception {
         Properties properties = new Properties(HTTP_ADMIN_SERVER_CONFIG);
 
         properties.put("filter.1.type", "match-user-regexp");
@@ -546,18 +549,19 @@ public class StartAPIServerIT extends UseAdminServer {
             RawHttpClient.HttpResponse response = client.get("/api/requestfilters", credentials);
             String json = response.getBodyString();
 
-            assertThat(json, containsString(RegexpMapUserIdFilter.TYPE));
-            assertThat(json, containsString("param_test_session"));
-            assertThat(json, containsString(RegexpMapSessionIdFilter.TYPE));
-            assertThat(json, containsString("param_test_user"));
-            assertThat(json, containsString(XForwardedForRequestFilter.TYPE));
-            assertThat(json, containsString(XTlsProtocolRequestFilter.TYPE));
-            assertThat(json, containsString(XTlsCipherRequestFilter.TYPE));
+            assertThat(json)
+                    .contains(RegexpMapUserIdFilter.TYPE)
+                    .contains("param_test_session")
+                    .contains(RegexpMapSessionIdFilter.TYPE)
+                    .contains("param_test_user")
+                    .contains(XForwardedForRequestFilter.TYPE)
+                    .contains(XTlsProtocolRequestFilter.TYPE)
+                    .contains(XTlsCipherRequestFilter.TYPE);
         }
     }
 
     @Test
-    public void testUserRealm() throws Exception {
+    void userRealm() throws Exception {
         Properties properties = new Properties(HTTP_ADMIN_SERVER_CONFIG);
 
         properties.put("userrealm.class", "org.carapaceproxy.utils.TestUserRealm");
@@ -575,13 +579,14 @@ public class StartAPIServerIT extends UseAdminServer {
             RawHttpClient.HttpResponse response = client.get("/api/users/all", c);
             String json = response.getBodyString();
 
-            assertThat(json, containsString("test1"));
-            assertThat(json, containsString("test2"));
+            assertThat(json)
+                    .contains("test1")
+                    .contains("test2");
         }
     }
 
     @Test
-    public void testHttpsApi() throws Exception {
+    void httpsApi() throws Exception {
         String certificate = TestUtils.deployResource("localhost.p12", tmpDir);
 
         Properties properties = new Properties();
@@ -597,7 +602,7 @@ public class StartAPIServerIT extends UseAdminServer {
             RawHttpClient.HttpResponse response = client.get("/api/config", credentials);
             String json = response.getBodyString();
 
-            assertThat(json, containsString("https.admin.sslcertfile=" + certificate));
+            assertThat(json).contains("https.admin.sslcertfile=" + certificate);
         }
 
         IOException exc = null;
@@ -607,12 +612,12 @@ public class StartAPIServerIT extends UseAdminServer {
             exc = ex;
         }
 
-        Assertions.assertNotNull(exc);
-        assertThat(exc.getMessage(), containsString("bad response, does not start with HTTP/1.1"));
+        assertThat(exc).isNotNull();
+        assertThat(exc.getMessage()).contains("bad response, does not start with HTTP/1.1");
     }
 
     @Test
-    public void testHttpAndHttpsApi() throws Exception {
+    void httpAndHttpsApi() throws Exception {
         String certificate = TestUtils.deployResource("localhost.p12", tmpDir);
 
         Properties properties = new Properties(HTTP_ADMIN_SERVER_CONFIG);
@@ -626,19 +631,19 @@ public class StartAPIServerIT extends UseAdminServer {
             RawHttpClient.HttpResponse response = client.get("/api/config", credentials);
             String json = response.getBodyString();
 
-            assertThat(json, containsString("https.admin.sslcertfile=" + certificate));
+            assertThat(json).contains("https.admin.sslcertfile=" + certificate);
         }
 
         try (RawHttpClient client = new RawHttpClient("localhost", 8761, false)) {
             RawHttpClient.HttpResponse response = client.get("/api/config", credentials);
             String json = response.getBodyString();
 
-            assertThat(json, containsString("https.admin.sslcertfile=" + certificate));
+            assertThat(json).contains("https.admin.sslcertfile=" + certificate);
         }
     }
 
     @Test
-    public void testApiRequestsLogger() throws Exception {
+    void apiRequestsLogger() throws Exception {
         String certificate = TestUtils.deployResource("localhost.p12", tmpDir);
 
         Properties properties = new Properties(HTTP_ADMIN_SERVER_CONFIG);
@@ -665,11 +670,11 @@ public class StartAPIServerIT extends UseAdminServer {
             String line;
             int lineCount = 0;
             while ((line = reader.readLine()) != null) {
-                assertThat(line, containsString("\"GET /api/config HTTP/1.1\" 200"));
+                assertThat(line).contains("\"GET /api/config HTTP/1.1\" 200");
                 lineCount++;
             }
 
-            assertEquals(2, lineCount);
+            assertThat(lineCount).isEqualTo(2);
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/api/UseAdminServer.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/api/UseAdminServer.java
@@ -19,8 +19,8 @@
  */
 package org.carapaceproxy.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.carapaceproxy.core.HttpProxyServer.buildForTests;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -58,15 +58,15 @@ public class UseAdminServer {
     public RawHttpClient.BasicAuthCredentials credentials;
 
     @BeforeEach
-    public void buildNewServer() throws Exception {
-        assertNull(server);
+    void buildNewServer() throws Exception {
+        assertThat(server).isNull();
         credentials = new RawHttpClient.BasicAuthCredentials(DEFAULT_USERNAME, DEFAULT_PASSWORD);
         File serverRoot = tmpDir; // at every reboot we must keep the same directory
         server = buildForTests("localhost", 0, new TestEndpointMapper("localhost", 0), serverRoot);
     }
 
     @AfterEach
-    public void stopServer() {
+    void stopServer() {
         if (server != null) {
             server.close();
             server = null;

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/ChunkedEncodingRequestsIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/ChunkedEncodingRequestsIT.java
@@ -23,7 +23,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -59,7 +59,7 @@ public class ChunkedEncodingRequestsIT {
     public File tmpDir;
 
     @Test
-    public void testSimple() throws Exception {
+    void simple() throws Exception {
 
         wireMockRule.stubFor(
                 post(urlEqualTo("/index.html")).
@@ -82,13 +82,13 @@ public class ChunkedEncodingRequestsIT {
                 String s = client
                         .executeRequest("POST /index.html HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n" + TEST_DATA).toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
             }
         }
     }
 
     @Test
-    public void testClientAbortsUpload() throws Exception {
+    void clientAbortsUpload() throws Exception {
 
         wireMockRule.stubFor(
                 post(urlEqualTo("/index.html")).
@@ -111,7 +111,7 @@ public class ChunkedEncodingRequestsIT {
                 String s = client
                         .executeRequest("POST /index.html HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n" + TEST_DATA).toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
 
                 client
                         .sendRequest("POST /index.html HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n" + TEST_DATA_ABORTED);
@@ -122,7 +122,7 @@ public class ChunkedEncodingRequestsIT {
                 String s = client
                         .executeRequest("POST /index.html HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n" + TEST_DATA).toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
             }
         }
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/ChunkedEncodingResponseIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/ChunkedEncodingResponseIT.java
@@ -168,7 +168,7 @@ public class ChunkedEncodingResponseIT {
     }
 
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "httpVersion={0}, inCache={1}")
     @MethodSource("parametersForChunkedHttp10Test")
     void chunkedHttp(final HttpVersion httpVersion, final boolean inCache) throws Exception {
         wireMockRule.stubFor(

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/ChunkedEncodingResponseIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/ChunkedEncodingResponseIT.java
@@ -24,10 +24,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderNames.TRANSFER_ENCODING;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -61,7 +58,7 @@ public class ChunkedEncodingResponseIT {
     public File tmpDir;
 
     @Test
-    public void testSimpleChunkedResponseNoCache() throws Exception {
+    void simpleChunkedResponseNoCache() throws Exception {
         wireMockRule.stubFor(
                 get(urlEqualTo("/index.html")).
                         willReturn(aResponse()
@@ -79,41 +76,41 @@ public class ChunkedEncodingResponseIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("""
+                assertThat(s).contains("""
                         12\r
                         it <b>works</b> !!\r
                         0\r
                         \r
-                        """));
-                assertEquals("it <b>works</b> !!", resp.getBodyString());
+                        """);
+                assertThat(resp.getBodyString()).isEqualTo("it <b>works</b> !!");
 
                 resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 System.out.println("s:" + resp);
-                assertTrue(resp.toString().contains("""
+                assertThat(resp.toString()).contains("""
                         12\r
                         it <b>works</b> !!\r
                         0\r
                         \r
-                        """));
-                assertEquals("it <b>works</b> !!", resp.getBodyString());
+                        """);
+                assertThat(resp.getBodyString()).isEqualTo("it <b>works</b> !!");
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("""
+                assertThat(s).contains("""
                         12\r
                         it <b>works</b> !!\r
                         0\r
                         \r
-                        """));
+                        """);
             }
-            assertEquals(0, server.getCache().getCacheSize());
+            assertThat(server.getCache().getCacheSize()).isZero();
         }
     }
 
     @Test
-    public void testSimpleChunkedResponseWithCache() throws Exception {
+    void simpleChunkedResponseWithCache() throws Exception {
         wireMockRule.stubFor(
                 get(urlEqualTo("/index.html")).
                         willReturn(aResponse()
@@ -133,47 +130,47 @@ public class ChunkedEncodingResponseIT {
                         .executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("""
+                assertThat(s).contains("""
                         12\r
                         it <b>works</b> !!\r
                         0\r
                         \r
-                        """));
-                assertEquals("it <b>works</b> !!", resp.getBodyString());
+                        """);
+                assertThat(resp.getBodyString()).isEqualTo("it <b>works</b> !!");
 
                 resp = client
                         .executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 System.out.println("s:" + resp);
-                assertTrue(resp.toString().contains("""
+                assertThat(resp.toString()).contains("""
                         12\r
                         it <b>works</b> !!\r
                         0\r
                         \r
-                        """));
-                assertEquals("it <b>works</b> !!", resp.getBodyString());
+                        """);
+                assertThat(resp.getBodyString()).isEqualTo("it <b>works</b> !!");
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client
                         .executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("""
+                assertThat(s).contains("""
                         12\r
                         it <b>works</b> !!\r
                         0\r
                         \r
-                        """));
+                        """);
             }
-            assertEquals(1, server.getCache().getCacheSize());
-            assertEquals(2, server.getCache().getStats().getHits());
-            assertEquals(1, server.getCache().getStats().getMisses());
+            assertThat(server.getCache().getCacheSize()).isOne();
+            assertThat(server.getCache().getStats().getHits()).isEqualTo(2);
+            assertThat(server.getCache().getStats().getMisses()).isOne();
         }
     }
 
 
     @ParameterizedTest
     @MethodSource("parametersForChunkedHttp10Test")
-    public void testChunkedHttp(final HttpVersion httpVersion, final boolean inCache) throws Exception {
+    void chunkedHttp(final HttpVersion httpVersion, final boolean inCache) throws Exception {
         wireMockRule.stubFor(
                 get(urlEqualTo("/index.html")).
                         willReturn(aResponse()
@@ -202,18 +199,18 @@ public class ChunkedEncodingResponseIT {
                 HttpResponse response = client.execute(request);
 
                 if (Objects.equals(httpVersion, HttpVersion.HTTP_1_0)) {
-                    assertNull(response.getFirstHeader(TRANSFER_ENCODING.toString()));
-                    assertNotNull(response.getFirstHeader(CONTENT_LENGTH.toString()));
+                    assertThat(response.getFirstHeader(TRANSFER_ENCODING.toString())).isNull();
+                    assertThat(response.getFirstHeader(CONTENT_LENGTH.toString())).isNotNull();
                 } else {
-                    assertEquals("chunked", response.getFirstHeader(TRANSFER_ENCODING.toString()).getValue());
-                    assertNull(response.getFirstHeader(CONTENT_LENGTH.toString()));
+                    assertThat(response.getFirstHeader(TRANSFER_ENCODING.toString()).getValue()).isEqualTo("chunked");
+                    assertThat(response.getFirstHeader(CONTENT_LENGTH.toString())).isNull();
                 }
                 if (inCache) {
-                    assertNotNull(response.getFirstHeader("X-cached"));
-                    assertEquals(1, server.getCache().getStats().getHits());
+                    assertThat(response.getFirstHeader("X-cached")).isNotNull();
+                    assertThat(server.getCache().getStats().getHits()).isOne();
                 } else {
-                    assertNull(response.getFirstHeader("X-cached"));
-                    assertEquals(0, server.getCache().getStats().getHits());
+                    assertThat(response.getFirstHeader("X-cached")).isNull();
+                    assertThat(server.getCache().getStats().getHits()).isZero();
                 }
             }
 
@@ -224,9 +221,9 @@ public class ChunkedEncodingResponseIT {
         server.getCache().reloadConfiguration(server.getCurrentConfiguration());
         server.getCache().getStats().resetCacheMetrics();
         server.getCache().clear();
-        assertEquals(0, server.getCache().getCacheSize());
-        assertEquals(0, server.getCache().getStats().getHits());
-        assertEquals(0, server.getCache().getStats().getMisses());
+        assertThat(server.getCache().getCacheSize()).isZero();
+        assertThat(server.getCache().getStats().getHits()).isZero();
+        assertThat(server.getCache().getStats().getMisses()).isZero();
     }
 
     public static Object[] parametersForChunkedHttp10Test() {

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/ConnectionPoolIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/ConnectionPoolIT.java
@@ -259,7 +259,7 @@ public class ConnectionPoolIT extends UseAdminServer {
             Map<SocketAddress, Integer> maxConnectionsPerHost = provider.maxConnectionsPerHost();
             assertThat(maxConnectionsPerHost)
                     .hasSize(2);
-            assertThat(maxConnectionsPerHost.values()).allMatch(e -> e == 10);
+            assertThat(maxConnectionsPerHost.values()).containsOnly(10);
         }
 
         // pool with defaults
@@ -272,7 +272,7 @@ public class ConnectionPoolIT extends UseAdminServer {
             Map<SocketAddress, Integer> maxConnectionsPerHost = provider.maxConnectionsPerHost();
             assertThat(maxConnectionsPerHost)
                     .hasSize(2);
-            assertThat(maxConnectionsPerHost.values()).allMatch(e -> e == 10);
+            assertThat(maxConnectionsPerHost.values()).containsOnly(10);
         }
 
         // custom pool
@@ -285,7 +285,7 @@ public class ConnectionPoolIT extends UseAdminServer {
             Map<SocketAddress, Integer> maxConnectionsPerHost = provider.maxConnectionsPerHost();
             assertThat(maxConnectionsPerHost)
                     .hasSize(2);
-            assertThat(maxConnectionsPerHost.values()).allMatch(e -> e == 20);
+            assertThat(maxConnectionsPerHost.values()).containsOnly(20);
         }
 
         // connection pool selection
@@ -305,7 +305,7 @@ public class ConnectionPoolIT extends UseAdminServer {
             Map<SocketAddress, Integer> maxConnectionsPerHost = provider.maxConnectionsPerHost();
             assertThat(maxConnectionsPerHost)
                     .hasSize(2);
-            assertThat(maxConnectionsPerHost.values()).allMatch(e -> e == 10);
+            assertThat(maxConnectionsPerHost.values()).containsOnly(10);
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\n" + HttpHeaderNames.HOST + ": localhostx" + "\r\n\r\n");
@@ -331,7 +331,7 @@ public class ConnectionPoolIT extends UseAdminServer {
             Map<SocketAddress, Integer> maxConnectionsPerHost = provider.maxConnectionsPerHost();
             assertThat(maxConnectionsPerHost)
                     .hasSize(2);
-            assertThat(maxConnectionsPerHost.values()).allMatch(e -> e == 10);
+            assertThat(maxConnectionsPerHost.values()).containsOnly(10);
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\n" + HttpHeaderNames.HOST + ": localhost" + "\r\n\r\n");
@@ -357,7 +357,7 @@ public class ConnectionPoolIT extends UseAdminServer {
             Map<SocketAddress, Integer> maxConnectionsPerHost = provider.maxConnectionsPerHost();
             assertThat(maxConnectionsPerHost)
                     .hasSize(2);
-            assertThat(maxConnectionsPerHost.values()).allMatch(e -> e == 20);
+            assertThat(maxConnectionsPerHost.values()).containsOnly(20);
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\n" + HttpHeaderNames.HOST + ": localhost3" + "\r\n\r\n");

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/ConnectionPoolIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/ConnectionPoolIT.java
@@ -23,14 +23,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -162,7 +155,7 @@ public class ConnectionPoolIT extends UseAdminServer {
     }
 
     @Test
-    public void hostHeaderTest() throws Exception {
+    void hostHeaderTest() throws Exception {
         configureAndStartServer();
         int port = server.getLocalPort();
         String hostname = "localhost";
@@ -170,55 +163,55 @@ public class ConnectionPoolIT extends UseAdminServer {
 
         //No Http header host
         String response = sendRequest(false, hostname, port, path, null);
-        assertThat(response, containsString("Bad request"));
+        assertThat(response).contains("Bad request");
 
         //Add Http header host
         String response2 = sendRequest(true, hostname, port, path, "localhost");
-        assertThat(response2, containsString("it <b>works</b> !!"));
+        assertThat(response2).contains("it <b>works</b> !!");
 
         //Empty header host
         String response3 = sendRequest(true, hostname, port, path, "");
-        assertThat(response3, containsString("Bad request"));
+        assertThat(response3).contains("Bad request");
 
         //Empty header host
         String response4 = sendRequest(true, hostname, port, path, " ");
-        assertThat(response4, containsString("Bad request"));
+        assertThat(response4).contains("Bad request");
 
         //Header host with special character
         String response5 = sendRequest(true, hostname, port, path, "local%&&host");
-        assertThat(response5, containsString("Bad request"));
+        assertThat(response5).contains("Bad request");
 
         //Header host with multiple domain
         String response6 = sendRequest(true, hostname, port, path, "localhost1,localhost2");
-        assertThat(response6, containsString("Bad request"));
+        assertThat(response6).contains("Bad request");
 
         //Ip address as host header
         String response7 = sendRequest(true, hostname, port, path, "127.0.0.1");
-        assertThat(response7, containsString("it <b>works</b> !!"));
+        assertThat(response7).contains("it <b>works</b> !!");
 
         //Invalid ip address
         String response8 = sendRequest(true, hostname, port, path, "256.0.0.0");
-        assertThat(response8, containsString("Bad request"));
+        assertThat(response8).contains("Bad request");
 
         //Ip address as host header with port
         String response9 = sendRequest(true, hostname, port, path, "127.0.0.1:8080");
-        assertThat(response9, containsString("it <b>works</b> !!"));
+        assertThat(response9).contains("it <b>works</b> !!");
 
         //Hostname as host header with port
         String response10 = sendRequest(true, hostname, port, path, "localhost:8080");
-        assertThat(response10, containsString("it <b>works</b> !!"));
+        assertThat(response10).contains("it <b>works</b> !!");
 
         //Hostname as host header with port
         String response11 = sendRequest(true, hostname, port, path, "localhost:8080&");
-        assertThat(response11, containsString("Bad Request"));
+        assertThat(response11).contains("Bad Request");
 
         //Invalid hostname
         String response12 = sendRequest(true, hostname, port, path, "::::8080::9999");
-        assertThat(response12, containsString("Bad Request"));
+        assertThat(response12).contains("Bad Request");
 
         //Add Http header host
         String response13 = sendRequest(true, hostname, port, path, "localhost3");
-        assertThat(response13, containsString("it <b>works</b> !!"));
+        assertThat(response13).contains("it <b>works</b> !!");
     }
 
     public String sendRequest(boolean addHeaderHost, String hostname, int port, String path, String headerHost) throws IOException {
@@ -252,7 +245,7 @@ public class ConnectionPoolIT extends UseAdminServer {
     }
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         configureAndStartServer();
         int port = server.getLocalPort();
 
@@ -262,11 +255,11 @@ public class ConnectionPoolIT extends UseAdminServer {
         );
         {
             ConnectionProvider provider = server.getProxyRequestsManager().getConnectionsManager().getConnectionProvider(defaultPool);
-            assertThat(provider, not(nullValue()));
+            assertThat(provider).isNotNull();
             Map<SocketAddress, Integer> maxConnectionsPerHost = provider.maxConnectionsPerHost();
-            assertThat(maxConnectionsPerHost, is(notNullValue(Map.class)));
-            assertThat(maxConnectionsPerHost.size(), is(2));
-            assertTrue(maxConnectionsPerHost.values().stream().allMatch(e -> e == 10));
+            assertThat(maxConnectionsPerHost)
+                    .hasSize(2);
+            assertThat(maxConnectionsPerHost.values()).allMatch(e -> e == 10);
         }
 
         // pool with defaults
@@ -275,11 +268,11 @@ public class ConnectionPoolIT extends UseAdminServer {
         );
         {
             ConnectionProvider provider = server.getProxyRequestsManager().getConnectionsManager().getConnectionProvider(poolWithDefaults);
-            assertThat(provider, not(nullValue()));
+            assertThat(provider).isNotNull();
             Map<SocketAddress, Integer> maxConnectionsPerHost = provider.maxConnectionsPerHost();
-            assertThat(maxConnectionsPerHost, is(notNullValue(Map.class)));
-            assertThat(maxConnectionsPerHost.size(), is(2));
-            assertTrue(maxConnectionsPerHost.values().stream().allMatch(e -> e == 10));
+            assertThat(maxConnectionsPerHost)
+                    .hasSize(2);
+            assertThat(maxConnectionsPerHost.values()).allMatch(e -> e == 10);
         }
 
         // custom pool
@@ -288,11 +281,11 @@ public class ConnectionPoolIT extends UseAdminServer {
         );
         {
             ConnectionProvider provider = server.getProxyRequestsManager().getConnectionsManager().getConnectionProvider(customPool);
-            assertThat(provider, not(nullValue()));
+            assertThat(provider).isNotNull();
             Map<SocketAddress, Integer> maxConnectionsPerHost = provider.maxConnectionsPerHost();
-            assertThat(maxConnectionsPerHost, is(notNullValue(Map.class)));
-            assertThat(maxConnectionsPerHost.size(), is(2));
-            assertTrue(maxConnectionsPerHost.values().stream().allMatch(e -> e == 20));
+            assertThat(maxConnectionsPerHost)
+                    .hasSize(2);
+            assertThat(maxConnectionsPerHost.values()).allMatch(e -> e == 20);
         }
 
         // connection pool selection
@@ -308,20 +301,20 @@ public class ConnectionPoolIT extends UseAdminServer {
             final String hostName = proxyRequest.getRequestHostname();
             final ConnectionPoolConfiguration configuration = connectionsManager.findConnectionPool(hostName);
             final ConnectionProvider provider = connectionsManager.getConnectionProvider(configuration);
-            assertThat(configuration, is(defaultPool));
+            assertThat(configuration).isEqualTo(defaultPool);
             Map<SocketAddress, Integer> maxConnectionsPerHost = provider.maxConnectionsPerHost();
-            assertThat(maxConnectionsPerHost, is(notNullValue(Map.class)));
-            assertThat(maxConnectionsPerHost.size(), is(2));
-            assertTrue(maxConnectionsPerHost.values().stream().allMatch(e -> e == 10));
+            assertThat(maxConnectionsPerHost)
+                    .hasSize(2);
+            assertThat(maxConnectionsPerHost.values()).allMatch(e -> e == 10);
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\n" + HttpHeaderNames.HOST + ": localhostx" + "\r\n\r\n");
-                assertEquals("it <b>works</b> !!", resp.getBodyString());
+                assertThat(resp.getBodyString()).isEqualTo("it <b>works</b> !!");
             }
             Map<String, HttpProxyServer.ConnectionPoolStats> stats = server.getConnectionPoolsStats().get(EndpointKey.make("localhost", wireMockRule.getPort()));
-            assertThat(stats.get("*").getTotalConnections(), is(1));
-            assertThat(stats.get("localhost"), is(nullValue()));
-            assertThat(stats.get("localhosts"), is(nullValue()));
+            assertThat(stats.get("*").getTotalConnections()).isOne();
+            assertThat(stats.get("localhost")).isNull();
+            assertThat(stats.get("localhosts")).isNull();
         }
 
         // provider with defaults
@@ -334,20 +327,20 @@ public class ConnectionPoolIT extends UseAdminServer {
             final String hostName = proxyRequest.getRequestHostname();
             final ConnectionPoolConfiguration configuration = connectionsManager.findConnectionPool(hostName);
             final ConnectionProvider provider = connectionsManager.getConnectionProvider(configuration);
-            assertThat(configuration, is(poolWithDefaults));
+            assertThat(configuration).isEqualTo(poolWithDefaults);
             Map<SocketAddress, Integer> maxConnectionsPerHost = provider.maxConnectionsPerHost();
-            assertThat(maxConnectionsPerHost, is(notNullValue(Map.class)));
-            assertThat(maxConnectionsPerHost.size(), is(2));
-            assertTrue(maxConnectionsPerHost.values().stream().allMatch(e -> e == 10));
+            assertThat(maxConnectionsPerHost)
+                    .hasSize(2);
+            assertThat(maxConnectionsPerHost.values()).allMatch(e -> e == 10);
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\n" + HttpHeaderNames.HOST + ": localhost" + "\r\n\r\n");
-                assertEquals("it <b>works</b> !!", resp.getBodyString());
+                assertThat(resp.getBodyString()).isEqualTo("it <b>works</b> !!");
             }
             Map<String, HttpProxyServer.ConnectionPoolStats> stats = server.getConnectionPoolsStats().get(EndpointKey.make("localhost", wireMockRule.getPort()));
-            assertThat(stats.get("*").getTotalConnections(), is(1));
-            assertThat(stats.get("localhost").getTotalConnections(), is(1));
-            assertThat(stats.get("localhosts"), is(nullValue()));
+            assertThat(stats.get("*").getTotalConnections()).isOne();
+            assertThat(stats.get("localhost").getTotalConnections()).isOne();
+            assertThat(stats.get("localhosts")).isNull();
         }
 
         // custom provider
@@ -360,31 +353,31 @@ public class ConnectionPoolIT extends UseAdminServer {
             final String hostName = proxyRequest.getRequestHostname();
             final ConnectionPoolConfiguration configuration = connectionsManager.findConnectionPool(hostName);
             final ConnectionProvider provider = connectionsManager.getConnectionProvider(configuration);
-            assertThat(configuration, is(customPool));
+            assertThat(configuration).isEqualTo(customPool);
             Map<SocketAddress, Integer> maxConnectionsPerHost = provider.maxConnectionsPerHost();
-            assertThat(maxConnectionsPerHost, is(notNullValue(Map.class)));
-            assertThat(maxConnectionsPerHost.size(), is(2));
-            assertTrue(maxConnectionsPerHost.values().stream().allMatch(e -> e == 20));
+            assertThat(maxConnectionsPerHost)
+                    .hasSize(2);
+            assertThat(maxConnectionsPerHost.values()).allMatch(e -> e == 20);
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\n" + HttpHeaderNames.HOST + ": localhost3" + "\r\n\r\n");
-                assertEquals("it <b>works</b> !!", resp.getBodyString());
+                assertThat(resp.getBodyString()).isEqualTo("it <b>works</b> !!");
             }
             Map<String, HttpProxyServer.ConnectionPoolStats> stats = server.getConnectionPoolsStats().get(EndpointKey.make("localhost", wireMockRule.getPort()));
-            assertThat(stats.get("*").getTotalConnections(), is(1));
-            assertThat(stats.get("localhost").getTotalConnections(), is(1));
-            assertThat(stats.get("localhosts").getTotalConnections(), is(1));
+            assertThat(stats.get("*").getTotalConnections()).isOne();
+            assertThat(stats.get("localhost").getTotalConnections()).isOne();
+            assertThat(stats.get("localhosts").getTotalConnections()).isOne();
         }
     }
 
     @Test
-    public void testAPIResource() throws Exception {
+    void apiResource() throws Exception {
         configureAndStartServer();
         int port = server.getLocalPort();
 
         try (RawHttpClient client = new RawHttpClient("localhost", port)) {
             String s1 = client.get("/index.html").getBodyString();
-            assertEquals("it <b>works</b> !!", s1);
+            assertThat(s1).isEqualTo("it <b>works</b> !!");
         }
 
         try (RawHttpClient client = new RawHttpClient("localhost", 8761)) {
@@ -392,27 +385,27 @@ public class ConnectionPoolIT extends UseAdminServer {
             TypeReference<HashMap<String, ConnectionPoolsResource.ConnectionPoolBean>> typeRef = new TypeReference<HashMap<String, ConnectionPoolsResource.ConnectionPoolBean>>() {
             };
             Map<String, ConnectionPoolsResource.ConnectionPoolBean> pools = MAPPER.readValue(response.getBodyString(), typeRef);
-            assertThat(pools.size(), is(4));
+            assertThat(pools).hasSize(4);
 
             // default pool
-            assertThat(pools.get("*"), is(new ConnectionPoolsResource.ConnectionPoolBean(
-                    "*", "*", 10, 5_000, 10_000, 15_000, 20_000, 100_000, 50_000, 500, 50, 5, true,true, 0
-            )));
+            assertThat(pools).containsEntry("*", new ConnectionPoolsResource.ConnectionPoolBean(
+                    "*", "*", 10, 5_000, 10_000, 15_000, 20_000, 100_000, 50_000, 500, 50, 5, true, true, 0
+            ));
 
             // pool with defaults
-            assertThat(pools.get("localhost"), is(new ConnectionPoolsResource.ConnectionPoolBean(
-                    "localhost", "localhost", 10, 5_000, 10_000, 15_000, 20_000, 100_000,50_000, 500, 50, 5, true,true, 1
-            )));
+            assertThat(pools).containsEntry("localhost", new ConnectionPoolsResource.ConnectionPoolBean(
+                    "localhost", "localhost", 10, 5_000, 10_000, 15_000, 20_000, 100_000, 50_000, 500, 50, 5, true, true, 1
+            ));
 
             // disabled custom pool
-            assertThat(pools.get("localhost2"), is(new ConnectionPoolsResource.ConnectionPoolBean(
+            assertThat(pools).containsEntry("localhost2", new ConnectionPoolsResource.ConnectionPoolBean(
                     "localhost2", "localhost2", 10, 5_000, 10_000, 15_000, 20_000, 100_000, 50_000, 500, 50, 5, true, false, 0
-            )));
+            ));
 
             // custom pool
-            assertThat(pools.get("localhosts"), is(new ConnectionPoolsResource.ConnectionPoolBean(
+            assertThat(pools).containsEntry("localhosts", new ConnectionPoolsResource.ConnectionPoolBean(
                     "localhosts", "localhost[0-9]", 20, 21_000, 22_000, 23_000, 24_000, 100_000, 25_000, 250, 25, 2, true, true, 0
-            )));
+            ));
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/ConnectionPoolIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/ConnectionPoolIT.java
@@ -255,7 +255,6 @@ public class ConnectionPoolIT extends UseAdminServer {
         );
         {
             ConnectionProvider provider = server.getProxyRequestsManager().getConnectionsManager().getConnectionProvider(defaultPool);
-            assertThat(provider).isNotNull();
             Map<SocketAddress, Integer> maxConnectionsPerHost = provider.maxConnectionsPerHost();
             assertThat(maxConnectionsPerHost)
                     .hasSize(2);
@@ -268,7 +267,6 @@ public class ConnectionPoolIT extends UseAdminServer {
         );
         {
             ConnectionProvider provider = server.getProxyRequestsManager().getConnectionsManager().getConnectionProvider(poolWithDefaults);
-            assertThat(provider).isNotNull();
             Map<SocketAddress, Integer> maxConnectionsPerHost = provider.maxConnectionsPerHost();
             assertThat(maxConnectionsPerHost)
                     .hasSize(2);
@@ -281,7 +279,6 @@ public class ConnectionPoolIT extends UseAdminServer {
         );
         {
             ConnectionProvider provider = server.getProxyRequestsManager().getConnectionsManager().getConnectionProvider(customPool);
-            assertThat(provider).isNotNull();
             Map<SocketAddress, Integer> maxConnectionsPerHost = provider.maxConnectionsPerHost();
             assertThat(maxConnectionsPerHost)
                     .hasSize(2);

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/ConnectionPoolIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/ConnectionPoolIT.java
@@ -312,9 +312,9 @@ public class ConnectionPoolIT extends UseAdminServer {
                 assertThat(resp.getBodyString()).isEqualTo("it <b>works</b> !!");
             }
             Map<String, HttpProxyServer.ConnectionPoolStats> stats = server.getConnectionPoolsStats().get(EndpointKey.make("localhost", wireMockRule.getPort()));
-            assertThat(stats.get("*").getTotalConnections()).isOne();
-            assertThat(stats.get("localhost")).isNull();
-            assertThat(stats.get("localhosts")).isNull();
+            assertThat(stats).hasEntrySatisfying("*", it -> assertThat(it.getTotalConnections()).isOne());
+            assertThat(stats).doesNotContainKey("localhost");
+            assertThat(stats).doesNotContainKey("localhosts");
         }
 
         // provider with defaults
@@ -338,9 +338,9 @@ public class ConnectionPoolIT extends UseAdminServer {
                 assertThat(resp.getBodyString()).isEqualTo("it <b>works</b> !!");
             }
             Map<String, HttpProxyServer.ConnectionPoolStats> stats = server.getConnectionPoolsStats().get(EndpointKey.make("localhost", wireMockRule.getPort()));
-            assertThat(stats.get("*").getTotalConnections()).isOne();
-            assertThat(stats.get("localhost").getTotalConnections()).isOne();
-            assertThat(stats.get("localhosts")).isNull();
+            assertThat(stats).hasEntrySatisfying("*", it -> assertThat(it.getTotalConnections()).isOne());
+            assertThat(stats).hasEntrySatisfying("localhost", it -> assertThat(it.getTotalConnections()).isOne());
+            assertThat(stats).doesNotContainKey("localhosts");
         }
 
         // custom provider
@@ -364,9 +364,9 @@ public class ConnectionPoolIT extends UseAdminServer {
                 assertThat(resp.getBodyString()).isEqualTo("it <b>works</b> !!");
             }
             Map<String, HttpProxyServer.ConnectionPoolStats> stats = server.getConnectionPoolsStats().get(EndpointKey.make("localhost", wireMockRule.getPort()));
-            assertThat(stats.get("*").getTotalConnections()).isOne();
-            assertThat(stats.get("localhost").getTotalConnections()).isOne();
-            assertThat(stats.get("localhosts").getTotalConnections()).isOne();
+            assertThat(stats).hasEntrySatisfying("*", it -> assertThat(it.getTotalConnections()).isOne());
+            assertThat(stats).hasEntrySatisfying("localhost", it -> assertThat(it.getTotalConnections()).isOne());
+            assertThat(stats).hasEntrySatisfying("localhosts", it -> assertThat(it.getTotalConnections()).isOne());
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/RestartEndpointIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/RestartEndpointIT.java
@@ -98,7 +98,7 @@ public class RestartEndpointIT {
                 wireMockRule.stop();
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 System.out.println("statusline:" + resp.getStatusLine());
-                assertThat(resp.getStatusLine()).isEqualTo("HTTP/1.1 503 Service Unavailable\r\n");
+                assertThat(resp.getStatusLine()).startsWith("HTTP/1.1 503");
                 assertThat(resp.getHeaderLines()).contains("cache-control: no-cache\r\n", "connection: keep-alive\r\n");
             }
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
@@ -138,7 +138,7 @@ public class RestartEndpointIT {
 
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 System.out.println("statusline:" + resp.getStatusLine());
-                assertThat(resp.getStatusLine()).isEqualTo("HTTP/1.1 503 Service Unavailable\r\n");
+                assertThat(resp.getStatusLine()).startsWith("HTTP/1.1 503");
                 assertThat(resp.getHeaderLines()).contains("cache-control: no-cache\r\n", "connection: keep-alive\r\n");
             }
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/RestartEndpointIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/RestartEndpointIT.java
@@ -25,9 +25,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import java.io.File;
@@ -67,20 +65,20 @@ public class RestartEndpointIT {
     public File tmpDir;
 
     @BeforeEach
-    public void startWireMock() {
+    void startWireMock() {
         wireMockRule.start();
         configureFor("localhost", wireMockRule.port());
     }
 
     @AfterEach
-    public void stopWireMock() {
+    void stopWireMock() {
         if (wireMockRule.isRunning()) {
             wireMockRule.stop();
         }
     }
 
     @Test
-    public void testClientsSendsRequestOnDownBackendAtSendRequest() throws Exception {
+    void clientsSendsRequestOnDownBackendAtSendRequest() throws Exception {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -95,13 +93,13 @@ public class RestartEndpointIT {
             int port = server.getLocalPort();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
-                assertEquals("it <b>works</b> !!", client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString());
-                assertEquals("it <b>works</b> !!", client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString());
+                assertThat(client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString()).isEqualTo("it <b>works</b> !!");
+                assertThat(client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString()).isEqualTo("it <b>works</b> !!");
                 wireMockRule.stop();
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 System.out.println("statusline:" + resp.getStatusLine());
-                assertEquals("HTTP/1.1 503 Service Unavailable\r\n", resp.getStatusLine());
-                assertThat(resp.getHeaderLines(), hasItems("cache-control: no-cache\r\n", "connection: keep-alive\r\n"));
+                assertThat(resp.getStatusLine()).isEqualTo("HTTP/1.1 503 Service Unavailable\r\n");
+                assertThat(resp.getHeaderLines()).contains("cache-control: no-cache\r\n", "connection: keep-alive\r\n");
             }
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 wireMockRule.start();
@@ -109,13 +107,13 @@ public class RestartEndpointIT {
                 IOUtils.toByteArray(URI.create("http://localhost:" + wireMockRule.port() + "/index.html").toURL());
                 System.out.println("Server at " + "http://localhost:" + wireMockRule.port() + "/index.html" + " is UP an running !");
 
-                assertEquals("it <b>works</b> !!", client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString());
+                assertThat(client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString()).isEqualTo("it <b>works</b> !!");
             }
         }
     }
 
     @Test
-    public void testClientsSendsRequestOnDownBackendAtSendRequestWithCache() throws Exception {
+    void clientsSendsRequestOnDownBackendAtSendRequestWithCache() throws Exception {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -130,18 +128,18 @@ public class RestartEndpointIT {
             int port = server.getLocalPort();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
-                assertEquals("it <b>works</b> !!", client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString());
-                assertEquals("it <b>works</b> !!", client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString());
+                assertThat(client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString()).isEqualTo("it <b>works</b> !!");
+                assertThat(client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString()).isEqualTo("it <b>works</b> !!");
                 wireMockRule.stop();
                 // content is cached
-                assertEquals("it <b>works</b> !!", client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString());
+                assertThat(client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString()).isEqualTo("it <b>works</b> !!");
 
                 server.getCache().clear();
 
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 System.out.println("statusline:" + resp.getStatusLine());
-                assertEquals("HTTP/1.1 503 Service Unavailable\r\n", resp.getStatusLine());
-                assertThat(resp.getHeaderLines(), hasItems("cache-control: no-cache\r\n", "connection: keep-alive\r\n"));
+                assertThat(resp.getStatusLine()).isEqualTo("HTTP/1.1 503 Service Unavailable\r\n");
+                assertThat(resp.getHeaderLines()).contains("cache-control: no-cache\r\n", "connection: keep-alive\r\n");
             }
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 wireMockRule.start();
@@ -149,13 +147,13 @@ public class RestartEndpointIT {
                 IOUtils.toByteArray(URI.create("http://localhost:" + wireMockRule.port() + "/index.html").toURL());
                 System.out.println("Server at " + "http://localhost:" + wireMockRule.port() + "/index.html" + " is UP an running !");
 
-                assertEquals("it <b>works</b> !!", client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString());
+                assertThat(client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString()).isEqualTo("it <b>works</b> !!");
             }
         }
     }
 
     @Test
-    public void testClientsSendsRequestBackendRestart() throws Exception {
+    void clientsSendsRequestBackendRestart() throws Exception {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -170,15 +168,15 @@ public class RestartEndpointIT {
             int port = server.getLocalPort();
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
-                assertEquals("it <b>works</b> !!", client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString());
-                assertEquals("it <b>works</b> !!", client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString());
+                assertThat(client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString()).isEqualTo("it <b>works</b> !!");
+                assertThat(client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString()).isEqualTo("it <b>works</b> !!");
 
                 wireMockRule.stop();
                 wireMockRule.start();
                 System.out.println("*********************************************************");
                 // ensure that wiremock started again
                 IOUtils.toByteArray(URI.create("http://localhost:" + wireMockRule.port() + "/index.html").toURL());
-                assertEquals("it <b>works</b> !!", client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString());
+                assertThat(client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n").getBodyString()).isEqualTo("it <b>works</b> !!");
             }
         }
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/StuckRequestsIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/StuckRequestsIT.java
@@ -23,11 +23,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -47,7 +43,7 @@ import org.carapaceproxy.utils.TestUtils;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class StuckRequestsIT {
 
@@ -58,8 +54,8 @@ public class StuckRequestsIT {
     public File tmpDir;
 
     @ParameterizedTest(name = "test(backend unreachable on stuck request: {0})")
-    @CsvSource({"true", "false"})
-    public void testBackendUnreachableOnStuckRequest(boolean backendsUnreachableOnStuckRequests) throws Exception {
+    @ValueSource(booleans = {true, false})
+    void backendUnreachableOnStuckRequest(boolean backendsUnreachableOnStuckRequests) throws Exception {
 
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
@@ -105,51 +101,51 @@ public class StuckRequestsIT {
             // configure resets all listeners configurations
             server.configureAtBoot(new PropertiesConfigurationStore(properties));
             server.addListener(NetworkListenerConfiguration.withDefault("localhost", 0));
-            assertEquals(100, server.getCurrentConfiguration().getStuckRequestTimeout());
-            assertEquals(backendsUnreachableOnStuckRequests, server.getCurrentConfiguration().isBackendsUnreachableOnStuckRequests());
+            assertThat(server.getCurrentConfiguration().getStuckRequestTimeout()).isEqualTo(100);
+            assertThat(server.getCurrentConfiguration().isBackendsUnreachableOnStuckRequests()).isEqualTo(backendsUnreachableOnStuckRequests);
             server.start();
             int port = server.getLocalPort();
-            assertTrue(port > 0);
+            assertThat(port).isGreaterThan(0);
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertEquals("HTTP/1.1 500 Internal Server Error\r\n", resp.getStatusLine());
-                assertEquals("""
+                assertThat(resp.getStatusLine()).isEqualTo("HTTP/1.1 500 Internal Server Error\r\n");
+                assertThat(resp.getBodyString()).isEqualTo("""
                         <html>
                             <body>
                                 An internal error occurred
                             </body>       \s
                         </html>
-                        """, resp.getBodyString());
+                        """);
             }
 
             TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
-            assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
-            assertThat((int) ProxyRequestsManager.STUCK_REQUESTS_COUNTER.get() > 0, is(true));
+            assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get()).isZero();
+            assertThat((int) ProxyRequestsManager.STUCK_REQUESTS_COUNTER.get()).isGreaterThan(0);
 
             final BackendHealthStatus.Status expected = backendsUnreachableOnStuckRequests
                     ? BackendHealthStatus.Status.DOWN
                     : BackendHealthStatus.Status.COLD;
-            assertSame(expected, server.getBackendHealthManager().getBackendStatus(key).getStatus());
+            assertThat(server.getBackendHealthManager().getBackendStatus(key).getStatus()).isSameAs(expected);
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /good-index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
                 if (backendsUnreachableOnStuckRequests) {
-                    assertEquals("HTTP/1.1 503 Service Unavailable\r\n", resp.getStatusLine());
-                    assertEquals("""
+                    assertThat(resp.getStatusLine()).isEqualTo("HTTP/1.1 503 Service Unavailable\r\n");
+                    assertThat(resp.getBodyString()).isEqualTo("""
                             <html>
                                 <body>
                                     Service Unavailable
                                 </body>
                             </html>
-                            """, resp.getBodyString());
+                            """);
                 } else {
-                    assertEquals("HTTP/1.1 200 OK\r\n", resp.getStatusLine());
-                    assertEquals("it <b>works</b> !!", resp.getBodyString());
+                    assertThat(resp.getStatusLine()).isEqualTo("HTTP/1.1 200 OK\r\n");
+                    assertThat(resp.getBodyString()).isEqualTo("it <b>works</b> !!");
                 }
             }
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/StuckRequestsIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/StuckRequestsIT.java
@@ -105,7 +105,6 @@ public class StuckRequestsIT {
             assertThat(server.getCurrentConfiguration().isBackendsUnreachableOnStuckRequests()).isEqualTo(backendsUnreachableOnStuckRequests);
             server.start();
             int port = server.getLocalPort();
-            assertThat(port).isGreaterThan(0);
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/StuckRequestsIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/StuckRequestsIT.java
@@ -110,7 +110,7 @@ public class StuckRequestsIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertThat(resp.getStatusLine()).isEqualTo("HTTP/1.1 500 Internal Server Error\r\n");
+                assertThat(resp.getStatusLine()).startsWith("HTTP/1.1 500");
                 assertThat(resp.getBodyString()).isEqualTo("""
                         <html>
                             <body>
@@ -134,7 +134,7 @@ public class StuckRequestsIT {
                 String s = resp.toString();
                 System.out.println("s:" + s);
                 if (backendsUnreachableOnStuckRequests) {
-                    assertThat(resp.getStatusLine()).isEqualTo("HTTP/1.1 503 Service Unavailable\r\n");
+                    assertThat(resp.getStatusLine()).startsWith("HTTP/1.1 503");
                     assertThat(resp.getBodyString()).isEqualTo("""
                             <html>
                                 <body>
@@ -143,7 +143,7 @@ public class StuckRequestsIT {
                             </html>
                             """);
                 } else {
-                    assertThat(resp.getStatusLine()).isEqualTo("HTTP/1.1 200 OK\r\n");
+                    assertThat(resp.getStatusLine()).startsWith("HTTP/1.1 200");
                     assertThat(resp.getBodyString()).isEqualTo("it <b>works</b> !!");
                 }
             }

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendIT.java
@@ -94,7 +94,7 @@ public class UnreachableBackendIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertThat(resp.getStatusLine()).isEqualTo("HTTP/1.1 503 Service Unavailable\r\n");
+                assertThat(resp.getStatusLine()).startsWith("HTTP/1.1 503");
                 assertThat(resp.getBodyString()).isEqualTo("""
                         <html>
                             <body>
@@ -153,7 +153,7 @@ public class UnreachableBackendIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertThat(resp.getStatusLine()).isEqualTo("HTTP/1.1 503 Service Unavailable\r\n");
+                assertThat(resp.getStatusLine()).startsWith("HTTP/1.1 503");
                 assertThat(resp.getBodyString()).isEqualTo("""
                         <html>
                             <body>
@@ -187,7 +187,7 @@ public class UnreachableBackendIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertThat(resp.getStatusLine()).isEqualTo("HTTP/1.1 503 Service Unavailable\r\n");
+                assertThat(resp.getStatusLine()).startsWith("HTTP/1.1 503");
                 assertThat(resp.getBodyString()).isEqualTo("""
                         <html>
                             <body>

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendIT.java
@@ -24,12 +24,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.carapaceproxy.server.backends.BackendHealthStatus.Status.COLD;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -52,6 +48,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class UnreachableBackendIT {
 
@@ -62,21 +59,21 @@ public class UnreachableBackendIT {
     public File tmpDir;
 
     @BeforeEach
-    public void startWireMock() {
+    void startWireMock() {
         wireMockRule.start();
         configureFor("localhost", wireMockRule.port());
     }
 
     @AfterEach
-    public void stopWireMock() {
+    void stopWireMock() {
         if (wireMockRule.isRunning()) {
             wireMockRule.stop();
         }
     }
 
     @ParameterizedTest
-    @CsvSource({"true", "false"})
-    public void testWithUnreachableBackend(boolean useCache) throws Exception {
+    @ValueSource(booleans = {true, false})
+    void withUnreachableBackend(boolean useCache) throws Exception {
 
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
@@ -97,18 +94,18 @@ public class UnreachableBackendIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertEquals("HTTP/1.1 503 Service Unavailable\r\n", resp.getStatusLine());
-                assertEquals("""
+                assertThat(resp.getStatusLine()).isEqualTo("HTTP/1.1 503 Service Unavailable\r\n");
+                assertThat(resp.getBodyString()).isEqualTo("""
                         <html>
                             <body>
                                 Service Unavailable
                             </body>
                         </html>
-                        """, resp.getBodyString());
+                        """);
             }
-            assertSame(BackendHealthStatus.Status.DOWN, server.getBackendHealthManager().getBackendStatus(key).getStatus());
+            assertThat(server.getBackendHealthManager().getBackendStatus(key).getStatus()).isSameAs(BackendHealthStatus.Status.DOWN);
             TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
-            assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
+            assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get()).isZero();
         }
     }
 
@@ -152,29 +149,29 @@ public class UnreachableBackendIT {
             server.addListener(NetworkListenerConfiguration.withDefault("localhost", 0));
             server.start();
             int port = server.getLocalPort();
-            assertTrue(port > 0);
+            assertThat(port).isGreaterThan(0);
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertEquals("HTTP/1.1 503 Service Unavailable\r\n", resp.getStatusLine());
-                assertEquals("""
+                assertThat(resp.getStatusLine()).isEqualTo("HTTP/1.1 503 Service Unavailable\r\n");
+                assertThat(resp.getBodyString()).isEqualTo("""
                         <html>
                             <body>
                                 Service Unavailable
                             </body>
                         </html>
-                        """, resp.getBodyString());
+                        """);
             }
-            assertSame(COLD, server.getBackendHealthManager().getBackendStatus(key).getStatus()); // no troubles for new connections
+            assertThat(server.getBackendHealthManager().getBackendStatus(key).getStatus()).isSameAs(COLD); // no troubles for new connections
             TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
-            assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
+            assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get()).isZero();
         }
     }
 
     @ParameterizedTest
-    @CsvSource({"true", "false"})
-    public void testConnectionResetByPeer(boolean useCache) throws Exception {
+    @ValueSource(booleans = {true, false})
+    void connectionResetByPeer(boolean useCache) throws Exception {
 
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
@@ -191,18 +188,18 @@ public class UnreachableBackendIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertEquals("HTTP/1.1 503 Service Unavailable\r\n", resp.getStatusLine());
-                assertEquals("""
+                assertThat(resp.getStatusLine()).isEqualTo("HTTP/1.1 503 Service Unavailable\r\n");
+                assertThat(resp.getBodyString()).isEqualTo("""
                         <html>
                             <body>
                                 Service Unavailable
                             </body>
                         </html>
-                        """, resp.getBodyString());
+                        """);
             }
-            assertSame(COLD, server.getBackendHealthManager().getBackendStatus(key).getStatus()); // no troubles for new connections
+            assertThat(server.getBackendHealthManager().getBackendStatus(key).getStatus()).isSameAs(COLD); // no troubles for new connections
             TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
-            assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
+            assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get()).isZero();
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendIT.java
@@ -71,7 +71,7 @@ public class UnreachableBackendIT {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "useCache={0}")
     @ValueSource(booleans = {true, false})
     void withUnreachableBackend(boolean useCache) throws Exception {
 
@@ -169,7 +169,7 @@ public class UnreachableBackendIT {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "useCache={0}")
     @ValueSource(booleans = {true, false})
     void connectionResetByPeer(boolean useCache) throws Exception {
 

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendIT.java
@@ -149,7 +149,6 @@ public class UnreachableBackendIT {
             server.addListener(NetworkListenerConfiguration.withDefault("localhost", 0));
             server.start();
             int port = server.getLocalPort();
-            assertThat(port).isGreaterThan(0);
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();

--- a/carapace-server/src/test/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandlerIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandlerIT.java
@@ -21,7 +21,6 @@ package org.carapaceproxy.cluster.impl;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -32,9 +31,7 @@ import org.carapaceproxy.cluster.GroupMembershipHandler;
 import org.carapaceproxy.utils.TestUtils;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import lombok.AllArgsConstructor;
@@ -51,7 +48,7 @@ public class ZooKeeperGroupMembershipHandlerIT {
     String peerId3 = "p3";
 
     @Test
-    public void testPeerDiscovery() throws Exception {
+    void peerDiscovery() throws Exception {
         try (TestingServer testingServer = new TestingServer(2229, tmpDir)) {
             testingServer.start();
             try (ZooKeeperGroupMembershipHandler peer1 = new ZooKeeperGroupMembershipHandler(testingServer.getConnectString(),
@@ -62,8 +59,8 @@ public class ZooKeeperGroupMembershipHandlerIT {
                 peer2.start();
                 List<String> peersFrom1 = peer1.getPeers();
                 List<String> peersFrom2 = peer2.getPeers();
-                assertEquals(Arrays.asList(peerId1, peerId2), peersFrom1);
-                assertEquals(Arrays.asList(peerId1, peerId2), peersFrom2);
+                assertThat(peersFrom1).containsExactly(peerId1, peerId2);
+                assertThat(peersFrom2).containsExactly(peerId1, peerId2);
 
                 try (ZooKeeperGroupMembershipHandler peer3 = new ZooKeeperGroupMembershipHandler(testingServer.getConnectString(),
                         6000, false /*acl */, peerId3, Collections.EMPTY_MAP, new Properties())) {
@@ -71,16 +68,16 @@ public class ZooKeeperGroupMembershipHandlerIT {
                     peersFrom1 = peer1.getPeers();
                     peersFrom2 = peer2.getPeers();
                     List<String> peersFrom3 = peer3.getPeers();
-                    assertEquals(Arrays.asList(peerId1, peerId2, peerId3), peersFrom1);
-                    assertEquals(Arrays.asList(peerId1, peerId2, peerId3), peersFrom2);
-                    assertEquals(Arrays.asList(peerId1, peerId2, peerId3), peersFrom3);
+                    assertThat(peersFrom1).containsExactly(peerId1, peerId2, peerId3);
+                    assertThat(peersFrom2).containsExactly(peerId1, peerId2, peerId3);
+                    assertThat(peersFrom3).containsExactly(peerId1, peerId2, peerId3);
                 }
 
                 // peer3 exits
                 peersFrom1 = peer1.getPeers();
                 peersFrom2 = peer2.getPeers();
-                assertEquals(Arrays.asList(peerId1, peerId2), peersFrom1);
-                assertEquals(Arrays.asList(peerId1, peerId2), peersFrom2);
+                assertThat(peersFrom1).containsExactly(peerId1, peerId2);
+                assertThat(peersFrom2).containsExactly(peerId1, peerId2);
 
             }
         }
@@ -97,7 +94,7 @@ public class ZooKeeperGroupMembershipHandlerIT {
     }
 
     @Test
-    public void testWatchEvent() throws Exception {
+    void watchEvent() throws Exception {
         try (TestingServer testingServer = new TestingServer(2229, tmpDir);) {
             testingServer.start();
             try (ZooKeeperGroupMembershipHandler peer1 = new ZooKeeperGroupMembershipHandler(testingServer.getConnectString(),
@@ -108,8 +105,8 @@ public class ZooKeeperGroupMembershipHandlerIT {
                 peer2.start();
                 List<String> peersFrom1 = peer1.getPeers();
                 List<String> peersFrom2 = peer2.getPeers();
-                assertEquals(Arrays.asList(peerId1, peerId2), peersFrom1);
-                assertEquals(Arrays.asList(peerId1, peerId2), peersFrom2);
+                assertThat(peersFrom1).containsExactly(peerId1, peerId2);
+                assertThat(peersFrom2).containsExactly(peerId1, peerId2);
 
                 AtomicInteger eventFired2 = new AtomicInteger();
                 Map<String, Object> dataRes2 = new HashMap<>();
@@ -128,8 +125,8 @@ public class ZooKeeperGroupMembershipHandlerIT {
 
                 peer1.fireEvent("foo", null);
                 TestUtils.waitForCondition(() -> eventFired2.get() >= 1, 100);
-                assertTrue(eventFired2.get() >= 1);
-                assertTrue(dataRes2.isEmpty());
+                assertThat(eventFired2.get()).isGreaterThanOrEqualTo(1);
+                assertThat(dataRes2).isEmpty();
                 eventFired2.set(0);
 
                 peer1.fireEvent("foo", Map.of(
@@ -139,12 +136,12 @@ public class ZooKeeperGroupMembershipHandlerIT {
                         "obj", new DummyObject(1, "s")
                 ));
                 TestUtils.waitForCondition(() -> eventFired2.get() >= 1, 100);
-                assertTrue(eventFired2.get() >= 1);
-                assertTrue(((int) dataRes2.get("number")) == 1);
-                assertTrue(dataRes2.get("string").equals("mystring"));
-                assertTrue(((List<Integer>) dataRes2.get("list")).containsAll(List.of(1, 2)));
-                assertTrue(((Map<String, Object>) dataRes2.get("obj")).get("number").equals(1));
-                assertTrue(((Map<String, Object>) dataRes2.get("obj")).get("string").equals("s"));
+                assertThat(eventFired2.get()).isGreaterThanOrEqualTo(1);
+                assertThat(((int) dataRes2.get("number"))).isOne();
+                assertThat(dataRes2).containsEntry("string", "mystring");
+                assertThat(((List<Integer>) dataRes2.get("list"))).containsAll(List.of(1, 2));
+                assertThat(((Map<String, Object>) dataRes2.get("obj"))).containsEntry("number", 1);
+                assertThat(((Map<String, Object>) dataRes2.get("obj"))).containsEntry("string", "s");
                 eventFired2.set(0);
                 dataRes2.clear();
 
@@ -172,11 +169,11 @@ public class ZooKeeperGroupMembershipHandlerIT {
                     peer1.fireEvent("foo", null);
                     TestUtils.waitForCondition(() -> (eventFired2.get() >= 1
                                 && eventFired3.get() >= 1), 100);
-                    assertTrue(eventFired2.get() >= 1);
-                    assertTrue(dataRes2.isEmpty());
+                    assertThat(eventFired2.get()).isGreaterThanOrEqualTo(1);
+                    assertThat(dataRes2).isEmpty();
                     eventFired2.set(0);
-                    assertTrue(eventFired3.get() >= 1);
-                    assertTrue(dataRes3.isEmpty());
+                    assertThat(eventFired3.get()).isGreaterThanOrEqualTo(1);
+                    assertThat(dataRes3).isEmpty();
                     eventFired3.set(0);
 
                     peer1.fireEvent("foo", Map.of(
@@ -187,20 +184,20 @@ public class ZooKeeperGroupMembershipHandlerIT {
                     ));
                     TestUtils.waitForCondition(() -> (eventFired2.get() >= 1
                                 && eventFired3.get() >= 1), 100);
-                    assertTrue(eventFired2.get() >= 1);
-                    assertTrue(((int) dataRes2.get("number")) == 1);
-                    assertTrue(dataRes2.get("string").equals("mystring"));
-                    assertTrue(((List<String>) dataRes2.get("list")).containsAll(List.of("1", "2")));
-                    assertTrue(((Map<String, Object>) dataRes2.get("obj")).get("number").equals(1));
-                    assertTrue(((Map<String, Object>) dataRes2.get("obj")).get("string").equals("s"));
+                    assertThat(eventFired2.get()).isGreaterThanOrEqualTo(1);
+                    assertThat(((int) dataRes2.get("number"))).isOne();
+                    assertThat(dataRes2).containsEntry("string", "mystring");
+                    assertThat(((List<String>) dataRes2.get("list"))).containsAll(List.of("1", "2"));
+                    assertThat(((Map<String, Object>) dataRes2.get("obj"))).containsEntry("number", 1);
+                    assertThat(((Map<String, Object>) dataRes2.get("obj"))).containsEntry("string", "s");
                     eventFired2.set(0);
                     dataRes2.clear();
-                    assertTrue(eventFired3.get() >= 1);
-                    assertTrue(((int) dataRes3.get("number")) == 1);
-                    assertTrue(dataRes3.get("string").equals("mystring"));
-                    assertTrue(((List<Integer>) dataRes3.get("list")).containsAll(List.of("1", "2")));
-                    assertTrue(((Map<String, Object>) dataRes3.get("obj")).get("number").equals(1));
-                    assertTrue(((Map<String, Object>) dataRes3.get("obj")).get("string").equals("s"));
+                    assertThat(eventFired3.get()).isGreaterThanOrEqualTo(1);
+                    assertThat(((int) dataRes3.get("number"))).isOne();
+                    assertThat(dataRes3).containsEntry("string", "mystring");
+                    assertThat((List<?>) dataRes3.get("list")).asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.LIST).containsAll(List.of("1", "2"));
+                    assertThat(((Map<String, Object>) dataRes3.get("obj"))).containsEntry("number", 1);
+                    assertThat(((Map<String, Object>) dataRes3.get("obj"))).containsEntry("string", "s");
                     eventFired3.set(0);
                     dataRes3.clear();
 
@@ -217,15 +214,15 @@ public class ZooKeeperGroupMembershipHandlerIT {
                         }
                         Thread.sleep(100);
                     }
-                    assertTrue(eventFired2.get() > 0);
-                    assertTrue(((int) dataRes2.get("number")) == 1);
-                    assertTrue(dataRes2.get("string").equals("mystring"));
-                    assertTrue(((List<Integer>) dataRes2.get("list")).containsAll(List.of(1, 2)));
-                    assertTrue(((Map<String, Object>) dataRes2.get("obj")).get("number").equals(1));
-                    assertTrue(((Map<String, Object>) dataRes2.get("obj")).get("string").equals("s"));
+                    assertThat(eventFired2.get()).isGreaterThan(0);
+                    assertThat(((int) dataRes2.get("number"))).isOne();
+                    assertThat(dataRes2).containsEntry("string", "mystring");
+                    assertThat(((List<Integer>) dataRes2.get("list"))).containsAll(List.of(1, 2));
+                    assertThat(((Map<String, Object>) dataRes2.get("obj"))).containsEntry("number", 1);
+                    assertThat(((Map<String, Object>) dataRes2.get("obj"))).containsEntry("string", "s");
                     // self events are not fired
-                    assertTrue(eventFired3.get() == 0);
-                    assertTrue(dataRes3.isEmpty());
+                    assertThat(eventFired3.get()).isZero();
+                    assertThat(dataRes3).isEmpty();
                 }
 
             }
@@ -233,7 +230,7 @@ public class ZooKeeperGroupMembershipHandlerIT {
     }
 
     @Test
-    public void testPeerInfo() throws Exception {
+    void peerInfo() throws Exception {
         try (TestingServer testingServer = new TestingServer(2229, tmpDir);) {
             testingServer.start();
             try (ZooKeeperGroupMembershipHandler peer1 = new ZooKeeperGroupMembershipHandler(testingServer.getConnectString(),
@@ -246,34 +243,36 @@ public class ZooKeeperGroupMembershipHandlerIT {
                 // OP on peer1
                 {
                     Map<String, String> info = peer1.loadInfoForPeer(peerId1);
-                    assertEquals("peer1", info.get("name"));
+                    assertThat(info).containsEntry("name", "peer1");
                     info = peer1.loadInfoForPeer(peerId2);
-                    assertEquals("peer2", info.get("name"));
+                    assertThat(info).containsEntry("name", "peer2");
 
                     peer1.storeLocalPeerInfo(Map.of("name", "newpeer1", "address", "localhost"));
                     info = peer1.loadInfoForPeer(peerId1);
-                    assertEquals("newpeer1", info.get("name"));
-                    assertEquals("localhost", info.get("address"));
+                    assertThat(info)
+                            .containsEntry("name", "newpeer1")
+                            .containsEntry("address", "localhost");
 
                     peer1.storeLocalPeerInfo(Collections.EMPTY_MAP);
                     info = peer1.loadInfoForPeer(peerId1);
-                    assertTrue(info.isEmpty());
+                    assertThat(info).isEmpty();
                     peer1.storeLocalPeerInfo(Map.of("port", "8080"));
                     info = peer1.loadInfoForPeer(peerId1);
-                    assertNull(info.get("name"));
+                    assertThat(info.get("name")).isNull();
                     peer1.storeLocalPeerInfo(null); // discarded
                     info = peer1.loadInfoForPeer(peerId1);
-                    assertNull(info);
+                    assertThat(info).isNull();
                 }
 
                 // OP on peer2
                 {
                     peer2.storeLocalPeerInfo(Map.of("name", "peer2", "address", "localhost:8080"));
                     Map<String, String> info = peer2.loadInfoForPeer(peerId2);
-                    assertEquals("peer2", info.get("name"));
-                    assertEquals("localhost:8080", info.get("address"));
+                    assertThat(info)
+                            .containsEntry("name", "peer2")
+                            .containsEntry("address", "localhost:8080");
                     info = peer2.loadInfoForPeer(peerId1);
-                    assertNull(info);
+                    assertThat(info).isNull();
                 }
             }
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandlerIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandlerIT.java
@@ -139,7 +139,7 @@ public class ZooKeeperGroupMembershipHandlerIT {
                 assertThat(eventFired2.get()).isGreaterThanOrEqualTo(1);
                 assertThat(((int) dataRes2.get("number"))).isOne();
                 assertThat(dataRes2).containsEntry("string", "mystring");
-                assertThat(((List<Integer>) dataRes2.get("list"))).containsAll(List.of(1, 2));
+                assertThat(((List<Integer>) dataRes2.get("list"))).containsExactly(1, 2);
                 assertThat(((Map<String, Object>) dataRes2.get("obj"))).containsEntry("number", 1);
                 assertThat(((Map<String, Object>) dataRes2.get("obj"))).containsEntry("string", "s");
                 eventFired2.set(0);
@@ -187,7 +187,7 @@ public class ZooKeeperGroupMembershipHandlerIT {
                     assertThat(eventFired2.get()).isGreaterThanOrEqualTo(1);
                     assertThat(((int) dataRes2.get("number"))).isOne();
                     assertThat(dataRes2).containsEntry("string", "mystring");
-                    assertThat(((List<String>) dataRes2.get("list"))).containsAll(List.of("1", "2"));
+                    assertThat(((List<String>) dataRes2.get("list"))).containsExactly("1", "2");
                     assertThat(((Map<String, Object>) dataRes2.get("obj"))).containsEntry("number", 1);
                     assertThat(((Map<String, Object>) dataRes2.get("obj"))).containsEntry("string", "s");
                     eventFired2.set(0);
@@ -195,7 +195,7 @@ public class ZooKeeperGroupMembershipHandlerIT {
                     assertThat(eventFired3.get()).isGreaterThanOrEqualTo(1);
                     assertThat(((int) dataRes3.get("number"))).isOne();
                     assertThat(dataRes3).containsEntry("string", "mystring");
-                    assertThat((List<?>) dataRes3.get("list")).asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.LIST).containsAll(List.of("1", "2"));
+                    assertThat((List<?>) dataRes3.get("list")).asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.LIST).containsExactly("1", "2");
                     assertThat(((Map<String, Object>) dataRes3.get("obj"))).containsEntry("number", 1);
                     assertThat(((Map<String, Object>) dataRes3.get("obj"))).containsEntry("string", "s");
                     eventFired3.set(0);
@@ -217,7 +217,7 @@ public class ZooKeeperGroupMembershipHandlerIT {
                     assertThat(eventFired2.get()).isGreaterThan(0);
                     assertThat(((int) dataRes2.get("number"))).isOne();
                     assertThat(dataRes2).containsEntry("string", "mystring");
-                    assertThat(((List<Integer>) dataRes2.get("list"))).containsAll(List.of(1, 2));
+                    assertThat(((List<Integer>) dataRes2.get("list"))).containsExactly(1, 2);
                     assertThat(((Map<String, Object>) dataRes2.get("obj"))).containsEntry("number", 1);
                     assertThat(((Map<String, Object>) dataRes2.get("obj"))).containsEntry("string", "s");
                     // self events are not fired

--- a/carapace-server/src/test/java/org/carapaceproxy/cluster/impl/ZookKeeperACLIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/cluster/impl/ZookKeeperACLIT.java
@@ -21,7 +21,6 @@ package org.carapaceproxy.cluster.impl;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -34,8 +33,7 @@ import org.apache.curator.test.TestingServer;
 import org.carapaceproxy.cluster.GroupMembershipHandler;
 import org.carapaceproxy.utils.TestUtils;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -61,10 +59,10 @@ public class ZookKeeperACLIT {
      *
      */
     @BeforeAll
-    public static void setUpEnvironment() {
+    static void setUpEnvironment() {
         File file = new File("src/test/resources/jaas/test_jaas.conf");
         System.setProperty("java.security.auth.login.config", file.getAbsolutePath());
-        assertTrue(file.isFile());
+        assertThat(file).isFile();
         Configuration.getConfiguration().refresh();
     }
 
@@ -74,13 +72,13 @@ public class ZookKeeperACLIT {
      * @throws IOException
      */
     @AfterAll
-    public static void cleanUpEnvironment() throws InterruptedException, IOException {
+    static void cleanUpEnvironment() throws InterruptedException, IOException {
         System.clearProperty("java.security.auth.login.config");
         Configuration.getConfiguration().refresh();
     }
 
     @Test
-    public void testUseAcl() throws Exception {
+    void useAcl() throws Exception {
         Map<String, Object> customProperties = new HashMap<>();
         customProperties.put("authProvider.1", "org.apache.zookeeper.server.auth.SASLAuthenticationProvider");
         InstanceSpec def = InstanceSpec.newInstanceSpec();
@@ -99,8 +97,8 @@ public class ZookKeeperACLIT {
                 peer2.start();
                 List<String> peersFrom1 = peer1.getPeers();
                 List<String> peersFrom2 = peer2.getPeers();
-                assertEquals(Arrays.asList(peerId1, peerId2), peersFrom1);
-                assertEquals(Arrays.asList(peerId1, peerId2), peersFrom2);
+                assertThat(peersFrom1).containsExactly(peerId1, peerId2);
+                assertThat(peersFrom2).containsExactly(peerId1, peerId2);
 
                 AtomicInteger eventFired2 = new AtomicInteger();
                 Map<String, Object> dataRes2 = new HashMap<>();
@@ -119,14 +117,14 @@ public class ZookKeeperACLIT {
 
                 peer1.fireEvent("foo", null);
                 TestUtils.waitForCondition(() -> eventFired2.get() >= 1, 100);
-                assertTrue(eventFired2.get() >= 1);
-                assertTrue(dataRes2.isEmpty());
+                assertThat(eventFired2.get()).isGreaterThanOrEqualTo(1);
+                assertThat(dataRes2).isEmpty();
                 eventFired2.set(0);
 
                 peer1.fireEvent("foo", Map.of("data", "mydata"));
                 TestUtils.waitForCondition(() -> eventFired2.get() >= 1, 100);
-                assertTrue(eventFired2.get() >= 1);
-                assertTrue(dataRes2.get("data").equals("mydata"));
+                assertThat(eventFired2.get()).isGreaterThanOrEqualTo(1);
+                assertThat(dataRes2).containsEntry("data", "mydata");
                 eventFired2.set(0);
                 dataRes2.clear();
 
@@ -152,22 +150,22 @@ public class ZookKeeperACLIT {
                     peer1.fireEvent("foo", null);
                     TestUtils.waitForCondition(() -> (eventFired2.get() >= 1
                                 && eventFired3.get() >= 1), 100);
-                    assertTrue(eventFired2.get() >= 1);
-                    assertTrue(dataRes2.isEmpty());
+                    assertThat(eventFired2.get()).isGreaterThanOrEqualTo(1);
+                    assertThat(dataRes2).isEmpty();
                     eventFired2.set(0);
-                    assertTrue(eventFired3.get() >= 1);
-                    assertTrue(dataRes3.isEmpty());
+                    assertThat(eventFired3.get()).isGreaterThanOrEqualTo(1);
+                    assertThat(dataRes3).isEmpty();
                     eventFired3.set(0);
 
                     peer1.fireEvent("foo", Map.of("data", "mydata"));
                     TestUtils.waitForCondition(() -> (eventFired2.get() >= 1
                                 && eventFired3.get() >= 1), 100);
-                    assertTrue(eventFired2.get() >= 1);
-                    assertTrue(dataRes2.get("data").equals("mydata"));
+                    assertThat(eventFired2.get()).isGreaterThanOrEqualTo(1);
+                    assertThat(dataRes2).containsEntry("data", "mydata");
                     eventFired2.set(0);
                     dataRes2.clear();
-                    assertTrue(eventFired3.get() >= 1);
-                    assertTrue(dataRes3.get("data").equals("mydata"));
+                    assertThat(eventFired3.get()).isGreaterThanOrEqualTo(1);
+                    assertThat(dataRes3).containsEntry("data", "mydata");
                     eventFired3.set(0);
                     dataRes3.clear();
 
@@ -179,11 +177,11 @@ public class ZookKeeperACLIT {
                         }
                         Thread.sleep(100);
                     }
-                    assertTrue(eventFired2.get() > 0);
-                    assertTrue(dataRes2.get("data").equals("mydata"));
+                    assertThat(eventFired2.get()).isGreaterThan(0);
+                    assertThat(dataRes2).containsEntry("data", "mydata");
                     // self events are not fired
-                    assertTrue(eventFired3.get() == 0);
-                    assertTrue(dataRes3.isEmpty());
+                    assertThat(eventFired3.get()).isZero();
+                    assertThat(dataRes3).isEmpty();
                 }
 
             }

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/CertificateDataBindingEquivalentTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/CertificateDataBindingEquivalentTest.java
@@ -19,17 +19,16 @@
  */
 package org.carapaceproxy.configstore;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.AVAILABLE;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.REQUEST_FAILED;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.WAITING;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
-public class CertificateDataBindingEquivalentTest {
+class CertificateDataBindingEquivalentTest {
 
     private static final byte[] KEYSTORE_A = {0x01, 0x02, 0x03};
     private static final byte[] KEYSTORE_B = {0x04, 0x05, 0x06};
@@ -37,25 +36,25 @@ public class CertificateDataBindingEquivalentTest {
     private static final Set<String> SANS_B = Set.of("alt-b.example.com");
 
     @Test
-    public void testBothNullReturnsTrue() {
-        assertTrue(CertificateData.bindingEquivalent(null, null));
+    void bothNullReturnsTrue() {
+        assertThat(CertificateData.bindingEquivalent(null, null)).isTrue();
     }
 
     @Test
-    public void testOneNullReturnsFalse() {
+    void oneNullReturnsFalse() {
         final CertificateData cert = buildCert(KEYSTORE_A, SANS_A);
-        assertFalse(CertificateData.bindingEquivalent(cert, null));
-        assertFalse(CertificateData.bindingEquivalent(null, cert));
+        assertThat(CertificateData.bindingEquivalent(cert, null)).isFalse();
+        assertThat(CertificateData.bindingEquivalent(null, cert)).isFalse();
     }
 
     @Test
-    public void testSameReferenceReturnsTrue() {
+    void sameReferenceReturnsTrue() {
         final CertificateData cert = buildCert(KEYSTORE_A, SANS_A);
-        assertTrue(CertificateData.bindingEquivalent(cert, cert));
+        assertThat(CertificateData.bindingEquivalent(cert, cert)).isTrue();
     }
 
     @Test
-    public void testIdenticalKeystoreAndSansReturnsTrueDespiteTransientState() throws Exception {
+    void identicalKeystoreAndSansReturnsTrueDespiteTransientState() throws Exception {
         // Staging symptom: a stuck ACME order ticks attemptsCount/message/state/pendingOrderLocation
         // every poll while keystore bytes and SANs stay the same.
         final CertificateData stable = buildCert(KEYSTORE_A, SANS_A);
@@ -70,28 +69,28 @@ public class CertificateDataBindingEquivalentTest {
         ticked.setMessage("stuck order");
         ticked.setPendingOrderLocation(URI.create("https://acme/order/42").toURL());
 
-        assertTrue(CertificateData.bindingEquivalent(stable, ticked));
+        assertThat(CertificateData.bindingEquivalent(stable, ticked)).isTrue();
     }
 
     @Test
-    public void testKeystoreBytesDifferReturnsFalse() {
+    void keystoreBytesDifferReturnsFalse() {
         final CertificateData a = buildCert(KEYSTORE_A, SANS_A);
         final CertificateData b = buildCert(KEYSTORE_B, SANS_A);
-        assertFalse(CertificateData.bindingEquivalent(a, b));
+        assertThat(CertificateData.bindingEquivalent(a, b)).isFalse();
     }
 
     @Test
-    public void testKeystoreNullVsBytesReturnsFalse() {
+    void keystoreNullVsBytesReturnsFalse() {
         final CertificateData a = buildCert(null, SANS_A);
         final CertificateData b = buildCert(KEYSTORE_A, SANS_A);
-        assertFalse(CertificateData.bindingEquivalent(a, b));
+        assertThat(CertificateData.bindingEquivalent(a, b)).isFalse();
     }
 
     @Test
-    public void testSubjectAltNamesDifferReturnsFalse() {
+    void subjectAltNamesDifferReturnsFalse() {
         final CertificateData a = buildCert(KEYSTORE_A, SANS_A);
         final CertificateData b = buildCert(KEYSTORE_A, SANS_B);
-        assertFalse(CertificateData.bindingEquivalent(a, b));
+        assertThat(CertificateData.bindingEquivalent(a, b)).isFalse();
     }
 
     private static CertificateData buildCert(final byte[] keystoreData, final Set<String> sans) {

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreIT.java
@@ -19,16 +19,12 @@
  */
 package org.carapaceproxy.configstore;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
 import static org.carapaceproxy.server.config.AcmeProviderConfiguration.DEFAULT_PROVIDER_NAME;
 import static org.carapaceproxy.utils.TestUtils.assertEqualsKey;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 
@@ -44,7 +40,6 @@ import org.carapaceproxy.api.ConfigResource;
 import org.carapaceproxy.server.certificates.DynamicCertificateState;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.utils.TestUtils;
-import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -71,7 +66,7 @@ public class ConfigurationStoreIT {
     private static final String d3 = "localhost3";
 
     @AfterEach
-    public void after() {
+    void after() {
         if (store != null) {
             store.close();
         }
@@ -127,39 +122,39 @@ public class ConfigurationStoreIT {
 
         updateConfigStore(props);
 
-        assertThat(store.getInt("property.int.1", 11), is(1));
-        assertThat(store.getInt("property.int.2", 11), is(11)); // empty > default
-        TestUtils.assertThrows(ConfigurationNotValidException.class, () -> store.getInt("property.int.3", 11));
-        assertThat(store.getInt("property.int.11", 11), is(11)); // not exists
+        assertThat(store.getInt("property.int.1", 11)).isOne();
+        assertThat(store.getInt("property.int.2", 11)).isEqualTo(11); // empty > default
+        assertThatThrownBy(() -> store.getInt("property.int.3", 11)).isInstanceOf(ConfigurationNotValidException.class);
+        assertThat(store.getInt("property.int.11", 11)).isEqualTo(11); // not exists
 
-        assertThat(store.getLong("property.long.1", 11), is(1L));
-        assertThat(store.getLong("property.long.2", 11), is(11L)); // empty > default
-        TestUtils.assertThrows(ConfigurationNotValidException.class, () -> store.getLong("property.long.3", 11));
-        assertThat(store.getLong("property.long.11", 11), is(11L)); // not exists
+        assertThat(store.getLong("property.long.1", 11)).isOne();
+        assertThat(store.getLong("property.long.2", 11)).isEqualTo(11L); // empty > default
+        assertThatThrownBy(() -> store.getLong("property.long.3", 11)).isInstanceOf(ConfigurationNotValidException.class);
+        assertThat(store.getLong("property.long.11", 11)).isEqualTo(11L); // not exists
 
-        assertThat(store.getBoolean("property.boolean.1", false), is(true));
-        assertThat(store.getBoolean("property.boolean.2", true), is(false));
-        assertThat(store.getBoolean("property.boolean.3", true), is(false));
-        assertThat(store.getBoolean("property.boolean.4", true), is(true)); // empty > default
-        assertThat(store.getBoolean("property.boolean.ne", true), is(true)); // not exists
+        assertThat(store.getBoolean("property.boolean.1", false)).isTrue();
+        assertThat(store.getBoolean("property.boolean.2", true)).isFalse();
+        assertThat(store.getBoolean("property.boolean.3", true)).isFalse();
+        assertThat(store.getBoolean("property.boolean.4", true)).isTrue(); // empty > default
+        assertThat(store.getBoolean("property.boolean.ne", true)).isTrue(); // not exists
 
-        assertThat(store.getString("property.string.1", "default"), is("a string"));
-        assertThat(store.getString("property.string.2", null), is(IsNull.nullValue())); // empty > default
-        assertThat(store.getString("property.string.3", "default"), is("default")); // not exists
+        assertThat(store.getString("property.string.1", "default")).isEqualTo("a string");
+        assertThat(store.getString("property.string.2", null)).isNull(); // empty > default
+        assertThat(store.getString("property.string.3", "default")).isEqualTo("default"); // not exists
 
-        assertThat(store.getValues("property.array.1", Set.of("default")), hasItems("1", "2", "3", "4"));
-        assertThat(store.getValues("property.array.2", Set.of("default")), hasItems("a1", "a2", "a3", "a4"));
-        assertThat(store.getValues("property.array.3", Set.of("default")), hasItems("default")); // no elements > default
-        assertThat(store.getValues("property.array.4", Set.of("default")), hasItems("default")); // empty > default
-        assertThat(store.getValues("property.array.11", Set.of("default")), hasItems("default")); // not exitst
+        assertThat(store.getValues("property.array.1", Set.of("default"))).contains("1", "2", "3", "4");
+        assertThat(store.getValues("property.array.2", Set.of("default"))).contains("a1", "a2", "a3", "a4");
+        assertThat(store.getValues("property.array.3", Set.of("default"))).contains("default"); // no elements > default
+        assertThat(store.getValues("property.array.4", Set.of("default"))).contains("default"); // empty > default
+        assertThat(store.getValues("property.array.11", Set.of("default"))).contains("default"); // not exitst
 
         String DClassName = Object.class.getName();
-        assertThat(store.getClassname("property.class.1", DClassName), is(className));
-        assertThat(store.getClassname("property.class.2", DClassName), is(className));
-        assertThat(store.getClassname("property.class.3", DClassName), is(DClassName)); // empty > default
-        assertThat(store.getClassname("property.class.nd", DClassName), is(DClassName)); // not defined > default
-        assertThat(store.getClassname("property.class.nd", null), is(IsNull.nullValue())); // not defined > default
-        TestUtils.assertThrows(ConfigurationNotValidException.class, () -> store.getClassname("property.class.4", "DClassName")); // not exists
+        assertThat(store.getClassname("property.class.1", DClassName)).isEqualTo(className);
+        assertThat(store.getClassname("property.class.2", DClassName)).isEqualTo(className);
+        assertThat(store.getClassname("property.class.3", DClassName)).isEqualTo(DClassName); // empty > default
+        assertThat(store.getClassname("property.class.nd", DClassName)).isEqualTo(DClassName); // not defined > default
+        assertThat(store.getClassname("property.class.nd", null)).isNull(); // not defined > default
+        assertThatThrownBy(() -> store.getClassname("property.class.4", "DClassName")).isInstanceOf(ConfigurationNotValidException.class); // not exists
     }
 
     @ParameterizedTest
@@ -169,42 +164,42 @@ public class ConfigurationStoreIT {
 
         // test no properties -> max index -1
         updateConfigStore(new Properties());
-        assertThat(store.findMaxIndexForPrefix("property"), is(-1));
+        assertThat(store.findMaxIndexForPrefix("property")).isEqualTo(-1);
 
         // test single property -> max index == property index
         Properties props = new Properties();
         props.setProperty("property.0.value", "value");
         updateConfigStore(props);
-        assertThat(store.findMaxIndexForPrefix("property"), is(0));
+        assertThat(store.findMaxIndexForPrefix("property")).isZero();
 
         props = new Properties();
         props.setProperty("property.100.value", "value");
         updateConfigStore(props);
-        assertThat(store.findMaxIndexForPrefix("property"), is(100));
+        assertThat(store.findMaxIndexForPrefix("property")).isEqualTo(100);
 
         // test multiple properties -> max index == max property index
         props = new Properties();
         props.setProperty("property.0.value", "value");
         props.setProperty("property.1.value", "value");
         updateConfigStore(props);
-        assertThat(store.findMaxIndexForPrefix("property"), is(1));
+        assertThat(store.findMaxIndexForPrefix("property")).isOne();
 
         props.setProperty("property.100.value", "value");
         updateConfigStore(props);
-        assertThat(store.findMaxIndexForPrefix("property"), is(100));
+        assertThat(store.findMaxIndexForPrefix("property")).isEqualTo(100);
 
         props.setProperty("property2.111.value", "value");
         updateConfigStore(props);
-        assertThat(store.findMaxIndexForPrefix("property"), is(100));
-        assertThat(store.findMaxIndexForPrefix("property2"), is(111));
+        assertThat(store.findMaxIndexForPrefix("property")).isEqualTo(100);
+        assertThat(store.findMaxIndexForPrefix("property2")).isEqualTo(111);
 
         props.setProperty("property.weird.8.9.value", "value");
         updateConfigStore(props);
-        assertThat(store.findMaxIndexForPrefix("property"), is(100));
-        assertThat(store.findMaxIndexForPrefix("property.weird"), is(8));
-        assertThat(store.findMaxIndexForPrefix("property.weird.8"), is(9));
-        assertThat(store.findMaxIndexForPrefix("property.weird.8.9"), is(-1));
-        assertThat(store.findMaxIndexForPrefix("property.weird.8.9.value"), is(-1));
+        assertThat(store.findMaxIndexForPrefix("property")).isEqualTo(100);
+        assertThat(store.findMaxIndexForPrefix("property.weird")).isEqualTo(8);
+        assertThat(store.findMaxIndexForPrefix("property.weird.8")).isEqualTo(9);
+        assertThat(store.findMaxIndexForPrefix("property.weird.8.9")).isEqualTo(-1);
+        assertThat(store.findMaxIndexForPrefix("property.weird.8.9.value")).isEqualTo(-1);
     }
 
     @ParameterizedTest
@@ -219,15 +214,15 @@ public class ConfigurationStoreIT {
         props.setProperty("certificate.1.dynamic", "true");
         updateConfigStore(props);
 
-        assertEquals(type.equals("db") ? 7 : 4, store.asProperties(null).size());
-        assertEquals(1, store.findMaxIndexForPrefix("certificate"));
-        assertEquals(2, store.asProperties("certificate.1").size());
-        assertEquals(true, store.anyPropertyMatches(
+        assertThat(store.asProperties(null)).hasSize(type.equals("db") ? 7 : 4);
+        assertThat(store.findMaxIndexForPrefix("certificate")).isOne();
+        assertThat(store.asProperties("certificate.1")).hasSize(2);
+        assertThat(store.anyPropertyMatches(
                 (k, v) -> k.matches("certificate\\.[0-9]+\\.hostname") && v.equals(d1)
-        ));
-        assertEquals(false, store.anyPropertyMatches(
+        )).isTrue();
+        assertThat(store.anyPropertyMatches(
                 (k, v) -> k.matches("certificate\\.[0-9]+\\.hostname") && v.equals("unknown")
-        ));
+        )).isFalse();
 
         testKeyPairOperations();
         testCertificateOperations();
@@ -289,30 +284,30 @@ public class ConfigurationStoreIT {
         store.saveCertificate(cert2);
 
         // Certificates loading
-        assertEquals(cert1, store.loadCertificateForDomain(d1));
-        assertEquals(cert2, store.loadCertificateForDomain(d2));
+        assertThat(store.loadCertificateForDomain(d1)).isEqualTo(cert1);
+        assertThat(store.loadCertificateForDomain(d2)).isEqualTo(cert2);
 
         // Cert Updating
         cert1.setState(DynamicCertificateState.WAITING);
         cert1.setPendingOrderLocation(URI.create("http://locallhost/updatedorder").toURL());
         cert1.setPendingChallengesData(Map.of(cert1.getDomain(), JSON.parse("{\"challenge\": \"updateddata\"}")));
         store.saveCertificate(cert1);
-        assertEquals(cert1, store.loadCertificateForDomain(d1));
+        assertThat(store.loadCertificateForDomain(d1)).isEqualTo(cert1);
     }
 
     private void testAcmeChallengeTokens() {
         store.saveAcmeChallengeToken("token-id", "token-data");
         store.saveAcmeChallengeToken("token-id2", "token-data2");
-        assertEquals("token-data", store.loadAcmeChallengeToken("token-id"));
-        assertEquals("token-data2", store.loadAcmeChallengeToken("token-id2"));
+        assertThat(store.loadAcmeChallengeToken("token-id")).isEqualTo("token-data");
+        assertThat(store.loadAcmeChallengeToken("token-id2")).isEqualTo("token-data2");
         store.deleteAcmeChallengeToken("token-id");
-        assertNull(store.loadAcmeChallengeToken("token-id"));
+        assertThat(store.loadAcmeChallengeToken("token-id")).isNull();
         store.deleteAcmeChallengeToken("token-id2");
-        assertNull(store.loadAcmeChallengeToken("token-id2"));
+        assertThat(store.loadAcmeChallengeToken("token-id2")).isNull();
     }
 
     @Test
-    public void testCertificatesPersistency() throws ConfigurationNotValidException {
+    void certificatesPersistency() throws Exception {
         Properties props = new Properties();
         props.setProperty("certificate.0.hostname", d1);
         props.setProperty("certificate.0.dynamic", "true");
@@ -325,29 +320,29 @@ public class ConfigurationStoreIT {
         store = new HerdDBConfigurationStore(propertiesConfigurationStore, false, null, tmpDir, NullStatsLogger.INSTANCE);
 
         // Check applied configuration (loaded from empty db NB: passed configuration is ignored)
-        assertEquals("", store.getProperty("certificate.0.hostname", ""));
-        assertEquals("", store.getProperty("certificate.0.dynamic", ""));
-        assertEquals("", store.getProperty("certificate.1.hostname", ""));
-        assertEquals("", store.getProperty("certificate.1.dynamic", ""));
+        assertThat(store.getProperty("certificate.0.hostname", "")).isEmpty();
+        assertThat(store.getProperty("certificate.0.dynamic", "")).isEmpty();
+        assertThat(store.getProperty("certificate.1.hostname", "")).isEmpty();
+        assertThat(store.getProperty("certificate.1.dynamic", "")).isEmpty();
 
         // Apply first configuration
         store.commitConfiguration(propertiesConfigurationStore);
 
         // Check cached applied configuration
-        assertEquals(d1, store.getProperty("certificate.0.hostname", ""));
-        assertEquals("true", store.getProperty("certificate.0.dynamic", ""));
-        assertEquals(d2, store.getProperty("certificate.1.hostname", ""));
-        assertEquals("true", store.getProperty("certificate.1.dynamic", ""));
+        assertThat(store.getProperty("certificate.0.hostname", "")).isEqualTo(d1);
+        assertThat(store.getProperty("certificate.0.dynamic", "")).isEqualTo("true");
+        assertThat(store.getProperty("certificate.1.hostname", "")).isEqualTo(d2);
+        assertThat(store.getProperty("certificate.1.dynamic", "")).isEqualTo("true");
 
-        assertEquals(5, store.asProperties(null).size());
-        assertEquals(1, store.findMaxIndexForPrefix("certificate"));
-        assertEquals(2, store.asProperties("certificate.1").size());
-        assertEquals(true, store.anyPropertyMatches(
+        assertThat(store.asProperties(null)).hasSize(5);
+        assertThat(store.findMaxIndexForPrefix("certificate")).isOne();
+        assertThat(store.asProperties("certificate.1")).hasSize(2);
+        assertThat(store.anyPropertyMatches(
                 (k, v) -> k.matches("certificate\\.[0-9]+\\.hostname") && v.equals(d1)
-        ));
-        assertEquals(false, store.anyPropertyMatches(
+        )).isTrue();
+        assertThat(store.anyPropertyMatches(
                 (k, v) -> k.matches("certificate\\.[0-9]+\\.hostname") && v.equals("unknown")
-        ));
+        )).isFalse();
 
         // New configuration to apply
         props = new Properties();
@@ -374,26 +369,26 @@ public class ConfigurationStoreIT {
 
     private void checkConfiguration() {
         // check new configuration has been applied successfully
-        assertEquals("", store.getProperty("certificate.0.hostname", ""));
-        assertEquals("", store.getProperty("certificate.0.dynamic", ""));
-        assertEquals(d1, store.getProperty("certificate.1.hostname", ""));
-        assertEquals("false", store.getProperty("certificate.1.dynamic", ""));
-        assertEquals(d3, store.getProperty("certificate.3.hostname", ""));
-        assertEquals("true", store.getProperty("certificate.3.dynamic", ""));
+        assertThat(store.getProperty("certificate.0.hostname", "")).isEmpty();
+        assertThat(store.getProperty("certificate.0.dynamic", "")).isEmpty();
+        assertThat(store.getProperty("certificate.1.hostname", "")).isEqualTo(d1);
+        assertThat(store.getProperty("certificate.1.dynamic", "")).isEqualTo("false");
+        assertThat(store.getProperty("certificate.3.hostname", "")).isEqualTo(d3);
+        assertThat(store.getProperty("certificate.3.dynamic", "")).isEqualTo("true");
 
-        assertEquals(4, store.asProperties(null).size());
-        assertEquals(3, store.findMaxIndexForPrefix("certificate"));
-        assertEquals(2, store.asProperties("certificate.1.").size());
-        assertEquals(2, store.asProperties("certificate.3.").size());
-        assertEquals(true, store.anyPropertyMatches(
+        assertThat(store.asProperties(null)).hasSize(4);
+        assertThat(store.findMaxIndexForPrefix("certificate")).isEqualTo(3);
+        assertThat(store.asProperties("certificate.1.")).hasSize(2);
+        assertThat(store.asProperties("certificate.3.")).hasSize(2);
+        assertThat(store.anyPropertyMatches(
                 (k, v) -> k.matches("certificate\\.[0-9]+\\.hostname") && v.equals(d1)
-        ));
-        assertEquals(true, store.anyPropertyMatches(
+        )).isTrue();
+        assertThat(store.anyPropertyMatches(
                 (k, v) -> k.matches("certificate\\.[0-9]+\\.hostname") && v.equals(d3)
-        ));
-        assertEquals(false, store.anyPropertyMatches(
+        )).isTrue();
+        assertThat(store.anyPropertyMatches(
                 (k, v) -> k.matches("certificate\\.[0-9]+\\.hostname") && v.equals("unknown")
-        ));
+        )).isFalse();
     }
 
 
@@ -411,17 +406,17 @@ public class ConfigurationStoreIT {
 
         // round-trip through the same parse path used by rewriteConfiguration and /api/config/apply
         ConfigurationStore reloaded = ConfigResource.buildStore(store.toStringConfiguration());
-        assertEquals(domain, reloaded.getProperty("connectionpool.1.domain", null));
-        assertEquals(matcher, reloaded.getProperty("route.5.match", null));
+        assertThat(reloaded.getProperty("connectionpool.1.domain", null)).isEqualTo(domain);
+        assertThat(reloaded.getProperty("route.5.match", null)).isEqualTo(matcher);
 
         // a second round-trip must be stable too
         ConfigurationStore reloadedTwice = ConfigResource.buildStore(reloaded.toStringConfiguration());
-        assertEquals(domain, reloadedTwice.getProperty("connectionpool.1.domain", null));
-        assertEquals(matcher, reloadedTwice.getProperty("route.5.match", null));
+        assertThat(reloadedTwice.getProperty("connectionpool.1.domain", null)).isEqualTo(domain);
+        assertThat(reloadedTwice.getProperty("route.5.match", null)).isEqualTo(matcher);
     }
 
     @Test
-    public void testCommitConfigurationMasksSecretsInLogs() throws Exception {
+    void commitConfigurationMasksSecretsInLogs() throws Exception {
         this.type = "db";
         final var logAppender = new ListAppender<ILoggingEvent>();
         logAppender.start();
@@ -439,15 +434,16 @@ public class ConfigurationStoreIT {
             updateConfigStore(props);
 
             final var loggedLines = logAppender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
-            assertThat(loggedLines, hasItems(containsString("acme.1.hmac"), containsString("******")));
+            assertThat(loggedLines).anySatisfy(line -> assertThat(line).contains("acme.1.hmac", "******"));
             for (final var line : loggedLines) {
-                assertThat(line, not(containsString(hmac)));
-                assertThat(line, not(containsString(password)));
+                assertThat(line)
+                        .doesNotContain(hmac)
+                        .doesNotContain(password);
             }
 
             // masking applies to the log only: the stored values stay raw, they are needed at use time
-            assertEquals(hmac, store.getProperty("acme.1.hmac", ""));
-            assertEquals(password, store.getProperty("certificate.1.password", ""));
+            assertThat(store.getProperty("acme.1.hmac", "")).isEqualTo(hmac);
+            assertThat(store.getProperty("certificate.1.password", "")).isEqualTo(password);
         } finally {
             logger.detachAppender(logAppender);
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreIT.java
@@ -124,12 +124,14 @@ public class ConfigurationStoreIT {
 
         assertThat(store.getInt("property.int.1", 11)).isOne();
         assertThat(store.getInt("property.int.2", 11)).isEqualTo(11); // empty > default
-        assertThatThrownBy(() -> store.getInt("property.int.3", 11)).isInstanceOf(ConfigurationNotValidException.class);
+        assertThatThrownBy(() -> store.getInt("property.int.3", 11)).isInstanceOf(ConfigurationNotValidException.class)
+                .hasMessageContaining("for parameter 'property.int.3'");
         assertThat(store.getInt("property.int.11", 11)).isEqualTo(11); // not exists
 
         assertThat(store.getLong("property.long.1", 11)).isOne();
         assertThat(store.getLong("property.long.2", 11)).isEqualTo(11L); // empty > default
-        assertThatThrownBy(() -> store.getLong("property.long.3", 11)).isInstanceOf(ConfigurationNotValidException.class);
+        assertThatThrownBy(() -> store.getLong("property.long.3", 11)).isInstanceOf(ConfigurationNotValidException.class)
+                .hasMessageContaining("for parameter 'property.long.3'");
         assertThat(store.getLong("property.long.11", 11)).isEqualTo(11L); // not exists
 
         assertThat(store.getBoolean("property.boolean.1", false)).isTrue();
@@ -154,7 +156,8 @@ public class ConfigurationStoreIT {
         assertThat(store.getClassname("property.class.3", DClassName)).isEqualTo(DClassName); // empty > default
         assertThat(store.getClassname("property.class.nd", DClassName)).isEqualTo(DClassName); // not defined > default
         assertThat(store.getClassname("property.class.nd", null)).isNull(); // not defined > default
-        assertThatThrownBy(() -> store.getClassname("property.class.4", "DClassName")).isInstanceOf(ConfigurationNotValidException.class); // not exists
+        assertThatThrownBy(() -> store.getClassname("property.class.4", "DClassName")).isInstanceOf(ConfigurationNotValidException.class)
+                .hasMessageContaining("for parameter 'property.class.4'"); // not exists
     }
 
     @ParameterizedTest

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreIT.java
@@ -88,7 +88,7 @@ public class ConfigurationStoreIT {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "type={0}")
     @ValueSource(strings = {"db"})
     void test(String type) throws Exception {
         this.type = type;
@@ -160,7 +160,7 @@ public class ConfigurationStoreIT {
                 .hasMessageContaining("for parameter 'property.class.4'"); // not exists
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "type={0}")
     @ValueSource(strings = {"db"})
     void propertiesIndex(String type) throws Exception {
         this.type = type;
@@ -205,7 +205,7 @@ public class ConfigurationStoreIT {
         assertThat(store.findMaxIndexForPrefix("property.weird.8.9.value")).isEqualTo(-1);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "type={0}")
     @ValueSource(strings = {"db"})
     void certiticatesConfigurationStore(String type) throws Exception {
         this.type = type;
@@ -395,7 +395,7 @@ public class ConfigurationStoreIT {
     }
 
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "type={0}")
     @ValueSource(strings = {"in-memory", "db"})
     void toStringConfigurationPreservesBackslashes(String type) throws Exception {
         this.type = type;

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreUtilsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreUtilsTest.java
@@ -70,7 +70,6 @@ class ConfigurationStoreUtilsTest {
                 .hasSameSizeAs(originalChain);
         for (int i = 0; i < decodedChain.length; i++) {
             Certificate decodedCert = decodedChain[i];
-            assertThat(decodedCert).isNotNull();
             assertThat(decodedCert.getEncoded()).isEqualTo(originalChain[i].getEncoded());
         }
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreUtilsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreUtilsTest.java
@@ -23,9 +23,9 @@ import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
-import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64DecodeCertificateChain;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64DecodePrivateKey;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64DecodePublicKey;
@@ -34,9 +34,6 @@ import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64Encode
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
 import static org.carapaceproxy.utils.CertificatesTestUtils.generateSampleChain;
 import static org.carapaceproxy.utils.TestUtils.assertEqualsKey;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.shredzone.acme4j.util.KeyPairUtils;
 
@@ -44,10 +41,10 @@ import org.shredzone.acme4j.util.KeyPairUtils;
  *
  * @author paolo.venturi
  */
-public class ConfigurationStoreUtilsTest {
+class ConfigurationStoreUtilsTest {
 
     @Test
-    public void testBase64EncodeDecodeKeys() throws Exception {
+    void base64EncodeDecodeKeys() throws Exception {
         KeyPair pair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
         PrivateKey privateKey = pair.getPrivate();
         PublicKey publicKey = pair.getPublic();
@@ -62,18 +59,19 @@ public class ConfigurationStoreUtilsTest {
     }
 
     @Test
-    public void testBase64EncodeEncodeCertificateChain() throws Exception {
+    void base64EncodeEncodeCertificateChain() throws Exception {
         KeyPair endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
         Certificate[] originalChain = generateSampleChain(endUserKeyPair, false);
         String encodedChain = base64EncodeCertificateChain(originalChain, endUserKeyPair.getPrivate());
         Certificate[] decodedChain = base64DecodeCertificateChain(encodedChain);
 
-        assertNotNull(decodedChain);
-        assertEquals(originalChain.length, decodedChain.length);
+        assertThat(decodedChain)
+                .isNotNull()
+                .hasSameSizeAs(originalChain);
         for (int i = 0; i < decodedChain.length; i++) {
             Certificate decodedCert = decodedChain[i];
-            assertNotNull(decodedCert);
-            assertTrue(Arrays.equals(decodedCert.getEncoded(), originalChain[i].getEncoded()));
+            assertThat(decodedCert).isNotNull();
+            assertThat(decodedCert.getEncoded()).isEqualTo(originalChain[i].getEncoded());
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/PropertiesConfigurationStoreTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/PropertiesConfigurationStoreTest.java
@@ -19,11 +19,8 @@
  */
 package org.carapaceproxy.configstore;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
 import static org.carapaceproxy.server.config.AcmeProviderConfiguration.DEFAULT_PROVIDER_NAME;
 import static org.carapaceproxy.utils.TestUtils.assertEqualsKey;
@@ -92,78 +89,78 @@ class PropertiesConfigurationStoreTest {
 
         store = new PropertiesConfigurationStore(props);
 
-        assertEquals(1, store.getInt("property.int.1", 11));
-        assertEquals(11, store.getInt("property.int.2", 11)); // empty > default
-        assertThrows(ConfigurationNotValidException.class, () -> store.getInt("property.int.3", 11));
-        assertEquals(11, store.getInt("property.int.11", 11)); // not exists
+        assertThat(store.getInt("property.int.1", 11)).isOne();
+        assertThat(store.getInt("property.int.2", 11)).isEqualTo(11); // empty > default
+        assertThatThrownBy(() -> store.getInt("property.int.3", 11)).isInstanceOf(ConfigurationNotValidException.class);
+        assertThat(store.getInt("property.int.11", 11)).isEqualTo(11); // not exists
 
-        assertEquals(1L, store.getLong("property.long.1", 11));
-        assertEquals(11L, store.getLong("property.long.2", 11)); // empty > default
-        assertThrows(ConfigurationNotValidException.class, () -> store.getLong("property.long.3", 11));
-        assertEquals(11L, store.getLong("property.long.11", 11)); // not exists
+        assertThat(store.getLong("property.long.1", 11)).isOne();
+        assertThat(store.getLong("property.long.2", 11)).isEqualTo(11L); // empty > default
+        assertThatThrownBy(() -> store.getLong("property.long.3", 11)).isInstanceOf(ConfigurationNotValidException.class);
+        assertThat(store.getLong("property.long.11", 11)).isEqualTo(11L); // not exists
 
-        assertEquals(true, store.getBoolean("property.boolean.1", false));
-        assertEquals(false, store.getBoolean("property.boolean.2", true));
-        assertEquals(false, store.getBoolean("property.boolean.3", true));
-        assertEquals(true, store.getBoolean("property.boolean.4", true)); // empty > default
-        assertEquals(true, store.getBoolean("property.boolean.ne", true)); // not exists
+        assertThat(store.getBoolean("property.boolean.1", false)).isTrue();
+        assertThat(store.getBoolean("property.boolean.2", true)).isFalse();
+        assertThat(store.getBoolean("property.boolean.3", true)).isFalse();
+        assertThat(store.getBoolean("property.boolean.4", true)).isTrue(); // empty > default
+        assertThat(store.getBoolean("property.boolean.ne", true)).isTrue(); // not exists
 
-        assertEquals("a string", store.getString("property.string.1", "default"));
-        assertNull(store.getString("property.string.2", null)); // empty > default
-        assertEquals("default", store.getString("property.string.3", "default")); // not exists
+        assertThat(store.getString("property.string.1", "default")).isEqualTo("a string");
+        assertThat(store.getString("property.string.2", null)).isNull(); // empty > default
+        assertThat(store.getString("property.string.3", "default")).isEqualTo("default"); // not exists
 
-        assertTrue(store.getValues("property.array.1", Set.of("default")).containsAll(List.of("1", "2", "3", "4")));
-        assertTrue(store.getValues("property.array.2", Set.of("default")).containsAll(List.of("a1", "a2", "a3", "a4")));
-        assertTrue(store.getValues("property.array.3", Set.of("default")).contains("default")); // no elements > default
-        assertTrue(store.getValues("property.array.4", Set.of("default")).contains("default")); // empty > default
-        assertTrue(store.getValues("property.array.11", Set.of("default")).contains("default")); // not exists
+        assertThat(store.getValues("property.array.1", Set.of("default"))).containsAll(List.of("1", "2", "3", "4"));
+        assertThat(store.getValues("property.array.2", Set.of("default"))).containsAll(List.of("a1", "a2", "a3", "a4"));
+        assertThat(store.getValues("property.array.3", Set.of("default"))).contains("default"); // no elements > default
+        assertThat(store.getValues("property.array.4", Set.of("default"))).contains("default"); // empty > default
+        assertThat(store.getValues("property.array.11", Set.of("default"))).contains("default"); // not exists
 
         String dClassName = Object.class.getName();
-        assertEquals(className, store.getClassname("property.class.1", dClassName));
-        assertEquals(className, store.getClassname("property.class.2", dClassName));
-        assertEquals(dClassName, store.getClassname("property.class.3", dClassName)); // empty > default
-        assertEquals(dClassName, store.getClassname("property.class.nd", dClassName)); // not defined > default
-        assertNull(store.getClassname("property.class.nd", null)); // not defined > default
-        assertThrows(ConfigurationNotValidException.class, () -> store.getClassname("property.class.4", "DClassName"));
+        assertThat(store.getClassname("property.class.1", dClassName)).isEqualTo(className);
+        assertThat(store.getClassname("property.class.2", dClassName)).isEqualTo(className);
+        assertThat(store.getClassname("property.class.3", dClassName)).isEqualTo(dClassName); // empty > default
+        assertThat(store.getClassname("property.class.nd", dClassName)).isEqualTo(dClassName); // not defined > default
+        assertThat(store.getClassname("property.class.nd", null)).isNull(); // not defined > default
+        assertThatThrownBy(() -> store.getClassname("property.class.4", "DClassName")).isInstanceOf(ConfigurationNotValidException.class);
     }
 
     @Test
     void findsMaxIndexForPrefix() throws Exception {
         store = new PropertiesConfigurationStore(new Properties());
-        assertEquals(-1, store.findMaxIndexForPrefix("property"));
+        assertThat(store.findMaxIndexForPrefix("property")).isEqualTo(-1);
 
         Properties props = new Properties();
         props.setProperty("property.0.value", "value");
         store = new PropertiesConfigurationStore(props);
-        assertEquals(0, store.findMaxIndexForPrefix("property"));
+        assertThat(store.findMaxIndexForPrefix("property")).isZero();
 
         props = new Properties();
         props.setProperty("property.100.value", "value");
         store = new PropertiesConfigurationStore(props);
-        assertEquals(100, store.findMaxIndexForPrefix("property"));
+        assertThat(store.findMaxIndexForPrefix("property")).isEqualTo(100);
 
         props = new Properties();
         props.setProperty("property.0.value", "value");
         props.setProperty("property.1.value", "value");
         store = new PropertiesConfigurationStore(props);
-        assertEquals(1, store.findMaxIndexForPrefix("property"));
+        assertThat(store.findMaxIndexForPrefix("property")).isOne();
 
         props.setProperty("property.100.value", "value");
         store = new PropertiesConfigurationStore(props);
-        assertEquals(100, store.findMaxIndexForPrefix("property"));
+        assertThat(store.findMaxIndexForPrefix("property")).isEqualTo(100);
 
         props.setProperty("property2.111.value", "value");
         store = new PropertiesConfigurationStore(props);
-        assertEquals(100, store.findMaxIndexForPrefix("property"));
-        assertEquals(111, store.findMaxIndexForPrefix("property2"));
+        assertThat(store.findMaxIndexForPrefix("property")).isEqualTo(100);
+        assertThat(store.findMaxIndexForPrefix("property2")).isEqualTo(111);
 
         props.setProperty("property.weird.8.9.value", "value");
         store = new PropertiesConfigurationStore(props);
-        assertEquals(100, store.findMaxIndexForPrefix("property"));
-        assertEquals(8, store.findMaxIndexForPrefix("property.weird"));
-        assertEquals(9, store.findMaxIndexForPrefix("property.weird.8"));
-        assertEquals(-1, store.findMaxIndexForPrefix("property.weird.8.9"));
-        assertEquals(-1, store.findMaxIndexForPrefix("property.weird.8.9.value"));
+        assertThat(store.findMaxIndexForPrefix("property")).isEqualTo(100);
+        assertThat(store.findMaxIndexForPrefix("property.weird")).isEqualTo(8);
+        assertThat(store.findMaxIndexForPrefix("property.weird.8")).isEqualTo(9);
+        assertThat(store.findMaxIndexForPrefix("property.weird.8.9")).isEqualTo(-1);
+        assertThat(store.findMaxIndexForPrefix("property.weird.8.9.value")).isEqualTo(-1);
     }
 
     @Test
@@ -175,15 +172,15 @@ class PropertiesConfigurationStoreTest {
         props.setProperty("certificate.1.dynamic", "true");
         store = new PropertiesConfigurationStore(props);
 
-        assertEquals(4, store.asProperties(null).size());
-        assertEquals(1, store.findMaxIndexForPrefix("certificate"));
-        assertEquals(2, store.asProperties("certificate.1").size());
-        assertTrue(store.anyPropertyMatches(
+        assertThat(store.asProperties(null)).hasSize(4);
+        assertThat(store.findMaxIndexForPrefix("certificate")).isOne();
+        assertThat(store.asProperties("certificate.1")).hasSize(2);
+        assertThat(store.anyPropertyMatches(
                 (k, v) -> k.matches("certificate\\.[0-9]+\\.hostname") && v.equals(d1)
-        ));
-        assertFalse(store.anyPropertyMatches(
+        )).isTrue();
+        assertThat(store.anyPropertyMatches(
                 (k, v) -> k.matches("certificate\\.[0-9]+\\.hostname") && v.equals("unknown")
-        ));
+        )).isFalse();
 
         // KeyPairs generation + saving
         KeyPair acmePair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
@@ -233,23 +230,23 @@ class PropertiesConfigurationStoreTest {
         CertificateData cert2 = new CertificateData(d2, "encodedChain2", DynamicCertificateState.WAITING);
         store.saveCertificate(cert2);
 
-        assertEquals(cert1, store.loadCertificateForDomain(d1));
-        assertEquals(cert2, store.loadCertificateForDomain(d2));
+        assertThat(store.loadCertificateForDomain(d1)).isEqualTo(cert1);
+        assertThat(store.loadCertificateForDomain(d2)).isEqualTo(cert2);
 
         cert1.setState(DynamicCertificateState.WAITING);
         cert1.setPendingOrderLocation(URI.create("http://locallhost/updatedorder").toURL());
         cert1.setPendingChallengesData(Map.of(cert1.getDomain(), JSON.parse("{\"challenge\": \"updateddata\"}")));
         store.saveCertificate(cert1);
-        assertEquals(cert1, store.loadCertificateForDomain(d1));
+        assertThat(store.loadCertificateForDomain(d1)).isEqualTo(cert1);
 
         // ACME challenge tokens
         store.saveAcmeChallengeToken("token-id", "token-data");
         store.saveAcmeChallengeToken("token-id2", "token-data2");
-        assertEquals("token-data", store.loadAcmeChallengeToken("token-id"));
-        assertEquals("token-data2", store.loadAcmeChallengeToken("token-id2"));
+        assertThat(store.loadAcmeChallengeToken("token-id")).isEqualTo("token-data");
+        assertThat(store.loadAcmeChallengeToken("token-id2")).isEqualTo("token-data2");
         store.deleteAcmeChallengeToken("token-id");
-        assertNull(store.loadAcmeChallengeToken("token-id"));
+        assertThat(store.loadAcmeChallengeToken("token-id")).isNull();
         store.deleteAcmeChallengeToken("token-id2");
-        assertNull(store.loadAcmeChallengeToken("token-id2"));
+        assertThat(store.loadAcmeChallengeToken("token-id2")).isNull();
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/PropertiesConfigurationStoreTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/PropertiesConfigurationStoreTest.java
@@ -111,8 +111,8 @@ class PropertiesConfigurationStoreTest {
         assertThat(store.getString("property.string.2", null)).isNull(); // empty > default
         assertThat(store.getString("property.string.3", "default")).isEqualTo("default"); // not exists
 
-        assertThat(store.getValues("property.array.1", Set.of("default"))).containsAll(List.of("1", "2", "3", "4"));
-        assertThat(store.getValues("property.array.2", Set.of("default"))).containsAll(List.of("a1", "a2", "a3", "a4"));
+        assertThat(store.getValues("property.array.1", Set.of("default"))).containsExactlyInAnyOrder("1", "2", "3", "4");
+        assertThat(store.getValues("property.array.2", Set.of("default"))).containsExactlyInAnyOrder("a1", "a2", "a3", "a4");
         assertThat(store.getValues("property.array.3", Set.of("default"))).contains("default"); // no elements > default
         assertThat(store.getValues("property.array.4", Set.of("default"))).contains("default"); // empty > default
         assertThat(store.getValues("property.array.11", Set.of("default"))).contains("default"); // not exists

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/PropertiesConfigurationStoreTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/PropertiesConfigurationStoreTest.java
@@ -91,12 +91,14 @@ class PropertiesConfigurationStoreTest {
 
         assertThat(store.getInt("property.int.1", 11)).isOne();
         assertThat(store.getInt("property.int.2", 11)).isEqualTo(11); // empty > default
-        assertThatThrownBy(() -> store.getInt("property.int.3", 11)).isInstanceOf(ConfigurationNotValidException.class);
+        assertThatThrownBy(() -> store.getInt("property.int.3", 11)).isInstanceOf(ConfigurationNotValidException.class)
+                .hasMessageContaining("for parameter 'property.int.3'");
         assertThat(store.getInt("property.int.11", 11)).isEqualTo(11); // not exists
 
         assertThat(store.getLong("property.long.1", 11)).isOne();
         assertThat(store.getLong("property.long.2", 11)).isEqualTo(11L); // empty > default
-        assertThatThrownBy(() -> store.getLong("property.long.3", 11)).isInstanceOf(ConfigurationNotValidException.class);
+        assertThatThrownBy(() -> store.getLong("property.long.3", 11)).isInstanceOf(ConfigurationNotValidException.class)
+                .hasMessageContaining("for parameter 'property.long.3'");
         assertThat(store.getLong("property.long.11", 11)).isEqualTo(11L); // not exists
 
         assertThat(store.getBoolean("property.boolean.1", false)).isTrue();
@@ -121,7 +123,8 @@ class PropertiesConfigurationStoreTest {
         assertThat(store.getClassname("property.class.3", dClassName)).isEqualTo(dClassName); // empty > default
         assertThat(store.getClassname("property.class.nd", dClassName)).isEqualTo(dClassName); // not defined > default
         assertThat(store.getClassname("property.class.nd", null)).isNull(); // not defined > default
-        assertThatThrownBy(() -> store.getClassname("property.class.4", "DClassName")).isInstanceOf(ConfigurationNotValidException.class);
+        assertThatThrownBy(() -> store.getClassname("property.class.4", "DClassName")).isInstanceOf(ConfigurationNotValidException.class)
+                .hasMessageContaining("for parameter 'property.class.4'");
     }
 
     @Test

--- a/carapace-server/src/test/java/org/carapaceproxy/core/EndpointKeyTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/EndpointKeyTest.java
@@ -1,23 +1,22 @@
 package org.carapaceproxy.core;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-public class EndpointKeyTest {
+class EndpointKeyTest {
 
     @Test
-    public void endpointKeyTest() {
+    void endpointKeyTest() {
         {
             EndpointKey entryPoint = EndpointKey.make("localhost:8080");
-            assertThat(entryPoint.host(), is("localhost"));
-            assertThat(entryPoint.port(), is(8080));
+            assertThat(entryPoint.host()).isEqualTo("localhost");
+            assertThat(entryPoint.port()).isEqualTo(8080);
         }
         {
             EndpointKey entryPoint = EndpointKey.make("localhost");
-            assertThat(entryPoint.host(), is("localhost"));
-            assertThat(entryPoint.port(), is(0));
+            assertThat(entryPoint.host()).isEqualTo("localhost");
+            assertThat(entryPoint.port()).isZero();
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/core/ForwardedStrategyIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/ForwardedStrategyIT.java
@@ -6,15 +6,13 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_KEEP_ALIVE_COUNT;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_KEEP_ALIVE_IDLE;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_KEEP_ALIVE_INTERVAL;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_MAX_KEEP_ALIVE_REQUESTS;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SO_BACKLOG;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static reactor.netty.http.HttpProtocol.HTTP11;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -24,7 +22,6 @@ import io.netty.util.concurrent.DefaultEventExecutor;
 import java.io.File;
 import java.io.IOException;
 import java.util.Set;
-import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.carapaceproxy.utils.RawHttpClient;
 import org.carapaceproxy.utils.TestEndpointMapper;
@@ -33,7 +30,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class ForwardedStrategyIT {
     public static final String REAL_IP_ADDRESS = "127.0.0.1";
@@ -50,7 +47,7 @@ public class ForwardedStrategyIT {
     public File tmpDir;
 
     @BeforeEach
-    public void setupWireMock() {
+    void setupWireMock() {
         stubFor(get(urlEqualTo("/index.html"))
                 .withHeader("X-Forwarded-For", equalTo(FORWARDED_IP_ADDRESS))
                 .willReturn(aResponse()
@@ -72,100 +69,100 @@ public class ForwardedStrategyIT {
     }
 
     @Test
-    public void testDropStrategy() throws IOException, ConfigurationNotValidException, InterruptedException {
+    void dropStrategy() throws Exception {
         final var mapper = new TestEndpointMapper("localhost", wireMockRule.getPort());
         try (final var server = new HttpProxyServer(mapper, tmpDir)) {
             server.addListener(getConfiguration(ForwardedStrategies.drop(), Set.of()));
             server.start();
             int port = server.getLocalPort();
-            assertTrue(port > 0);
+            assertThat(port).isGreaterThan(0);
             try (final var client = new RawHttpClient("localhost", port)) {
                 final var response = requestWithoutHeader(client);
-                assertThat(response, containsString(NO_HEADER));
+                assertThat(response).contains(NO_HEADER);
             }
             try (final var client = new RawHttpClient("localhost", port)) {
                 final var response = requestWithHeader(client);
-                assertThat(response, containsString(NO_HEADER));
+                assertThat(response).contains(NO_HEADER);
             }
         }
     }
 
     @Test
-    public void testPreserveStrategy() throws IOException, ConfigurationNotValidException, InterruptedException {
+    void preserveStrategy() throws Exception {
         final var mapper = new TestEndpointMapper("localhost", wireMockRule.getPort());
         try (final var server = new HttpProxyServer(mapper, tmpDir)) {
             server.addListener(getConfiguration(ForwardedStrategies.preserve(), Set.of()));
             server.start();
             int port = server.getLocalPort();
-            assertTrue(port > 0);
+            assertThat(port).isGreaterThan(0);
             try (final var client = new RawHttpClient("localhost", port)) {
                 final var response = requestWithoutHeader(client);
-                assertThat(response, containsString(NO_HEADER));
+                assertThat(response).contains(NO_HEADER);
             }
             try (final var client = new RawHttpClient("localhost", port)) {
                 final var response = requestWithHeader(client);
-                assertThat(response, containsString(HEADER_PRESENT));
+                assertThat(response).contains(HEADER_PRESENT);
             }
         }
     }
 
     @Test
-    public void testRewriteStrategy() throws IOException, ConfigurationNotValidException, InterruptedException {
+    void rewriteStrategy() throws Exception {
         final var mapper = new TestEndpointMapper("localhost", wireMockRule.getPort());
         try (final var server = new HttpProxyServer(mapper, tmpDir)) {
             server.addListener(getConfiguration(ForwardedStrategies.rewrite(), Set.of()));
             server.start();
             int port = server.getLocalPort();
-            assertTrue(port > 0);
+            assertThat(port).isGreaterThan(0);
             try (final var client = new RawHttpClient("localhost", port)) {
                 final var response = requestWithoutHeader(client);
-                assertThat(response, containsString(HEADER_REWRITTEN));
+                assertThat(response).contains(HEADER_REWRITTEN);
             }
             try (final var client = new RawHttpClient("localhost", port)) {
                 final var response = requestWithHeader(client);
-                assertThat(response, containsString(HEADER_REWRITTEN));
+                assertThat(response).contains(HEADER_REWRITTEN);
             }
         }
     }
 
     @ParameterizedTest
-    @CsvSource({"true", "false"})
-    public void testIfTrustedStrategy(boolean useCidr) throws IOException, ConfigurationNotValidException, InterruptedException {
+    @ValueSource(booleans = {true, false})
+    void ifTrustedStrategy(boolean useCidr) throws Exception {
         final var mapper = new TestEndpointMapper("localhost", wireMockRule.getPort());
         try (final var server = new HttpProxyServer(mapper, tmpDir)) {
             final var trustedIps = Set.of(REAL_IP_ADDRESS + (useCidr ? SUBNET : ""));
             server.addListener(getConfiguration(ForwardedStrategies.ifTrusted(trustedIps), trustedIps));
             server.start();
             int port = server.getLocalPort();
-            assertTrue(port > 0);
+            assertThat(port).isGreaterThan(0);
             try (final var client = new RawHttpClient("localhost", port)) {
                 final var response = requestWithoutHeader(client);
-                assertThat(response, containsString(NO_HEADER));
+                assertThat(response).contains(NO_HEADER);
             }
             try (final var client = new RawHttpClient("localhost", port)) {
                 final var response = requestWithHeader(client);
-                assertThat(response, containsString(HEADER_PRESENT));
+                assertThat(response).contains(HEADER_PRESENT);
             }
         }
     }
 
     @ParameterizedTest
-    @CsvSource({"true", "false"})
-    public void testIfNotTrustedStrategy(boolean useCidr) throws IOException, ConfigurationNotValidException, InterruptedException {
+    @ValueSource(booleans = {true, false})
+    void ifNotTrustedStrategy(boolean useCidr) throws Exception {
         final var mapper = new TestEndpointMapper("localhost", wireMockRule.getPort());
         try (final var server = new HttpProxyServer(mapper, tmpDir)) {
             final var trustedIps = Set.of(FORWARDED_IP_ADDRESS + (useCidr ? SUBNET : ""));
             server.addListener(getConfiguration(ForwardedStrategies.ifTrusted(trustedIps), trustedIps));
             server.start();
             int port = server.getLocalPort();
-            assertTrue(port > 0);
+            assertThat(port).isGreaterThan(0);
             try (final var client = new RawHttpClient("localhost", port)) {
                 final var response = requestWithoutHeader(client);
-                assertThat(response, containsString(HEADER_REWRITTEN));
+                assertThat(response).contains(HEADER_REWRITTEN);
             }
             try (final var client = new RawHttpClient("localhost", port)) {
                 final var response = requestWithHeader(client);
-                assertThat(response, containsString(HEADER_REWRITTEN));
+                assertThat(response).contains(HEADER_REWRITTEN);
             }
         }
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/core/ForwardedStrategyIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/ForwardedStrategyIT.java
@@ -125,7 +125,7 @@ public class ForwardedStrategyIT {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "useCidr={0}")
     @ValueSource(booleans = {true, false})
     void ifTrustedStrategy(boolean useCidr) throws Exception {
         final var mapper = new TestEndpointMapper("localhost", wireMockRule.getPort());
@@ -146,7 +146,7 @@ public class ForwardedStrategyIT {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "useCidr={0}")
     @ValueSource(booleans = {true, false})
     void ifNotTrustedStrategy(boolean useCidr) throws Exception {
         final var mapper = new TestEndpointMapper("localhost", wireMockRule.getPort());

--- a/carapace-server/src/test/java/org/carapaceproxy/core/ForwardedStrategyIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/ForwardedStrategyIT.java
@@ -75,7 +75,6 @@ public class ForwardedStrategyIT {
             server.addListener(getConfiguration(ForwardedStrategies.drop(), Set.of()));
             server.start();
             int port = server.getLocalPort();
-            assertThat(port).isGreaterThan(0);
             try (final var client = new RawHttpClient("localhost", port)) {
                 final var response = requestWithoutHeader(client);
                 assertThat(response).contains(NO_HEADER);
@@ -94,7 +93,6 @@ public class ForwardedStrategyIT {
             server.addListener(getConfiguration(ForwardedStrategies.preserve(), Set.of()));
             server.start();
             int port = server.getLocalPort();
-            assertThat(port).isGreaterThan(0);
             try (final var client = new RawHttpClient("localhost", port)) {
                 final var response = requestWithoutHeader(client);
                 assertThat(response).contains(NO_HEADER);
@@ -113,7 +111,6 @@ public class ForwardedStrategyIT {
             server.addListener(getConfiguration(ForwardedStrategies.rewrite(), Set.of()));
             server.start();
             int port = server.getLocalPort();
-            assertThat(port).isGreaterThan(0);
             try (final var client = new RawHttpClient("localhost", port)) {
                 final var response = requestWithoutHeader(client);
                 assertThat(response).contains(HEADER_REWRITTEN);
@@ -134,7 +131,6 @@ public class ForwardedStrategyIT {
             server.addListener(getConfiguration(ForwardedStrategies.ifTrusted(trustedIps), trustedIps));
             server.start();
             int port = server.getLocalPort();
-            assertThat(port).isGreaterThan(0);
             try (final var client = new RawHttpClient("localhost", port)) {
                 final var response = requestWithoutHeader(client);
                 assertThat(response).contains(NO_HEADER);
@@ -155,7 +151,6 @@ public class ForwardedStrategyIT {
             server.addListener(getConfiguration(ForwardedStrategies.ifTrusted(trustedIps), trustedIps));
             server.start();
             int port = server.getLocalPort();
-            assertThat(port).isGreaterThan(0);
             try (final var client = new RawHttpClient("localhost", port)) {
                 final var response = requestWithoutHeader(client);
                 assertThat(response).contains(HEADER_REWRITTEN);

--- a/carapace-server/src/test/java/org/carapaceproxy/core/Http2HeadersIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/Http2HeadersIT.java
@@ -102,7 +102,6 @@ public class Http2HeadersIT {
                     .response()
                     .block();
         }
-        assertThat(response).isNotNull();
         assertThat(response.status()).isEqualTo(HttpResponseStatus.OK);
         assertThat(response.version()).isEqualTo(HttpVersion.valueOf("HTTP/2.0"));
     }
@@ -137,7 +136,6 @@ public class Http2HeadersIT {
                     .response()
                     .block();
         }
-        assertThat(response).isNotNull();
         assertThat(response.status()).isEqualTo(HttpResponseStatus.OK);
         // Keep-Alive must be stripped from the backend response before forwarding to the client.
         // Connection is excluded from this check because Reactor Netty's HTTP server manages it
@@ -186,7 +184,6 @@ public class Http2HeadersIT {
             }
             // The request itself must succeed: pre-fix this would 503 once the connection switches to H2
             // and Netty's H2 encoder rejects the forwarded Keep-Alive header.
-            assertThat(response).isNotNull();
             assertThat(response.status()).isEqualTo(HttpResponseStatus.OK);
             // And the backend must never see Keep-Alive — regardless of which protocol the proxy used
             // to talk to it.
@@ -238,7 +235,6 @@ public class Http2HeadersIT {
             }
             // The concern was that a forwarded Transfer-Encoding could trip the encoder (RFC 9113 §8.2.2) and 503;
             // the request must instead complete normally.
-            assertThat(response).isNotNull();
             assertThat(response.status()).isEqualTo(HttpResponseStatus.OK);
             // The chunked request reached the backend — forwarding Transfer-Encoding did not break the hop.
             assertThat(capturedRequestHeaders.get()).isNotNull();

--- a/carapace-server/src/test/java/org/carapaceproxy/core/Http2HeadersIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/Http2HeadersIT.java
@@ -8,6 +8,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.Options.DYNAMIC_PORT;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_FORWARDED_STRATEGY;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_KEEP_ALIVE;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_KEEP_ALIVE_COUNT;
@@ -16,10 +17,6 @@ import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAU
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_MAX_KEEP_ALIVE_REQUESTS;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SO_BACKLOG;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.netty.channel.group.DefaultChannelGroup;
@@ -32,7 +29,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.carapaceproxy.utils.TestEndpointMapper;
 import org.junit.jupiter.api.io.TempDir;
@@ -80,7 +76,7 @@ public class Http2HeadersIT {
      * headers should still get a successful response via Carapace.
      */
     @Test
-    public void testH2CUpgradeRequestSucceeds() throws IOException, ConfigurationNotValidException, InterruptedException {
+    void h2cUpgradeRequestSucceeds() throws Exception {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(HttpResponseStatus.OK.code())
@@ -106,9 +102,9 @@ public class Http2HeadersIT {
                     .response()
                     .block();
         }
-        assertThat(response, is(notNullValue()));
-        assertThat(response.status(), is(HttpResponseStatus.OK));
-        assertThat(response.version(), is(HttpVersion.valueOf("HTTP/2.0")));
+        assertThat(response).isNotNull();
+        assertThat(response.status()).isEqualTo(HttpResponseStatus.OK);
+        assertThat(response.version()).isEqualTo(HttpVersion.valueOf("HTTP/2.0"));
     }
 
     /**
@@ -119,7 +115,7 @@ public class Http2HeadersIT {
      * connection autonomously, so we verify the absence of Keep-Alive (which Reactor Netty never sets).
      */
     @Test
-    public void testHopByHopHeadersStrippedFromResponse() throws IOException, ConfigurationNotValidException, InterruptedException {
+    void hopByHopHeadersStrippedFromResponse() throws Exception {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(HttpResponseStatus.OK.code())
@@ -141,12 +137,12 @@ public class Http2HeadersIT {
                     .response()
                     .block();
         }
-        assertThat(response, is(notNullValue()));
-        assertThat(response.status(), is(HttpResponseStatus.OK));
+        assertThat(response).isNotNull();
+        assertThat(response.status()).isEqualTo(HttpResponseStatus.OK);
         // Keep-Alive must be stripped from the backend response before forwarding to the client.
         // Connection is excluded from this check because Reactor Netty's HTTP server manages it
         // autonomously for the client-facing connection.
-        assertThat(response.responseHeaders().get(HttpHeaderNames.KEEP_ALIVE), is(nullValue()));
+        assertThat(response.responseHeaders().get(HttpHeaderNames.KEEP_ALIVE)).isNull();
     }
 
     /**
@@ -158,7 +154,7 @@ public class Http2HeadersIT {
      * for H2C as the backend so Carapace's outbound {@code HttpClient} can negotiate H2.
      */
     @Test
-    public void testHopByHopHeadersStrippedForH2cBackend() throws IOException, ConfigurationNotValidException, InterruptedException {
+    void hopByHopHeadersStrippedForH2cBackend() throws Exception {
         final AtomicReference<HttpHeaders> capturedRequestHeaders = new AtomicReference<>();
         final DisposableServer h2cBackend = HttpServer.create()
                 .host("localhost")
@@ -190,19 +186,19 @@ public class Http2HeadersIT {
             }
             // The request itself must succeed: pre-fix this would 503 once the connection switches to H2
             // and Netty's H2 encoder rejects the forwarded Keep-Alive header.
-            assertThat(response, is(notNullValue()));
-            assertThat(response.status(), is(HttpResponseStatus.OK));
+            assertThat(response).isNotNull();
+            assertThat(response.status()).isEqualTo(HttpResponseStatus.OK);
             // And the backend must never see Keep-Alive — regardless of which protocol the proxy used
             // to talk to it.
-            assertThat(capturedRequestHeaders.get(), is(notNullValue()));
-            assertThat(capturedRequestHeaders.get().get(HttpHeaderNames.KEEP_ALIVE), is(nullValue()));
+            assertThat(capturedRequestHeaders.get()).isNotNull();
+            assertThat(capturedRequestHeaders.get().get(HttpHeaderNames.KEEP_ALIVE)).isNull();
         } finally {
             h2cBackend.disposeNow();
         }
     }
 
     /**
-     * Companion to {@link #testHopByHopHeadersStrippedForH2cBackend}: a chunked ({@code Transfer-Encoding})
+     * Companion to {@link #hopByHopHeadersStrippedForH2cBackend}: a chunked ({@code Transfer-Encoding})
      * request body proxied to the backend. {@code Transfer-Encoding} is connection-specific and forbidden in
      * HTTP/2 (RFC 9113 §8.2.2), yet — unlike {@code Connection}/{@code Keep-Alive} — it is intentionally NOT
      * in the hop-by-hop strip set, because removing it would break HTTP/1.1 chunked proxying (it carries the
@@ -211,7 +207,7 @@ public class Http2HeadersIT {
      * negotiates HTTP/1.1 to the backend here, where forwarding {@code Transfer-Encoding} is correct.)
      */
     @Test
-    public void testChunkedRequestBodyForwardedToH2cBackend() throws IOException, ConfigurationNotValidException, InterruptedException {
+    void chunkedRequestBodyForwardedToH2cBackend() throws Exception {
         final AtomicReference<HttpHeaders> capturedRequestHeaders = new AtomicReference<>();
         final DisposableServer h2cBackend = HttpServer.create()
                 .host("localhost")
@@ -242,10 +238,10 @@ public class Http2HeadersIT {
             }
             // The concern was that a forwarded Transfer-Encoding could trip the encoder (RFC 9113 §8.2.2) and 503;
             // the request must instead complete normally.
-            assertThat(response, is(notNullValue()));
-            assertThat(response.status(), is(HttpResponseStatus.OK));
+            assertThat(response).isNotNull();
+            assertThat(response.status()).isEqualTo(HttpResponseStatus.OK);
             // The chunked request reached the backend — forwarding Transfer-Encoding did not break the hop.
-            assertThat(capturedRequestHeaders.get(), is(notNullValue()));
+            assertThat(capturedRequestHeaders.get()).isNotNull();
         } finally {
             h2cBackend.disposeNow();
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/core/Http2IT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/Http2IT.java
@@ -6,6 +6,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.Options.DYNAMIC_PORT;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_FORWARDED_STRATEGY;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_KEEP_ALIVE;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_KEEP_ALIVE_COUNT;
@@ -14,8 +15,6 @@ import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAU
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_MAX_KEEP_ALIVE_REQUESTS;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SO_BACKLOG;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.netty.channel.group.DefaultChannelGroup;
@@ -26,7 +25,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.carapaceproxy.utils.TestEndpointMapper;
 import org.junit.jupiter.api.io.TempDir;
@@ -58,7 +56,7 @@ public class Http2IT {
 
     @ParameterizedTest(name = "Client: {0}, Carapace conf: {1}, using cache: {2}")
     @MethodSource("data")
-    public void test(final HttpProtocol protocol, final Set<HttpProtocol> carapaceProtocols, final boolean withCache) throws IOException, ConfigurationNotValidException, InterruptedException {
+    void test(final HttpProtocol protocol, final Set<HttpProtocol> carapaceProtocols, final boolean withCache) throws Exception {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(HttpResponseStatus.OK.code())
@@ -88,9 +86,9 @@ public class Http2IT {
 
             server.start();
             final var port = server.getLocalPort();
-            assertThat(executeRequest(protocol, port), is(RESPONSE));
+            assertThat(executeRequest(protocol, port)).isEqualTo(RESPONSE);
             if (withCache) {
-                assertThat(executeRequest(protocol, port), is(RESPONSE));
+                assertThat(executeRequest(protocol, port)).isEqualTo(RESPONSE);
             }
         }
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/core/HttpProtocolAndSSLIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/HttpProtocolAndSSLIT.java
@@ -5,9 +5,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.okForContentType;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -107,7 +105,7 @@ public class HttpProtocolAndSSLIT {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("scenarios")
-    public void testMatrixCase(final Scenario scenario) throws Exception {
+    void matrixCase(final Scenario scenario) throws Exception {
         final AtomicReference<String> channelIdRef = new AtomicReference<>();
         final AtomicBoolean allSameConnection = new AtomicBoolean(true);
         final WireMockConfiguration cfg = WireMockConfiguration.options();
@@ -188,7 +186,7 @@ public class HttpProtocolAndSSLIT {
                     .aggregate()
                     .asString()
                     .block();
-            assertEquals(RESPONSE, htmlBody);
+            assertThat(htmlBody).isEqualTo(RESPONSE);
 
             final int jsFiles = 5;
             final int cssFiles = 5;
@@ -211,17 +209,14 @@ public class HttpProtocolAndSSLIT {
                     .collectList()
                     .block();
 
-            assertNotNull(allBodies);
-            assertEquals(jsFiles + cssFiles, allBodies.size());
+            assertThat(allBodies)
+                    .hasSize(jsFiles + cssFiles);
             for (String body : allBodies) {
-                assertNotNull(body);
-                assertTrue(body.length() > 10_000, "Body too small");
+                assertThat(body).isNotNull();
+                assertThat(body).as("Body too small").hasSizeGreaterThan(10_000);
             }
             if (scenario.proxyHttp2()) {
-                assertTrue(
-                        allSameConnection.get(),
-                        "HTTP/2 requests must be multiplexed over a single TCP connection " + channelIdRef.get()
-                );
+                assertThat(allSameConnection.get()).as("HTTP/2 requests must be multiplexed over a single TCP connection " + channelIdRef.get()).isTrue();
             }
         } finally {
             backendRule.stop();

--- a/carapace-server/src/test/java/org/carapaceproxy/core/HttpProtocolAndSSLIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/HttpProtocolAndSSLIT.java
@@ -212,7 +212,6 @@ public class HttpProtocolAndSSLIT {
             assertThat(allBodies)
                     .hasSize(jsFiles + cssFiles);
             for (String body : allBodies) {
-                assertThat(body).isNotNull();
                 assertThat(body).as("Body too small").hasSizeGreaterThan(10_000);
             }
             if (scenario.proxyHttp2()) {

--- a/carapace-server/src/test/java/org/carapaceproxy/core/JettyHttpTraceMethodIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/JettyHttpTraceMethodIT.java
@@ -1,6 +1,6 @@
 package org.carapaceproxy.core;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.netty.handler.codec.http.HttpMethod;
 import java.net.HttpURLConnection;
@@ -10,16 +10,16 @@ import javax.servlet.http.HttpServletResponse;
 import org.carapaceproxy.api.UseAdminServer;
 import org.junit.jupiter.api.Test;
 
-public class JettyHttpTraceMethodIT extends UseAdminServer {
+class JettyHttpTraceMethodIT extends UseAdminServer {
 
     @Test
-    public void httpTraceMethodTest() throws Exception {
+    void httpTraceMethodTest() throws Exception {
         startAdmin();
         String URL = "http://localhost:8761";
         URL url = URI.create(URL).toURL();
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.setRequestMethod(String.valueOf(HttpMethod.TRACE));
         int code = conn.getResponseCode();
-        assertEquals(HttpServletResponse.SC_FORBIDDEN, code);
+        assertThat(code).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/core/MaxHeaderSizeIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/MaxHeaderSizeIT.java
@@ -4,7 +4,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -24,7 +24,7 @@ public class MaxHeaderSizeIT extends UseAdminServer {
     public WireMockExtension wireMockRule = WireMockExtension.newInstance().configureStaticDsl(true).options(WireMockConfiguration.options().port(0)).build();
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -84,7 +84,7 @@ public class MaxHeaderSizeIT extends UseAdminServer {
 
         try (final HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build()) {
             final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            assertEquals(200, response.statusCode());
+            assertThat(response.statusCode()).isEqualTo(200);
         }
 
         config.put("carapace.maxheadersize", "1");
@@ -92,7 +92,7 @@ public class MaxHeaderSizeIT extends UseAdminServer {
 
         try (final HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build()) {
             final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            assertEquals(431, response.statusCode());
+            assertThat(response.statusCode()).isEqualTo(431);
         }
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/core/RequestsLoggerIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/RequestsLoggerIT.java
@@ -521,7 +521,7 @@ public class RequestsLoggerIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 assertThat(s).contains("it <b>works</b> !!");
-                assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
+                assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
@@ -529,14 +529,14 @@ public class RequestsLoggerIT {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     String s = resp.toString();
                     assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
 
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     String s = resp.toString();
                     assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
             }
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/core/RequestsLoggerIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/RequestsLoggerIT.java
@@ -23,10 +23,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -72,7 +69,7 @@ public class RequestsLoggerIT {
     public File tmpDir;
 
     @BeforeEach
-    public void before() {
+    void before() {
         accessLogFilePath = tmpDir.getAbsolutePath() + "/access.log";
     }
 
@@ -145,7 +142,7 @@ public class RequestsLoggerIT {
     }
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
 
         final int FLUSH_WAIT_TIME = 150;
 
@@ -157,17 +154,17 @@ public class RequestsLoggerIT {
         reqLogger.setVerbose(DEBUG);
         reqLogger.setBreakRunForTests(true);
 
-        assertThat((new File(accessLogFilePath)).isFile(), is(false));
+        assertThat((new File(accessLogFilePath)).isFile()).isFalse();
 
         // Wait without a request to log
         {
             long startts = System.currentTimeMillis();
             run(reqLogger);
-            assertTrue((System.currentTimeMillis() - startts) >= FLUSH_WAIT_TIME);
+            assertThat(System.currentTimeMillis() - startts).isGreaterThanOrEqualTo(FLUSH_WAIT_TIME);
         }
 
-        assertThat((new File(accessLogFilePath)).isFile(), is(true));
-        assertThat(readFile(accessLogFilePath).size(), is(0));
+        assertThat((new File(accessLogFilePath)).isFile()).isTrue();
+        assertThat(readFile(accessLogFilePath)).isEmpty();
 
         {
             // Request to log 1
@@ -195,15 +192,14 @@ public class RequestsLoggerIT {
 
             long startts = System.currentTimeMillis();
             run(reqLogger);
-            assertTrue((System.currentTimeMillis() - startts) < FLUSH_WAIT_TIME);
+            assertThat(System.currentTimeMillis() - startts).isLessThan(FLUSH_WAIT_TIME);
 
             reqLogger.flushAccessLogFile();
 
             List<String> rows1 = readFile(accessLogFilePath);
-            assertThat(rows1.size(), is(1));
-            assertThat(rows1.get(0), is(
-                    "[2018-10-23 10:10:10.000] [GET thehost /index.html] [uid:uid_1, sid:sid_1, ip:123.123.123.123] "
-                    + "server=234.234.234.234, act=CACHE, route=routeid_1, backend=host:1111. time t=1012ms b=542ms, protocol=" + HttpVersion.HTTP_1_1));
+            assertThat(rows1).hasSize(1);
+            assertThat(rows1.get(0)).isEqualTo("[2018-10-23 10:10:10.000] [GET thehost /index.html] [uid:uid_1, sid:sid_1, ip:123.123.123.123] "
+                    + "server=234.234.234.234, act=CACHE, route=routeid_1, backend=host:1111. time t=1012ms b=542ms, protocol=" + HttpVersion.HTTP_1_1);
 
             // Request to log 2. Let's wait 100ms before do the request and check if flush will be done within the
             // initial FLUSH_WAIT_TIME ms timeframe
@@ -232,25 +228,24 @@ public class RequestsLoggerIT {
             reqLogger.logRequest(createMockRequestHandler(r2));
 
             run(reqLogger);
-            assertTrue((System.currentTimeMillis() - startts) < FLUSH_WAIT_TIME);
+            assertThat(System.currentTimeMillis() - startts).isLessThan(FLUSH_WAIT_TIME);
 
             // No flush here. The new line should not have been flushed yet
             //reqLogger.flushAccessLogFile();
             List<String> rows2 = readFile(accessLogFilePath);
-            assertThat(rows2.size(), is(1));
+            assertThat(rows2).hasSize(1);
 
             // This run will wait until flush time is over and than flush
             long startts2 = System.currentTimeMillis();
             run(reqLogger);
-            assertTrue((System.currentTimeMillis() - startts) >= FLUSH_WAIT_TIME);
-            assertTrue((System.currentTimeMillis() - startts2) < FLUSH_WAIT_TIME); // should discount the splept 100ms
+            assertThat(System.currentTimeMillis() - startts).isGreaterThanOrEqualTo(FLUSH_WAIT_TIME);
+            assertThat(System.currentTimeMillis() - startts2).isLessThan(FLUSH_WAIT_TIME); // should discount the splept 100ms
 
             //reqLogger.flushAccessLogFile();
             List<String> rows3 = readFile(accessLogFilePath);
-            assertThat(rows3.size(), is(2));
-            assertThat(rows3.get(1), is(
-                    "[2018-10-23 11:10:10.000] [POST thehost2 /index2.html] [uid:uid_2, sid:sid_2, ip:111.123.123.123] "
-                    + "server=111.234.234.234, act=PROXY, route=routeid_2, backend=host2:2222. time t=912ms b=142ms, protocol=" + HttpVersion.HTTP_1_1));
+            assertThat(rows3).hasSize(2);
+            assertThat(rows3.get(1)).isEqualTo("[2018-10-23 11:10:10.000] [POST thehost2 /index2.html] [uid:uid_2, sid:sid_2, ip:111.123.123.123] "
+                    + "server=111.234.234.234, act=PROXY, route=routeid_2, backend=host2:2222. time t=912ms b=142ms, protocol=" + HttpVersion.HTTP_1_1);
         }
 
         // Hot configuration reload
@@ -288,15 +283,14 @@ public class RequestsLoggerIT {
 
             long startts = System.currentTimeMillis();
             run(reqLogger);
-            assertTrue((System.currentTimeMillis() - startts) < FLUSH_WAIT_TIME);
+            assertThat(System.currentTimeMillis() - startts).isLessThan(FLUSH_WAIT_TIME);
 
             reqLogger.flushAccessLogFile();
 
             List<String> rows1 = readFile(accessLogFilePath);
-            assertThat(rows1.size(), is(3));
-            assertThat(rows1.get(2), is(
-                    "[2018-10-23 10:10:10.000] [GET thehost /index.html] [uid:uid_1, sid:sid_1, ip:123.123.123.123] "
-                    + "server=234.234.234.234, act=CACHE, route=routeid_1, backend=host:1111. time t=1012ms b=542ms, protocol=" + HttpVersion.HTTP_1_1));
+            assertThat(rows1).hasSize(3);
+            assertThat(rows1.get(2)).isEqualTo("[2018-10-23 10:10:10.000] [GET thehost /index.html] [uid:uid_1, sid:sid_1, ip:123.123.123.123] "
+                    + "server=234.234.234.234, act=CACHE, route=routeid_1, backend=host:1111. time t=1012ms b=542ms, protocol=" + HttpVersion.HTTP_1_1);
 
             // This request will be taken in with the new conf
             MockProxyRequest r2 = new MockProxyRequest();
@@ -320,14 +314,13 @@ public class RequestsLoggerIT {
             reqLogger.logRequest(createMockRequestHandler(r2));
 
             run(reqLogger);
-            assertTrue((System.currentTimeMillis() - startts) < FLUSH_WAIT_TIME);
+            assertThat(System.currentTimeMillis() - startts).isLessThan(FLUSH_WAIT_TIME);
 
             reqLogger.flushAccessLogFile();
 
             List<String> rows2 = readFile(accessLogFilePath);
-            assertThat(rows2.size(), is(4));
-            assertThat(rows2.get(3), is(
-                    "[2018-10-23 10:10] [GET thehost /index.html]"));
+            assertThat(rows2).hasSize(4);
+            assertThat(rows2.get(3)).isEqualTo("[2018-10-23 10:10] [GET thehost /index.html]");
         }
 
         // Access log writing issues test
@@ -367,11 +360,11 @@ public class RequestsLoggerIT {
             // This run will try to create the new file but it will fail and wait WAIT_TIME_BETWEEN_FAILURES
             long startts = System.currentTimeMillis();
             run(reqLogger);
-            assertTrue((System.currentTimeMillis() - startts) >= WAIT_TIME_BETWEEN_FAILURES);
+            assertThat(System.currentTimeMillis() - startts).isGreaterThanOrEqualTo(WAIT_TIME_BETWEEN_FAILURES);
 
             // reqLogger.flushAccessLogFile();
             List<String> rows1 = readFile(accessLogFilePath);
-            assertThat(rows1.size(), is(4));
+            assertThat(rows1).hasSize(4);
 
             // Other 2 requests. Only r1 and r2 will be retained (max queue capacity = 2). r3 should be discarded
             MockProxyRequest r2 = new MockProxyRequest();
@@ -430,15 +423,13 @@ public class RequestsLoggerIT {
             run(reqLogger); // r1
             run(reqLogger); // r2
             run(reqLogger); // r3 should be missing, it will wait for flush times
-            assertTrue((System.currentTimeMillis() - startts2) >= FLUSH_WAIT_TIME - (startts2 - startts)); // needs a little more tolerance
+            assertThat(System.currentTimeMillis() - startts2).isGreaterThanOrEqualTo(FLUSH_WAIT_TIME - (startts2 - startts)); // needs a little more tolerance
 
             //reqLogger.flushAccessLogFile();
             List<String> rows2 = readFile(accessLogFilePath);
-            assertThat(rows2.size(), is(4 + 2));
-            assertThat(rows2.get(4), is(
-                    "[2018-10-23 11:10] [GET thehost /index1.html]"));
-            assertThat(rows2.get(5), is(
-                    "[2018-10-23 11:10] [GET thehost /index2.html]"));
+            assertThat(rows2).hasSize(4 + 2);
+            assertThat(rows2.get(4)).isEqualTo("[2018-10-23 11:10] [GET thehost /index1.html]");
+            assertThat(rows2.get(5)).isEqualTo("[2018-10-23 11:10] [GET thehost /index2.html]");
         }
 
         // Closing RequestLogger
@@ -492,27 +483,26 @@ public class RequestsLoggerIT {
             // First cycle will write r1
             long startts = System.currentTimeMillis();
             run(reqLogger);
-            assertTrue((System.currentTimeMillis() - startts) < FLUSH_WAIT_TIME);
+            assertThat(System.currentTimeMillis() - startts).isLessThan(FLUSH_WAIT_TIME);
 
             reqLogger.flushAccessLogFile();
 
             List<String> rows1 = readFile(accessLogFilePath);
-            assertThat(rows1.size(), is(6 + 1));
-            assertThat(rows1.get(6), is(
-                    "[2018-10-23 10:10] [GET thehost /index1.html]"));
+            assertThat(rows1).hasSize(6 + 1);
+            assertThat(rows1.get(6)).isEqualTo("[2018-10-23 10:10] [GET thehost /index1.html]");
 
             // Second cycle should close the file and return immediatly
             run(reqLogger);
-            assertTrue((System.currentTimeMillis() - startts) < FLUSH_WAIT_TIME);
+            assertThat(System.currentTimeMillis() - startts).isLessThan(FLUSH_WAIT_TIME);
 
             List<String> rows2 = readFile(accessLogFilePath);
-            assertThat(rows2.size(), is(7));
+            assertThat(rows2).hasSize(7);
         }
 
     }
 
     @Test
-    public void testWithServer() throws Exception {
+    void withServer() throws Exception {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -530,23 +520,23 @@ public class RequestsLoggerIT {
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
-                assertTrue(s.contains("it <b>works</b> !!"));
-                assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                assertThat(s).contains("it <b>works</b> !!");
+                assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     String s = resp.toString();
-                    assertTrue(s.contains("it <b>works</b> !!"));
-                    assertTrue(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertThat(s).contains("it <b>works</b> !!");
+                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
                 }
 
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     String s = resp.toString();
-                    assertTrue(s.contains("it <b>works</b> !!"));
-                    assertTrue(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertThat(s).contains("it <b>works</b> !!");
+                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
                 }
             }
         }
@@ -555,7 +545,7 @@ public class RequestsLoggerIT {
     }
 
     @Test
-    public void testAccessLogRotation() throws Exception {
+    void accessLogRotation() throws Exception {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -577,33 +567,33 @@ public class RequestsLoggerIT {
                     try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                         RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                         String s = resp.toString();
-                        assertTrue(s.contains("it <b>works</b> !!"));
+                        assertThat(s).contains("it <b>works</b> !!");
                     }
 
                     try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                         {
                             RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                             String s = resp.toString();
-                            assertTrue(s.contains("it <b>works</b> !!"));
+                            assertThat(s).contains("it <b>works</b> !!");
                         }
 
                         {
                             RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                             String s = resp.toString();
-                            assertTrue(s.contains("it <b>works</b> !!"));
+                            assertThat(s).contains("it <b>works</b> !!");
                         }
                     }
                 }
                 Thread.sleep(3000);
                 //check if gzip file exist
                 File[] f = new File(tmpDir.getAbsolutePath()).listFiles((dir, name) -> name.startsWith("access") && name.contains(".gzip"));
-                assertTrue(f.length == 1);
+                assertThat(f).hasSize(1);
                 try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                     String s = resp.toString();
-                    assertTrue(s.contains("it <b>works</b> !!"));
+                    assertThat(s).contains("it <b>works</b> !!");
                 }
-                assertTrue(logFileChannel.size() > 0);
+                assertThat(logFileChannel.size()).isGreaterThan(0);
             }
         }
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/core/RequestsLoggerIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/RequestsLoggerIT.java
@@ -197,8 +197,7 @@ public class RequestsLoggerIT {
             reqLogger.flushAccessLogFile();
 
             List<String> rows1 = readFile(accessLogFilePath);
-            assertThat(rows1).hasSize(1);
-            assertThat(rows1.get(0)).isEqualTo("[2018-10-23 10:10:10.000] [GET thehost /index.html] [uid:uid_1, sid:sid_1, ip:123.123.123.123] "
+            assertThat(rows1).containsExactly("[2018-10-23 10:10:10.000] [GET thehost /index.html] [uid:uid_1, sid:sid_1, ip:123.123.123.123] "
                     + "server=234.234.234.234, act=CACHE, route=routeid_1, backend=host:1111. time t=1012ms b=542ms, protocol=" + HttpVersion.HTTP_1_1);
 
             // Request to log 2. Let's wait 100ms before do the request and check if flush will be done within the
@@ -244,7 +243,7 @@ public class RequestsLoggerIT {
             //reqLogger.flushAccessLogFile();
             List<String> rows3 = readFile(accessLogFilePath);
             assertThat(rows3).hasSize(2);
-            assertThat(rows3.get(1)).isEqualTo("[2018-10-23 11:10:10.000] [POST thehost2 /index2.html] [uid:uid_2, sid:sid_2, ip:111.123.123.123] "
+            assertThat(rows3).element(1).isEqualTo("[2018-10-23 11:10:10.000] [POST thehost2 /index2.html] [uid:uid_2, sid:sid_2, ip:111.123.123.123] "
                     + "server=111.234.234.234, act=PROXY, route=routeid_2, backend=host2:2222. time t=912ms b=142ms, protocol=" + HttpVersion.HTTP_1_1);
         }
 
@@ -289,7 +288,7 @@ public class RequestsLoggerIT {
 
             List<String> rows1 = readFile(accessLogFilePath);
             assertThat(rows1).hasSize(3);
-            assertThat(rows1.get(2)).isEqualTo("[2018-10-23 10:10:10.000] [GET thehost /index.html] [uid:uid_1, sid:sid_1, ip:123.123.123.123] "
+            assertThat(rows1).element(2).isEqualTo("[2018-10-23 10:10:10.000] [GET thehost /index.html] [uid:uid_1, sid:sid_1, ip:123.123.123.123] "
                     + "server=234.234.234.234, act=CACHE, route=routeid_1, backend=host:1111. time t=1012ms b=542ms, protocol=" + HttpVersion.HTTP_1_1);
 
             // This request will be taken in with the new conf
@@ -320,7 +319,7 @@ public class RequestsLoggerIT {
 
             List<String> rows2 = readFile(accessLogFilePath);
             assertThat(rows2).hasSize(4);
-            assertThat(rows2.get(3)).isEqualTo("[2018-10-23 10:10] [GET thehost /index.html]");
+            assertThat(rows2).element(3).isEqualTo("[2018-10-23 10:10] [GET thehost /index.html]");
         }
 
         // Access log writing issues test
@@ -428,8 +427,8 @@ public class RequestsLoggerIT {
             //reqLogger.flushAccessLogFile();
             List<String> rows2 = readFile(accessLogFilePath);
             assertThat(rows2).hasSize(4 + 2);
-            assertThat(rows2.get(4)).isEqualTo("[2018-10-23 11:10] [GET thehost /index1.html]");
-            assertThat(rows2.get(5)).isEqualTo("[2018-10-23 11:10] [GET thehost /index2.html]");
+            assertThat(rows2).element(4).isEqualTo("[2018-10-23 11:10] [GET thehost /index1.html]");
+            assertThat(rows2).element(5).isEqualTo("[2018-10-23 11:10] [GET thehost /index2.html]");
         }
 
         // Closing RequestLogger
@@ -489,7 +488,7 @@ public class RequestsLoggerIT {
 
             List<String> rows1 = readFile(accessLogFilePath);
             assertThat(rows1).hasSize(6 + 1);
-            assertThat(rows1.get(6)).isEqualTo("[2018-10-23 10:10] [GET thehost /index1.html]");
+            assertThat(rows1).element(6).isEqualTo("[2018-10-23 10:10] [GET thehost /index1.html]");
 
             // Second cycle should close the file and return immediatly
             run(reqLogger);

--- a/carapace-server/src/test/java/org/carapaceproxy/core/RuntimeServerConfigurationTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/RuntimeServerConfigurationTest.java
@@ -19,15 +19,11 @@
  */
 package org.carapaceproxy.core;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.carapaceproxy.server.config.AcmeProviderConfiguration.DEFAULT_PROVIDER_NAME;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Properties;
 import org.carapaceproxy.configstore.PropertiesConfigurationStore;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
@@ -38,7 +34,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 /**
  * Tests for the {@code acme.<n>.*} provider family and the {@code certificate.<n>.provider} property.
  */
-public class RuntimeServerConfigurationTest {
+class RuntimeServerConfigurationTest {
 
     private static RuntimeServerConfiguration configure(String... keyValues) throws ConfigurationNotValidException {
         final var props = new Properties();
@@ -51,93 +47,91 @@ public class RuntimeServerConfigurationTest {
     }
 
     @Test
-    public void testEmptyConfigurationYieldsValidDefaults() throws Exception {
+    void emptyConfigurationYieldsValidDefaults() throws Exception {
         final var conf = configure();
 
-        assertEquals(8192, conf.getMaxHeaderSize());
-        assertEquals(60000, conf.getIdleTimeout());
-        assertEquals(100000, conf.getMaxLifeTime());
-        assertEquals(300000, conf.getDisposeTimeout());
-        assertEquals(5000, conf.getHealthConnectTimeout());
-        assertEquals(30000L, conf.getWarmupPeriod());
-        assertEquals("yyyy-MM-dd HH:mm:ss.SSS", conf.getAccessLogTimestampFormat());
-        assertTrue(conf.getListeners().isEmpty());
-        assertTrue(conf.getCertificates().isEmpty());
+        assertThat(conf.getMaxHeaderSize()).isEqualTo(8192);
+        assertThat(conf.getIdleTimeout()).isEqualTo(60000);
+        assertThat(conf.getMaxLifeTime()).isEqualTo(100000);
+        assertThat(conf.getDisposeTimeout()).isEqualTo(300000);
+        assertThat(conf.getHealthConnectTimeout()).isEqualTo(5000);
+        assertThat(conf.getWarmupPeriod()).isEqualTo(30000L);
+        assertThat(conf.getAccessLogTimestampFormat()).isEqualTo("yyyy-MM-dd HH:mm:ss.SSS");
+        assertThat(conf.getListeners()).isEmpty();
+        assertThat(conf.getCertificates()).isEmpty();
     }
 
     @ParameterizedTest
     @CsvSource({
-        "connectionsmanager.idletimeout, 0",
-        "connectionsmanager.maxlifetime, 0",
-        "carapace.maxheadersize, 0",
-        "healthmanager.connecttimeout, -1"
+            "connectionsmanager.idletimeout, 0",
+            "connectionsmanager.maxlifetime, 0",
+            "carapace.maxheadersize, 0",
+            "healthmanager.connecttimeout, -1"
     })
-    public void testRejectsNonPositiveNumericConfig(String key, String value) {
-        assertThrows(ConfigurationNotValidException.class, () -> configure(key, value));
+    void rejectsNonPositiveNumericConfig(String key, String value) {
+        assertThatThrownBy(() -> configure(key, value)).isInstanceOf(ConfigurationNotValidException.class);
     }
 
     @Test
-    public void testRejectsNonNumericIntValue() {
-        assertThrows(ConfigurationNotValidException.class,
-                () -> configure("connectionsmanager.disposetimeout", "abc"));
+    void rejectsNonNumericIntValue() {
+        assertThatThrownBy(() -> configure("connectionsmanager.disposetimeout", "abc")).isInstanceOf(ConfigurationNotValidException.class);
     }
 
     @Test
-    public void testRejectsInvalidAccessLogTimestampFormat() {
-        assertThrows(ConfigurationNotValidException.class,
-                () -> configure("accesslog.format.timestamp", "'unterminated"));
+    void rejectsInvalidAccessLogTimestampFormat() {
+        assertThatThrownBy(() -> configure("accesslog.format.timestamp", "'unterminated")).isInstanceOf(ConfigurationNotValidException.class);
     }
 
     @Test
-    public void testRejectsNonWritableLocalCertificatesStorePath() {
-        assertThrows(ConfigurationNotValidException.class, () -> configure(
-                "dynamiccertificatesmanager.localcertificates.store.path", "/nonexistent-carapace-test-dir/certs"));
+    void rejectsNonWritableLocalCertificatesStorePath() {
+        assertThatThrownBy(() -> configure(
+                "dynamiccertificatesmanager.localcertificates.store.path", "/nonexistent-carapace-test-dir/certs")).isInstanceOf(ConfigurationNotValidException.class);
     }
 
     @Test
-    public void testRejectsInvalidCertificateMode() {
-        assertThrows(ConfigurationNotValidException.class, () -> configure(
+    void rejectsInvalidCertificateMode() {
+        assertThatThrownBy(() -> configure(
                 "certificate.0.hostname", "example.com",
-                "certificate.0.mode", "badmode"));
+                "certificate.0.mode", "badmode")).isInstanceOf(ConfigurationNotValidException.class);
     }
 
     @Test
-    public void testRejectsConnectionPoolWithEmptyDomain() {
-        assertThrows(ConfigurationNotValidException.class, () -> configure(
+    void rejectsConnectionPoolWithEmptyDomain() {
+        assertThatThrownBy(() -> configure(
                 "connectionpool.0.id", "p0",
                 "connectionpool.0.enabled", "true",
-                "connectionpool.0.domain", ""));
+                "connectionpool.0.domain", "")).isInstanceOf(ConfigurationNotValidException.class);
     }
 
     @Test
-    public void testRejectsUnknownFilterType() {
-        assertThrows(ConfigurationNotValidException.class, () -> configure("filter.0.type", "badtype"));
+    void rejectsUnknownFilterType() {
+        assertThatThrownBy(() -> configure("filter.0.type", "badtype")).isInstanceOf(ConfigurationNotValidException.class);
     }
 
     @Test
-    public void testRejectsSslListenerWithoutDefaultCertificate() {
-        assertThrows(ConfigurationNotValidException.class, () -> configure(
+    void rejectsSslListenerWithoutDefaultCertificate() {
+        assertThatThrownBy(() -> configure(
                 "listener.0.port", "8080",
-                "listener.0.ssl", "true"));
+                "listener.0.ssl", "true")).isInstanceOf(ConfigurationNotValidException.class);
     }
 
     @Test
-    public void testRejectsInvalidListenerProtocol() {
+    void rejectsInvalidListenerProtocol() {
         // Regression: an unknown protocol used to escape as a raw IllegalArgumentException.
-        assertThrows(ConfigurationNotValidException.class, () -> configure(
+        assertThatThrownBy(() -> configure(
                 "listener.0.port", "8080",
-                "listener.0.protocol", "BADPROTO"));
+                "listener.0.protocol", "BADPROTO")).isInstanceOf(ConfigurationNotValidException.class);
     }
 
     @Test
-    public void testAcceptsValidListenerProtocol() {
-        assertDoesNotThrow(() -> configure(
+    void acceptsValidListenerProtocol() {
+        assertThatCode(() -> configure(
                 "listener.0.port", "8080",
-                "listener.0.protocol", "H2C"));
+                "listener.0.protocol", "H2C")).doesNotThrowAnyException();
     }
 
     @Test
-    public void testConfigureAcmeProviders() throws Exception {
+    void configureAcmeProviders() throws Exception {
         final var config = configure(
                 "acme.1.name", "digicert",
                 "acme.1.url", "https://acme.digicert.com/v2/acme/directory",
@@ -146,144 +140,144 @@ public class RuntimeServerConfigurationTest {
                 "acme.2.name", "pebble",
                 "acme.2.url", "https://localhost:14000/dir"
         );
-        assertEquals(2, config.getAcmeProviders().size());
+        assertThat(config.getAcmeProviders()).hasSize(2);
 
         final var digicert = config.getAcmeProviders().get("digicert");
-        assertEquals("https://acme.digicert.com/v2/acme/directory", digicert.url());
-        assertEquals("my-kid", digicert.kid());
-        assertEquals("my-base64-hmac", digicert.hmac());
-        assertTrue(digicert.hasExternalAccountBinding());
-        assertThat(digicert.toString(), not(containsString(digicert.hmac()))); // the hmac is a secret
+        assertThat(digicert.url()).isEqualTo("https://acme.digicert.com/v2/acme/directory");
+        assertThat(digicert.kid()).isEqualTo("my-kid");
+        assertThat(digicert.hmac()).isEqualTo("my-base64-hmac");
+        assertThat(digicert.hasExternalAccountBinding()).isTrue();
+        assertThat(digicert.toString()).doesNotContain(digicert.hmac()); // the hmac is a secret
 
         final var pebble = config.getAcmeProviders().get("pebble");
-        assertEquals("https://localhost:14000/dir", pebble.url());
-        assertFalse(pebble.hasExternalAccountBinding());
+        assertThat(pebble.url()).isEqualTo("https://localhost:14000/dir");
+        assertThat(pebble.hasExternalAccountBinding()).isFalse();
     }
 
     @Test
-    public void testAcmeProviderWithoutNameIsSkipped() throws Exception {
+    void acmeProviderWithoutNameIsSkipped() throws Exception {
         final var config = configure("acme.1.url", "https://acme.example.com/directory");
-        assertTrue(config.getAcmeProviders().isEmpty());
+        assertThat(config.getAcmeProviders()).isEmpty();
     }
 
     @Test
-    public void testAcmeProviderReservedName() {
-        final var e = assertThrows(ConfigurationNotValidException.class, () -> configure(
+    void acmeProviderReservedName() {
+        final var e = assertThatExceptionOfType(ConfigurationNotValidException.class).isThrownBy(() -> configure(
                 "acme.1.name", DEFAULT_PROVIDER_NAME,
                 "acme.1.url", "https://acme.example.com/directory"
-        ));
-        assertThat(e.getMessage(), containsString("built-in"));
+        )).actual();
+        assertThat(e.getMessage()).contains("built-in");
     }
 
     @Test
-    public void testAcmeProviderInvalidName() {
-        final var e = assertThrows(ConfigurationNotValidException.class, () -> configure(
+    void acmeProviderInvalidName() {
+        final var e = assertThatExceptionOfType(ConfigurationNotValidException.class).isThrownBy(() -> configure(
                 "acme.1.name", "Not A Valid Name!",
                 "acme.1.url", "https://acme.example.com/directory"
-        ));
-        assertThat(e.getMessage(), containsString("acme.1.name"));
+        )).actual();
+        assertThat(e.getMessage()).contains("acme.1.name");
     }
 
     @Test
-    public void testAcmeProviderDuplicateName() {
-        final var e = assertThrows(ConfigurationNotValidException.class, () -> configure(
+    void acmeProviderDuplicateName() {
+        final var e = assertThatExceptionOfType(ConfigurationNotValidException.class).isThrownBy(() -> configure(
                 "acme.1.name", "digicert",
                 "acme.1.url", "https://acme.example.com/directory",
                 "acme.2.name", "digicert",
                 "acme.2.url", "https://acme.example.org/directory"
-        ));
-        assertThat(e.getMessage(), containsString("duplicate"));
+        )).actual();
+        assertThat(e.getMessage()).contains("duplicate");
     }
 
     @Test
-    public void testAcmeProviderMissingUrl() {
-        final var e = assertThrows(ConfigurationNotValidException.class, () -> configure(
+    void acmeProviderMissingUrl() {
+        final var e = assertThatExceptionOfType(ConfigurationNotValidException.class).isThrownBy(() -> configure(
                 "acme.1.name", "digicert"
-        ));
-        assertThat(e.getMessage(), containsString("url"));
+        )).actual();
+        assertThat(e.getMessage()).contains("url");
     }
 
     @Test
-    public void testAcmeProviderAcmeUriAccepted() throws Exception {
+    void acmeProviderAcmeUriAccepted() throws Exception {
         final var config = configure(
                 "acme.1.name", "pebble",
                 "acme.1.url", "acme://pebble"
         );
-        assertEquals("acme://pebble", config.getAcmeProviders().get("pebble").url());
+        assertThat(config.getAcmeProviders().get("pebble").url()).isEqualTo("acme://pebble");
     }
 
     @Test
-    public void testAcmeProviderUnknownAcmeUri() {
-        final var e = assertThrows(ConfigurationNotValidException.class, () -> configure(
+    void acmeProviderUnknownAcmeUri() {
+        final var e = assertThatExceptionOfType(ConfigurationNotValidException.class).isThrownBy(() -> configure(
                 "acme.1.name", "pebble",
                 "acme.1.url", "acme://pebbel" // typo: no such acme4j provider
-        ));
-        assertThat(e.getMessage(), containsString("acme.1.url"));
+        )).actual();
+        assertThat(e.getMessage()).contains("acme.1.url");
     }
 
     @Test
-    public void testAcmeProviderUppercaseSchemeRejected() {
+    void acmeProviderUppercaseSchemeRejected() {
         // acme4j resolves providers by exact scheme match, so accepting HTTPS:// at parse time
         // would only defer the failure to the first login attempt
-        final var e = assertThrows(ConfigurationNotValidException.class, () -> configure(
+        final var e = assertThatExceptionOfType(ConfigurationNotValidException.class).isThrownBy(() -> configure(
                 "acme.1.name", "digicert",
                 "acme.1.url", "HTTPS://acme.example.com/directory"
-        ));
-        assertThat(e.getMessage(), containsString("scheme"));
+        )).actual();
+        assertThat(e.getMessage()).contains("scheme");
     }
 
     @Test
-    public void testAcmeProviderMalformedUrl() {
-        final var e = assertThrows(ConfigurationNotValidException.class, () -> configure(
+    void acmeProviderMalformedUrl() {
+        final var e = assertThatExceptionOfType(ConfigurationNotValidException.class).isThrownBy(() -> configure(
                 "acme.1.name", "digicert",
                 "acme.1.url", "not a valid url"
-        ));
-        assertThat(e.getMessage(), containsString("acme.1.url"));
+        )).actual();
+        assertThat(e.getMessage()).contains("acme.1.url");
     }
 
     @Test
-    public void testAcmeProviderUnsupportedUrlScheme() {
+    void acmeProviderUnsupportedUrlScheme() {
         for (final var url : new String[]{"ftp://acme.example.com/directory", "http://acme.example.com/directory"}) {
-            final var e = assertThrows(ConfigurationNotValidException.class, () -> configure(
+            final var e = assertThatExceptionOfType(ConfigurationNotValidException.class).isThrownBy(() -> configure(
                     "acme.1.name", "digicert",
                     "acme.1.url", url
-            ));
-            assertThat(e.getMessage(), containsString("scheme"));
+            )).actual();
+            assertThat(e.getMessage()).contains("scheme");
         }
     }
 
     @Test
-    public void testAcmeProviderInvalidHmac() {
-        final var e = assertThrows(ConfigurationNotValidException.class, () -> configure(
+    void acmeProviderInvalidHmac() {
+        final var e = assertThatExceptionOfType(ConfigurationNotValidException.class).isThrownBy(() -> configure(
                 "acme.1.name", "digicert",
                 "acme.1.url", "https://acme.example.com/directory",
                 "acme.1.kid", "my-kid",
                 "acme.1.hmac", "not+valid/base64url!"
-        ));
-        assertThat(e.getMessage(), containsString("base64url"));
+        )).actual();
+        assertThat(e.getMessage()).contains("base64url");
     }
 
     @Test
-    public void testAcmeProviderKidWithoutHmac() {
-        final var e = assertThrows(ConfigurationNotValidException.class, () -> configure(
+    void acmeProviderKidWithoutHmac() {
+        final var e = assertThatExceptionOfType(ConfigurationNotValidException.class).isThrownBy(() -> configure(
                 "acme.1.name", "digicert",
                 "acme.1.url", "https://acme.example.com/directory",
                 "acme.1.kid", "my-kid"
-        ));
-        assertThat(e.getMessage(), containsString("hmac"));
+        )).actual();
+        assertThat(e.getMessage()).contains("hmac");
     }
 
     @Test
-    public void testCertificateDefaultProvider() throws Exception {
+    void certificateDefaultProvider() throws Exception {
         final var config = configure(
                 "certificate.0.hostname", "example.com",
                 "certificate.0.mode", "acme"
         );
-        assertEquals(DEFAULT_PROVIDER_NAME, config.getCertificates().get("example.com").getProvider());
+        assertThat(config.getCertificates().get("example.com").getProvider()).isEqualTo(DEFAULT_PROVIDER_NAME);
     }
 
     @Test
-    public void testCertificateWithCustomProvider() throws Exception {
+    void certificateWithCustomProvider() throws Exception {
         final var config = configure(
                 "acme.1.name", "digicert",
                 "acme.1.url", "https://acme.digicert.com/v2/acme/directory",
@@ -291,16 +285,16 @@ public class RuntimeServerConfigurationTest {
                 "certificate.0.mode", "acme",
                 "certificate.0.provider", "digicert"
         );
-        assertEquals("digicert", config.getCertificates().get("example.com").getProvider());
+        assertThat(config.getCertificates().get("example.com").getProvider()).isEqualTo("digicert");
     }
 
     @Test
-    public void testCertificateWithUnknownProvider() {
-        final var e = assertThrows(ConfigurationNotValidException.class, () -> configure(
+    void certificateWithUnknownProvider() {
+        final var e = assertThatExceptionOfType(ConfigurationNotValidException.class).isThrownBy(() -> configure(
                 "certificate.0.hostname", "example.com",
                 "certificate.0.mode", "acme",
                 "certificate.0.provider", "unknown"
-        ));
-        assertThat(e.getMessage(), containsString("certificate.0.provider"));
+        )).actual();
+        assertThat(e.getMessage()).contains("certificate.0.provider");
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/core/RuntimeServerConfigurationTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/RuntimeServerConfigurationTest.java
@@ -69,30 +69,36 @@ class RuntimeServerConfigurationTest {
             "healthmanager.connecttimeout, -1"
     })
     void rejectsNonPositiveNumericConfig(String key, String value) {
-        assertThatThrownBy(() -> configure(key, value)).isInstanceOf(ConfigurationNotValidException.class);
+        assertThatThrownBy(() -> configure(key, value)).isInstanceOf(ConfigurationNotValidException.class)
+                .hasMessageContaining("Invalid value '" + value + "' for " + key);
     }
 
     @Test
     void rejectsNonNumericIntValue() {
-        assertThatThrownBy(() -> configure("connectionsmanager.disposetimeout", "abc")).isInstanceOf(ConfigurationNotValidException.class);
+        assertThatThrownBy(() -> configure("connectionsmanager.disposetimeout", "abc")).isInstanceOf(ConfigurationNotValidException.class)
+                .hasMessageContaining("Invalid integer value 'abc' for parameter 'connectionsmanager.disposetimeout'");
     }
 
     @Test
     void rejectsInvalidAccessLogTimestampFormat() {
-        assertThatThrownBy(() -> configure("accesslog.format.timestamp", "'unterminated")).isInstanceOf(ConfigurationNotValidException.class);
+        assertThatThrownBy(() -> configure("accesslog.format.timestamp", "'unterminated")).isInstanceOf(ConfigurationNotValidException.class)
+                .hasMessageContaining("accesslog.format.timestamp")
+                .hasMessageContaining("Unterminated quote");
     }
 
     @Test
     void rejectsNonWritableLocalCertificatesStorePath() {
         assertThatThrownBy(() -> configure(
-                "dynamiccertificatesmanager.localcertificates.store.path", "/nonexistent-carapace-test-dir/certs")).isInstanceOf(ConfigurationNotValidException.class);
+                "dynamiccertificatesmanager.localcertificates.store.path", "/nonexistent-carapace-test-dir/certs")).isInstanceOf(ConfigurationNotValidException.class)
+                .hasMessageContaining("Cannot write local certificates to path");
     }
 
     @Test
     void rejectsInvalidCertificateMode() {
         assertThatThrownBy(() -> configure(
                 "certificate.0.hostname", "example.com",
-                "certificate.0.mode", "badmode")).isInstanceOf(ConfigurationNotValidException.class);
+                "certificate.0.mode", "badmode")).isInstanceOf(ConfigurationNotValidException.class)
+                .hasMessageContaining("Invalid value of 'badmode' for certificate.0.mode");
     }
 
     @Test
@@ -100,19 +106,23 @@ class RuntimeServerConfigurationTest {
         assertThatThrownBy(() -> configure(
                 "connectionpool.0.id", "p0",
                 "connectionpool.0.enabled", "true",
-                "connectionpool.0.domain", "")).isInstanceOf(ConfigurationNotValidException.class);
+                "connectionpool.0.domain", "")).isInstanceOf(ConfigurationNotValidException.class)
+                .hasMessageContaining("domain cannot be empty");
     }
 
     @Test
     void rejectsUnknownFilterType() {
-        assertThatThrownBy(() -> configure("filter.0.type", "badtype")).isInstanceOf(ConfigurationNotValidException.class);
+        assertThatThrownBy(() -> configure("filter.0.type", "badtype")).isInstanceOf(ConfigurationNotValidException.class)
+                .hasMessageContaining("bad filter type 'badtype'");
     }
 
     @Test
     void rejectsSslListenerWithoutDefaultCertificate() {
         assertThatThrownBy(() -> configure(
                 "listener.0.port", "8080",
-                "listener.0.ssl", "true")).isInstanceOf(ConfigurationNotValidException.class);
+                "listener.0.ssl", "true")).isInstanceOf(ConfigurationNotValidException.class)
+                .hasMessageContaining("ssl=true")
+                .hasMessageContaining("not configured");
     }
 
     @Test
@@ -120,7 +130,8 @@ class RuntimeServerConfigurationTest {
         // Regression: an unknown protocol used to escape as a raw IllegalArgumentException.
         assertThatThrownBy(() -> configure(
                 "listener.0.port", "8080",
-                "listener.0.protocol", "BADPROTO")).isInstanceOf(ConfigurationNotValidException.class);
+                "listener.0.protocol", "BADPROTO")).isInstanceOf(ConfigurationNotValidException.class)
+                .hasMessageContaining("Invalid value for listener.0.protocol, supported: HTTP11, H2, H2C");
     }
 
     @Test

--- a/carapace-server/src/test/java/org/carapaceproxy/core/RuntimeServerConfigurationTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/core/RuntimeServerConfigurationTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.carapaceproxy.server.config.AcmeProviderConfiguration.DEFAULT_PROVIDER_NAME;
 import java.util.Properties;
 import org.carapaceproxy.configstore.PropertiesConfigurationStore;
+import org.carapaceproxy.server.config.AcmeProviderConfiguration;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -154,14 +155,13 @@ class RuntimeServerConfigurationTest {
         assertThat(config.getAcmeProviders()).hasSize(2);
 
         final var digicert = config.getAcmeProviders().get("digicert");
-        assertThat(digicert.url()).isEqualTo("https://acme.digicert.com/v2/acme/directory");
-        assertThat(digicert.kid()).isEqualTo("my-kid");
-        assertThat(digicert.hmac()).isEqualTo("my-base64-hmac");
+        assertThat(digicert).isEqualTo(new AcmeProviderConfiguration(
+                "digicert", "https://acme.digicert.com/v2/acme/directory", "my-kid", "my-base64-hmac"));
         assertThat(digicert.hasExternalAccountBinding()).isTrue();
         assertThat(digicert.toString()).doesNotContain(digicert.hmac()); // the hmac is a secret
 
         final var pebble = config.getAcmeProviders().get("pebble");
-        assertThat(pebble.url()).isEqualTo("https://localhost:14000/dir");
+        assertThat(pebble).isEqualTo(new AcmeProviderConfiguration("pebble", "https://localhost:14000/dir", "", ""));
         assertThat(pebble.hasExternalAccountBinding()).isFalse();
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/listeners/ListenerConfigurationIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/listeners/ListenerConfigurationIT.java
@@ -1,8 +1,6 @@
 package org.carapaceproxy.listeners;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -23,7 +21,7 @@ public class ListenerConfigurationIT {
     public File tmpDir;
 
     @Test
-    public void testListenerKeepAliveConfiguration() throws Exception {
+    void listenerKeepAliveConfiguration() throws Exception {
         try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, tmpDir)) {
 
             {
@@ -42,12 +40,12 @@ public class ListenerConfigurationIT {
                 Map<EndpointKey, ListeningChannel> listeners = server.getListeners().getListeningChannels();
 
                 //check default configuration
-                assertTrue(listeners.get(listenerKey).getConfig().keepAlive());
-                assertEquals(128, listeners.get(listenerKey).getConfig().soBacklog());
-                assertEquals(300, listeners.get(listenerKey).getConfig().keepAliveIdle());
-                assertEquals(60, listeners.get(listenerKey).getConfig().keepAliveInterval());
-                assertEquals(8, listeners.get(listenerKey).getConfig().keepAliveCount());
-                assertEquals(1000, listeners.get(listenerKey).getConfig().maxKeepAliveRequests());
+                assertThat(listeners.get(listenerKey).getConfig().keepAlive()).isTrue();
+                assertThat(listeners.get(listenerKey).getConfig().soBacklog()).isEqualTo(128);
+                assertThat(listeners.get(listenerKey).getConfig().keepAliveIdle()).isEqualTo(300);
+                assertThat(listeners.get(listenerKey).getConfig().keepAliveInterval()).isEqualTo(60);
+                assertThat(listeners.get(listenerKey).getConfig().keepAliveCount()).isEqualTo(8);
+                assertThat(listeners.get(listenerKey).getConfig().maxKeepAliveRequests()).isEqualTo(1000);
             }
             //disable keepAlive
             {
@@ -61,8 +59,8 @@ public class ListenerConfigurationIT {
 
                 Map<EndpointKey, ListeningChannel> listeners = server.getListeners().getListeningChannels();
 
-                assertEquals(1, listeners.size());
-                assertFalse(listeners.get(listenerKey).getConfig().keepAlive());
+                assertThat(listeners).hasSize(1);
+                assertThat(listeners.get(listenerKey).getConfig().keepAlive()).isFalse();
             }
 
             //customize keepAlive options
@@ -82,12 +80,12 @@ public class ListenerConfigurationIT {
 
                 Map<EndpointKey, ListeningChannel> listeners = server.getListeners().getListeningChannels();
 
-                assertTrue(listeners.get(listenerKey).getConfig().keepAlive());
-                assertEquals(10, listeners.get(listenerKey).getConfig().soBacklog());
-                assertEquals(10, listeners.get(listenerKey).getConfig().keepAliveIdle());
-                assertEquals(5, listeners.get(listenerKey).getConfig().keepAliveInterval());
-                assertEquals(2, listeners.get(listenerKey).getConfig().keepAliveCount());
-                assertEquals(2, listeners.get(listenerKey).getConfig().maxKeepAliveRequests());
+                assertThat(listeners.get(listenerKey).getConfig().keepAlive()).isTrue();
+                assertThat(listeners.get(listenerKey).getConfig().soBacklog()).isEqualTo(10);
+                assertThat(listeners.get(listenerKey).getConfig().keepAliveIdle()).isEqualTo(10);
+                assertThat(listeners.get(listenerKey).getConfig().keepAliveInterval()).isEqualTo(5);
+                assertThat(listeners.get(listenerKey).getConfig().keepAliveCount()).isEqualTo(2);
+                assertThat(listeners.get(listenerKey).getConfig().maxKeepAliveRequests()).isEqualTo(2);
             }
 
             //negative maxkeepAliverequests
@@ -104,7 +102,7 @@ public class ListenerConfigurationIT {
                     reloadConfiguration(configuration, server);
 
                 } catch (IllegalArgumentException e) {
-                    assertTrue(e.getMessage().contains("maxKeepAliveRequests must be positive or -1"));
+                    assertThat(e.getMessage()).contains("maxKeepAliveRequests must be positive or -1");
                 }
             }
 
@@ -122,7 +120,7 @@ public class ListenerConfigurationIT {
                     reloadConfiguration(configuration, server);
 
                 } catch (IllegalArgumentException e) {
-                    assertTrue(e.getMessage().contains("maxKeepAliveRequests must be positive or -1"));
+                    assertThat(e.getMessage()).contains("maxKeepAliveRequests must be positive or -1");
                 }
             }
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/listeners/ListenerConfigurationIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/listeners/ListenerConfigurationIT.java
@@ -6,11 +6,13 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import org.carapaceproxy.configstore.PropertiesConfigurationStore;
 import org.carapaceproxy.core.EndpointKey;
 import org.carapaceproxy.core.HttpProxyServer;
 import org.carapaceproxy.core.ListeningChannel;
 import org.carapaceproxy.server.config.ConfigurationChangeInProgressException;
+import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.carapaceproxy.server.mapper.StandardEndpointMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -39,13 +41,18 @@ public class ListenerConfigurationIT {
             {
                 Map<EndpointKey, ListeningChannel> listeners = server.getListeners().getListeningChannels();
 
-                //check default configuration
-                assertThat(listeners.get(listenerKey).getConfig().keepAlive()).isTrue();
-                assertThat(listeners.get(listenerKey).getConfig().soBacklog()).isEqualTo(128);
-                assertThat(listeners.get(listenerKey).getConfig().keepAliveIdle()).isEqualTo(300);
-                assertThat(listeners.get(listenerKey).getConfig().keepAliveInterval()).isEqualTo(60);
-                assertThat(listeners.get(listenerKey).getConfig().keepAliveCount()).isEqualTo(8);
-                assertThat(listeners.get(listenerKey).getConfig().maxKeepAliveRequests()).isEqualTo(1000);
+                // a listener declared with host and port alone must come up on every default: group holds a
+                // live Netty channel group, and the three TLS components are filled in by the properties path
+                final NetworkListenerConfiguration config = listeners.get(listenerKey).getConfig();
+                assertThat(config)
+                        .usingRecursiveComparison()
+                        .ignoringFields("group", "defaultCertificate", "sslCiphers", "sslProtocols")
+                        .isEqualTo(NetworkListenerConfiguration.withDefault("localhost", 8080));
+                assertThat(config)
+                        .extracting(NetworkListenerConfiguration::defaultCertificate,
+                                NetworkListenerConfiguration::sslCiphers,
+                                NetworkListenerConfiguration::sslProtocols)
+                        .containsExactly("*", "", Set.of("TLSv1.2", "TLSv1.3"));
             }
             //disable keepAlive
             {

--- a/carapace-server/src/test/java/org/carapaceproxy/listeners/MultiListeningEndpointIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/listeners/MultiListeningEndpointIT.java
@@ -24,7 +24,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -53,7 +53,7 @@ public class MultiListeningEndpointIT {
     public File tmpDir;
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
 
         stubFor(get(urlEqualTo("/index.html?redir"))
                 .willReturn(aResponse()
@@ -73,13 +73,13 @@ public class MultiListeningEndpointIT {
             {
                 String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index.html?redir"), StandardCharsets.UTF_8);
                 System.out.println("s:" + s);
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
             }
 
             {
                 String s = IOUtils.toString(URI.create("http://localhost:" + port2 + "/index.html?redir"), StandardCharsets.UTF_8);
                 System.out.println("s:" + s);
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
             }
 
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/listeners/SSLSNIIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/listeners/SSLSNIIT.java
@@ -157,7 +157,6 @@ public class SSLSNIIT {
 
     private static String chooseCertId(final HttpProxyServer server, final String sniHostname, final String defaultCertificate) {
         final var certificate = chooseCert(server, sniHostname, defaultCertificate);
-        assertThat(certificate).isNotNull();
         return certificate.getId();
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/listeners/SSLSNIIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/listeners/SSLSNIIT.java
@@ -19,17 +19,15 @@
  */
 package org.carapaceproxy.listeners;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_FORWARDED_STRATEGY;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
 import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.STATIC;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static reactor.netty.http.HttpProtocol.HTTP11;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -62,7 +60,7 @@ public class SSLSNIIT {
     public File tmpDir;
 
     @Test
-    public void testSelectCertWithoutSNI() throws Exception {
+    void selectCertWithoutSNI() throws Exception {
 
         String nonLocalhost = InetAddress.getLocalHost().getCanonicalHostName();
 
@@ -85,7 +83,7 @@ public class SSLSNIIT {
 
             try (RawHttpClient client = new RawHttpClient(nonLocalhost, port, true, nonLocalhost)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
-                assertTrue(resp.toString().contains("it <b>works</b> !!"));
+                assertThat(resp.toString()).contains("it <b>works</b> !!");
                 X509Certificate cert = (X509Certificate) client.getSSLSocket().getSession().getPeerCertificates()[0];
                 System.out.println("acert2: " + cert.getSerialNumber());
             }
@@ -93,7 +91,7 @@ public class SSLSNIIT {
     }
 
     @Test
-    public void testChooseCertificate() throws Exception {
+    void chooseCertificate() throws Exception {
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.getPort(), true, false);
 
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir)) {
@@ -106,38 +104,38 @@ public class SSLSNIIT {
 
 
             // client requests bad SNI, bad default in listener
-            assertNull(chooseCert(server, "no", "no-default"));
+            assertThat(chooseCert(server, "no", "no-default")).isNull();
 
-            assertEquals("*.qatest.pexample.it", chooseCertId(server, "test2.qatest.pexample.it", "no-default"));
+            assertThat(chooseCertId(server, "test2.qatest.pexample.it", "no-default")).isEqualTo("*.qatest.pexample.it");
             // client requests SNI, bad default in listener
-            assertEquals("other", chooseCertId(server, "other", "no-default"));
+            assertThat(chooseCertId(server, "other", "no-default")).isEqualTo("other");
 
-            assertEquals("www.example.com", chooseCertId(server, "unkn-other", "www.example.com"));
+            assertThat(chooseCertId(server, "unkn-other", "www.example.com")).isEqualTo("www.example.com");
             // client without SNI
-            assertEquals("www.example.com", chooseCertId(server, null, "www.example.com"));
+            assertThat(chooseCertId(server, null, "www.example.com")).isEqualTo("www.example.com");
             // exact match
-            assertEquals("www.example.com", chooseCertId(server, "www.example.com", "no-default"));
+            assertThat(chooseCertId(server, "www.example.com", "no-default")).isEqualTo("www.example.com");
             // wildcard
-            assertEquals("*.example.com", chooseCertId(server, "test.example.com", "no-default"));
+            assertThat(chooseCertId(server, "test.example.com", "no-default")).isEqualTo("*.example.com");
             // san
-            assertEquals("*.example.com", chooseCertId(server, "example.com", "no-default"));
-            assertEquals("*.example.com", chooseCertId(server, "test.example2.com", "no-default"));
+            assertThat(chooseCertId(server, "example.com", "no-default")).isEqualTo("*.example.com");
+            assertThat(chooseCertId(server, "test.example2.com", "no-default")).isEqualTo("*.example.com");
 
             // full wildcard
             server.addCertificate(new SSLCertificateConfiguration("*", null, "cert", "pwd", STATIC));
             // full wildcard has not to hide more specific wildcard one
-            assertEquals("*.example.com", chooseCertId(server, "test.example.com", "no-default"));
+            assertThat(chooseCertId(server, "test.example.com", "no-default")).isEqualTo("*.example.com");
             // san
-            assertEquals("*.example.com", chooseCertId(server, "example.com", "no-default"));
-            assertEquals("*.example.com", chooseCertId(server, "test.example2.com", "no-default"));
+            assertThat(chooseCertId(server, "example.com", "no-default")).isEqualTo("*.example.com");
+            assertThat(chooseCertId(server, "test.example2.com", "no-default")).isEqualTo("*.example.com");
 
             // more specific wildcard
             server.addCertificate(new SSLCertificateConfiguration("*.test.example.com", null, "cert", "pwd", STATIC));
             // more specific wildcard has to hide less specific one (*.example.com)
-            assertEquals("*.test.example.com", chooseCertId(server, "pippo.test.example.com", "no-default"));
+            assertThat(chooseCertId(server, "pippo.test.example.com", "no-default")).isEqualTo("*.test.example.com");
             // san
-            assertEquals("*.example.com", chooseCertId(server, "example.com", "no-default"));
-            assertEquals("*.example.com", chooseCertId(server, "test.example2.com", "no-default"));
+            assertThat(chooseCertId(server, "example.com", "no-default")).isEqualTo("*.example.com");
+            assertThat(chooseCertId(server, "test.example2.com", "no-default")).isEqualTo("*.example.com");
         }
 
         try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir)) {
@@ -145,11 +143,11 @@ public class SSLSNIIT {
             // full wildcard
             server.addCertificate(new SSLCertificateConfiguration("*", null, "cert", "pwd", STATIC));
 
-            assertEquals("*", chooseCertId(server, null, "www.example.com"));
-            assertEquals("*", chooseCertId(server, "www.example.com", null));
-            assertEquals("*", chooseCertId(server, null, null));
-            assertEquals("*", chooseCertId(server, "", null));
-            assertEquals("*", chooseCertId(server, null, ""));
+            assertThat(chooseCertId(server, null, "www.example.com")).isEqualTo("*");
+            assertThat(chooseCertId(server, "www.example.com", null)).isEqualTo("*");
+            assertThat(chooseCertId(server, null, null)).isEqualTo("*");
+            assertThat(chooseCertId(server, "", null)).isEqualTo("*");
+            assertThat(chooseCertId(server, null, "")).isEqualTo("*");
         }
     }
 
@@ -159,12 +157,12 @@ public class SSLSNIIT {
 
     private static String chooseCertId(final HttpProxyServer server, final String sniHostname, final String defaultCertificate) {
         final var certificate = chooseCert(server, sniHostname, defaultCertificate);
-        assertNotNull(certificate);
+        assertThat(certificate).isNotNull();
         return certificate.getId();
     }
 
     @Test
-    public void testTLSVersion() throws Exception {
+    void tlsVersion() throws Exception {
         String nonLocalhost = InetAddress.getLocalHost().getCanonicalHostName();
         String certificate = TestUtils.deployResource("localhost.p12", tmpDir);
         stubFor(get(urlEqualTo("/index.html"))
@@ -185,9 +183,9 @@ public class SSLSNIIT {
             int port = server.getLocalPort();
             try (RawHttpClient client = new RawHttpClient(nonLocalhost, port, true, nonLocalhost)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
-                assertTrue(resp.toString().contains("it <b>works</b> !!"));
+                assertThat(resp.toString()).contains("it <b>works</b> !!");
                 SSLSession session = client.getSSLSocket().getSession();
-                assertEquals("TLSv1.3", session.getProtocol());
+                assertThat(session.getProtocol()).isEqualTo("TLSv1.3");
             }
         }
 
@@ -201,9 +199,9 @@ public class SSLSNIIT {
                 int port = server.getLocalPort();
                 try (RawHttpClient client = new RawHttpClient(nonLocalhost, port, true, nonLocalhost)) {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
-                    assertTrue(resp.toString().contains("it <b>works</b> !!"));
+                    assertThat(resp.toString()).contains("it <b>works</b> !!");
                     SSLSession session = client.getSSLSocket().getSession();
-                    assertEquals(proto, session.getProtocol());
+                    assertThat(session.getProtocol()).isEqualTo(proto);
                 }
             }
         }
@@ -216,14 +214,14 @@ public class SSLSNIIT {
             int port = server.getLocalPort();
             try (RawHttpClient client = new RawHttpClient(nonLocalhost, port, true, nonLocalhost)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
-                assertTrue(resp.toString().contains("it <b>works</b> !!"));
+                assertThat(resp.toString()).contains("it <b>works</b> !!");
                 SSLSession session = client.getSSLSocket().getSession();
-                assertTrue(DEFAULT_SSL_PROTOCOLS.contains(session.getProtocol()));
+                assertThat(DEFAULT_SSL_PROTOCOLS).contains(session.getProtocol());
             }
         }
 
         // wrong ssl protocol version checking
-        TestUtils.assertThrows(ConfigurationNotValidException.class, () -> {
+        assertThatExceptionOfType(ConfigurationNotValidException.class).isThrownBy(() -> {
             try (HttpProxyServer server = new HttpProxyServer(mapper, tmpDir)) {
                 server.addCertificate(new SSLCertificateConfiguration(nonLocalhost, null, certificate, "testproxy", STATIC));
                 server.addListener(new NetworkListenerConfiguration(nonLocalhost, 0, true, null, nonLocalhost, Set.of("TLSvWRONG"),

--- a/carapace-server/src/test/java/org/carapaceproxy/server/backends/BackendHealthManagerSchedulingTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/backends/BackendHealthManagerSchedulingTest.java
@@ -19,7 +19,7 @@
  */
 package org.carapaceproxy.server.backends;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -43,10 +43,10 @@ import org.junit.jupiter.api.Test;
  *
  * @author paolo
  */
-public class BackendHealthManagerSchedulingTest {
+class BackendHealthManagerSchedulingTest {
 
     @Test
-    public void testBackendHealthManagerExecution() {
+    void backendHealthManagerExecution() {
         RuntimeServerConfiguration config = new RuntimeServerConfiguration();
         ScheduledExecutorService timer = mock(ScheduledExecutorService.class);
         when(timer.scheduleAtFixedRate(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(mock(ScheduledFuture.class));
@@ -60,13 +60,13 @@ public class BackendHealthManagerSchedulingTest {
         // With new period >0 the manager should run whether started before
         config.setHealthProbePeriod(1);
         man.reloadConfiguration(config, mock(EndpointMapper.class));
-        assertEquals(1, man.getPeriod());
+        assertThat(man.getPeriod()).isOne();
         verify(timer, times(1)).scheduleAtFixedRate(any(Runnable.class), eq(1L), eq(1L), eq(TimeUnit.SECONDS)); // once
 
         man.stop();
         config.setHealthProbePeriod(0);
         man.reloadConfiguration(config, mock(EndpointMapper.class));
-        assertEquals(0, man.getPeriod());
+        assertThat(man.getPeriod()).isZero();
         man.start();
         verify(timer, times(1)).scheduleAtFixedRate(any(Runnable.class), eq(1L), eq(1L), eq(TimeUnit.SECONDS)); // never
         man.stop();
@@ -74,7 +74,7 @@ public class BackendHealthManagerSchedulingTest {
         // With new period >0 the manager should not run because not started before.
         config.setHealthProbePeriod(1);
         man.reloadConfiguration(config, mock(EndpointMapper.class));
-        assertEquals(1, man.getPeriod());
+        assertThat(man.getPeriod()).isOne();
         verify(timer, times(1)).scheduleAtFixedRate(any(Runnable.class), eq(1L), eq(1L), eq(TimeUnit.SECONDS)); // never
 
         man.start();

--- a/carapace-server/src/test/java/org/carapaceproxy/server/backends/BackendHealthStatusTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/backends/BackendHealthStatusTest.java
@@ -19,7 +19,8 @@
  */
 package org.carapaceproxy.server.backends;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.carapaceproxy.core.EndpointKey;
 import org.carapaceproxy.server.backends.BackendHealthStatus.Status;
 import org.junit.jupiter.api.Test;
@@ -36,17 +37,17 @@ class BackendHealthStatusTest {
     @Test
     void freshStatusIsCold() {
         BackendHealthStatus status = new BackendHealthStatus(KEY, 500);
-        assertEquals(Status.COLD, status.getStatus());
-        assertEquals(0, status.getUnreachableSince());
+        assertThat(status.getStatus()).isEqualTo(Status.COLD);
+        assertThat(status.getUnreachableSince()).isZero();
     }
 
     @Test
     void reportAsUnreachableMovesToDown() {
         BackendHealthStatus status = new BackendHealthStatus(KEY, 500);
         status.reportAsUnreachable(1000, "500 error");
-        assertEquals(Status.DOWN, status.getStatus());
-        assertEquals(1000, status.getUnreachableSince());
-        assertEquals(1000, status.getLastUnreachable());
+        assertThat(status.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(status.getUnreachableSince()).isEqualTo(1000);
+        assertThat(status.getLastUnreachable()).isEqualTo(1000);
     }
 
     @Test
@@ -54,9 +55,9 @@ class BackendHealthStatusTest {
         BackendHealthStatus status = new BackendHealthStatus(KEY, 500);
         status.reportAsUnreachable(1000, "500 error");
         status.reportAsUnreachable(2000, "still down");
-        assertEquals(Status.DOWN, status.getStatus());
-        assertEquals(1000, status.getUnreachableSince()); // preserved, not reset
-        assertEquals(2000, status.getLastUnreachable()); // refreshed
+        assertThat(status.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(status.getUnreachableSince()).isEqualTo(1000); // preserved, not reset
+        assertThat(status.getLastUnreachable()).isEqualTo(2000); // refreshed
     }
 
     @Test
@@ -64,9 +65,9 @@ class BackendHealthStatusTest {
         BackendHealthStatus status = new BackendHealthStatus(KEY, 500);
         status.reportAsUnreachable(1000, "500 error");
         status.reportAsReachable(3000);
-        assertEquals(Status.COLD, status.getStatus());
-        assertEquals(0, status.getUnreachableSince());
-        assertEquals(3000, status.getLastReachable());
+        assertThat(status.getStatus()).isEqualTo(Status.COLD);
+        assertThat(status.getUnreachableSince()).isZero();
+        assertThat(status.getLastReachable()).isEqualTo(3000);
     }
 
     @Test
@@ -75,16 +76,16 @@ class BackendHealthStatusTest {
         // Establish a deterministic lastUnreachable=1000, then come back COLD (DOWN->COLD keeps lastUnreachable).
         status.reportAsUnreachable(1000, "500 error");
         status.reportAsReachable(1001);
-        assertEquals(Status.COLD, status.getStatus());
-        assertEquals(1000, status.getLastUnreachable());
+        assertThat(status.getStatus()).isEqualTo(Status.COLD);
+        assertThat(status.getLastUnreachable()).isEqualTo(1000);
 
         // Strict '>': exactly warmup after lastUnreachable stays COLD.
         status.reportAsReachable(1000 + 500);
-        assertEquals(Status.COLD, status.getStatus());
+        assertThat(status.getStatus()).isEqualTo(Status.COLD);
 
         // One past warmup flips to STABLE.
         status.reportAsReachable(1000 + 500 + 1);
-        assertEquals(Status.STABLE, status.getStatus());
+        assertThat(status.getStatus()).isEqualTo(Status.STABLE);
     }
 
     @Test
@@ -93,10 +94,10 @@ class BackendHealthStatusTest {
         status.reportAsUnreachable(1000, "500 error");
         status.reportAsReachable(1001);
         status.reportAsReachable(1000 + 500 + 1);
-        assertEquals(Status.STABLE, status.getStatus());
+        assertThat(status.getStatus()).isEqualTo(Status.STABLE);
 
         status.reportAsReachable(9999);
-        assertEquals(Status.STABLE, status.getStatus());
+        assertThat(status.getStatus()).isEqualTo(Status.STABLE);
     }
 
     @Test
@@ -106,20 +107,20 @@ class BackendHealthStatusTest {
         BackendHealthStatus status = new BackendHealthStatus(KEY, 500);
         long created = status.getLastUnreachable();
         status.reportAsReachable(created + 500 + 1);
-        assertEquals(Status.STABLE, status.getStatus());
+        assertThat(status.getStatus()).isEqualTo(Status.STABLE);
     }
 
     @Test
     void connectionsIncrementDecrementAndClampAtZero() {
         BackendHealthStatus status = new BackendHealthStatus(KEY, 500);
-        assertEquals(0, status.getConnections());
+        assertThat(status.getConnections()).isZero();
         status.incrementConnections();
         status.incrementConnections();
-        assertEquals(2, status.getConnections());
+        assertThat(status.getConnections()).isEqualTo(2);
         status.decrementConnections();
-        assertEquals(1, status.getConnections());
+        assertThat(status.getConnections()).isOne();
         status.decrementConnections();
         status.decrementConnections(); // already at 0, must clamp
-        assertEquals(0, status.getConnections());
+        assertThat(status.getConnections()).isZero();
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/backends/BackendHealthStatusTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/backends/BackendHealthStatusTest.java
@@ -22,6 +22,7 @@ package org.carapaceproxy.server.backends;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.carapaceproxy.core.EndpointKey;
+import org.carapaceproxy.server.backends.BackendHealthStatus.Snapshot;
 import org.carapaceproxy.server.backends.BackendHealthStatus.Status;
 import org.junit.jupiter.api.Test;
 
@@ -37,17 +38,18 @@ class BackendHealthStatusTest {
     @Test
     void freshStatusIsCold() {
         BackendHealthStatus status = new BackendHealthStatus(KEY, 500);
-        assertThat(status.getStatus()).isEqualTo(Status.COLD);
-        assertThat(status.getUnreachableSince()).isZero();
+        assertThat(status.snapshot())
+                .extracting(Snapshot::status, Snapshot::unreachableSince)
+                .containsExactly(Status.COLD, 0L);
     }
 
     @Test
     void reportAsUnreachableMovesToDown() {
         BackendHealthStatus status = new BackendHealthStatus(KEY, 500);
         status.reportAsUnreachable(1000, "500 error");
-        assertThat(status.getStatus()).isEqualTo(Status.DOWN);
-        assertThat(status.getUnreachableSince()).isEqualTo(1000);
-        assertThat(status.getLastUnreachable()).isEqualTo(1000);
+        assertThat(status.snapshot())
+                .extracting(Snapshot::status, Snapshot::unreachableSince, Snapshot::lastUnreachable)
+                .containsExactly(Status.DOWN, 1000L, 1000L);
     }
 
     @Test
@@ -55,9 +57,9 @@ class BackendHealthStatusTest {
         BackendHealthStatus status = new BackendHealthStatus(KEY, 500);
         status.reportAsUnreachable(1000, "500 error");
         status.reportAsUnreachable(2000, "still down");
-        assertThat(status.getStatus()).isEqualTo(Status.DOWN);
-        assertThat(status.getUnreachableSince()).isEqualTo(1000); // preserved, not reset
-        assertThat(status.getLastUnreachable()).isEqualTo(2000); // refreshed
+        assertThat(status.snapshot())
+                .extracting(Snapshot::status, Snapshot::unreachableSince, Snapshot::lastUnreachable)
+                .containsExactly(Status.DOWN, 1000L, 2000L); // unreachableSince preserved, lastUnreachable refreshed
     }
 
     @Test
@@ -65,9 +67,8 @@ class BackendHealthStatusTest {
         BackendHealthStatus status = new BackendHealthStatus(KEY, 500);
         status.reportAsUnreachable(1000, "500 error");
         status.reportAsReachable(3000);
-        assertThat(status.getStatus()).isEqualTo(Status.COLD);
-        assertThat(status.getUnreachableSince()).isZero();
-        assertThat(status.getLastReachable()).isEqualTo(3000);
+        // every field is deterministic here, so the whole snapshot can be compared
+        assertThat(status.snapshot()).isEqualTo(new Snapshot(Status.COLD, 0, 1000, 3000));
     }
 
     @Test

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheContentLengthLimitIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheContentLengthLimitIT.java
@@ -23,10 +23,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -54,7 +51,7 @@ public class CacheContentLengthLimitIT {
     public File tmpDir;
 
     @Test
-    public void testWithContentLengthHeader() throws Exception {
+    void withContentLengthHeader() throws Exception {
 
         String body = "01234567890123456789";
 
@@ -69,7 +66,7 @@ public class CacheContentLengthLimitIT {
     }
 
     @Test
-    public void testWithoutContentLengthHeader() throws Exception {
+    void withoutContentLengthHeader() throws Exception {
 
         String body = "01234567890123456789";
 
@@ -144,18 +141,17 @@ public class CacheContentLengthLimitIT {
             String s = resp.toString();
             System.out.println("s:" + s);
             if (!chunked) {
-                assertTrue(s.contains(body));
+                assertThat(s).contains(body);
             } else {
-                assertTrue(s.contains(
-                        Integer.toString(body.length(), 16) + "\r\n"
+                assertThat(s).contains(Integer.toString(body.length(), 16) + "\r\n"
                         + body + "\r\n"
-                        + "0\r\n\r\n"));
+                        + "0\r\n\r\n");
             }
-            assertThat(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")), is(cached));
+            assertThat(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached"))).isEqualTo(cached);
 
             EndpointStats stats = server.getProxyRequestsManager().getEndpointStats(key);
-            assertNotNull(stats);
-            assertThat(server.getCache().getCacheSize(), is(cacheSize));
+            assertThat(stats).isNotNull();
+            assertThat(server.getCache().getCacheSize()).isEqualTo(cacheSize);
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheExpireIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheExpireIT.java
@@ -19,18 +19,11 @@
  */
 package org.carapaceproxy.server.cache;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.CoreMatchers.startsWithIgnoringCase;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -65,7 +58,7 @@ public class CacheExpireIT {
     public File tmpDir;
 
     @Test
-    public void testHandleExpiresFromServer() throws Exception {
+    void handleExpiresFromServer() throws Exception {
         Date expire = new Date(System.currentTimeMillis() + 60000 * 2);
         String formatted = HttpUtils.formatDateHeader(expire); // ex Wed, 01 Dec 2021 08:11:39 GMT
 
@@ -94,12 +87,11 @@ public class CacheExpireIT {
                         """);
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines(), allOf(
-                        not(hasItem(startsWithIgnoringCase("X-Cached"))),
-                        hasItem(startsWithIgnoringCase("Expires: " + formatted))
-                ));
+                assertThat(resp.getHeaderLines())
+                        .noneSatisfy(h -> assertThat(h).startsWithIgnoringCase("X-Cached"))
+                        .anySatisfy(h -> assertThat(h).startsWithIgnoringCase("Expires: " + formatted));
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
@@ -110,24 +102,23 @@ public class CacheExpireIT {
                         """);
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines(), allOf(
-                        hasItem(startsWithIgnoringCase("X-Cached")),
-                        hasItem(startsWithIgnoringCase("Expires: " + formatted))
-                ));
+                assertThat(resp.getHeaderLines())
+                        .anySatisfy(h -> assertThat(h).startsWithIgnoringCase("X-Cached"))
+                        .anySatisfy(h -> assertThat(h).startsWithIgnoringCase("Expires: " + formatted));
             }
 
-            assertEquals(1, server.getCache().getCacheSize());
-            assertEquals(1, server.getCache().getStats().getHits());
-            assertEquals(1, server.getCache().getStats().getMisses());
-            assertEquals(18, server.getCache().getStats().getDirectMemoryUsed());
-            assertEquals(0, server.getCache().getStats().getHeapMemoryUsed());
+            assertThat(server.getCache().getCacheSize()).isOne();
+            assertThat(server.getCache().getStats().getHits()).isOne();
+            assertThat(server.getCache().getStats().getMisses()).isOne();
+            assertThat(server.getCache().getStats().getDirectMemoryUsed()).isEqualTo(18);
+            assertThat(server.getCache().getStats().getHeapMemoryUsed()).isZero();
         }
     }
 
     @Test
-    public void testHandleExpiresMissingFromServer() throws Exception {
+    void handleExpiresMissingFromServer() throws Exception {
         stubFor(get(urlEqualTo("/index-no-expire.html"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -152,12 +143,11 @@ public class CacheExpireIT {
                         """);
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines(), allOf(
-                        not(hasItem(startsWithIgnoringCase("X-Cached"))),
-                        hasItem(startsWithIgnoringCase("Expires: "))
-                ));
+                assertThat(resp.getHeaderLines())
+                        .noneSatisfy(h -> assertThat(h).startsWithIgnoringCase("X-Cached"))
+                        .anySatisfy(h -> assertThat(h).startsWithIgnoringCase("Expires: "));
                 expires = resp.getHeaderLines().stream().filter(h -> h.startsWith("expires: ")).findFirst().orElseThrow();
             }
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
@@ -168,22 +158,21 @@ public class CacheExpireIT {
                         """);
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines(), allOf(
-                        hasItem(startsWithIgnoringCase("X-Cached")),
-                        hasItem(startsWith(expires))
-                ));
+                assertThat(resp.getHeaderLines())
+                        .anySatisfy(h -> assertThat(h).startsWithIgnoringCase("X-Cached"))
+                        .anySatisfy(h -> assertThat(h).startsWith(expires));
             }
 
-            assertEquals(1, server.getCache().getCacheSize());
-            assertEquals(1, server.getCache().getStats().getHits());
-            assertEquals(1, server.getCache().getStats().getMisses());
+            assertThat(server.getCache().getCacheSize()).isOne();
+            assertThat(server.getCache().getStats().getHits()).isOne();
+            assertThat(server.getCache().getStats().getMisses()).isOne();
         }
     }
 
     @Test
-    public void testDoNotCacheExpiredContent() throws Exception {
+    void doNotCacheExpiredContent() throws Exception {
         Date expire = new Date(System.currentTimeMillis() - 1000);
         String formatted = HttpUtils.formatDateHeader(expire);
 
@@ -207,34 +196,32 @@ public class CacheExpireIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index-with-expire.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines(), allOf(
-                        not(hasItem(startsWithIgnoringCase("X-Cached"))),
-                        hasItem(startsWithIgnoringCase("Expires: " + formatted))
-                ));
+                assertThat(resp.getHeaderLines())
+                        .noneSatisfy(h -> assertThat(h).startsWithIgnoringCase("X-Cached"))
+                        .anySatisfy(h -> assertThat(h).startsWithIgnoringCase("Expires: " + formatted));
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index-with-expire.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines(), allOf(
-                        not(hasItem(startsWithIgnoringCase("X-Cached"))),
-                        hasItem(startsWithIgnoringCase("Expires: " + formatted))
-                ));
+                assertThat(resp.getHeaderLines())
+                        .noneSatisfy(h -> assertThat(h).startsWithIgnoringCase("X-Cached"))
+                        .anySatisfy(h -> assertThat(h).startsWithIgnoringCase("Expires: " + formatted));
             }
 
-            assertEquals(0, server.getCache().getCacheSize());
-            assertEquals(0, server.getCache().getStats().getHits());
-            assertEquals(2, server.getCache().getStats().getMisses());
+            assertThat(server.getCache().getCacheSize()).isZero();
+            assertThat(server.getCache().getStats().getHits()).isZero();
+            assertThat(server.getCache().getStats().getMisses()).isEqualTo(2);
         }
     }
 
     @Test
-    public void testExpireContentOnGet() throws Exception {
+    void expireContentOnGet() throws Exception {
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.getPort(), true, false);
 
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir);) {
@@ -259,17 +246,16 @@ public class CacheExpireIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index-with-expire.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines(), allOf(
-                        not(hasItem(startsWithIgnoringCase("X-Cached"))),
-                        hasItem(startsWithIgnoringCase("Expires: " + formatted))
-                ));
+                assertThat(resp.getHeaderLines())
+                        .noneSatisfy(h -> assertThat(h).startsWithIgnoringCase("X-Cached"))
+                        .anySatisfy(h -> assertThat(h).startsWithIgnoringCase("Expires: " + formatted));
             }
 
-            assertEquals(1, server.getCache().getCacheSize());
-            assertEquals(0, server.getCache().getStats().getHits());
-            assertEquals(1, server.getCache().getStats().getMisses());
+            assertThat(server.getCache().getCacheSize()).isOne();
+            assertThat(server.getCache().getStats().getHits()).isZero();
+            assertThat(server.getCache().getStats().getMisses()).isOne();
 
             Thread.sleep(5_000);
 
@@ -278,22 +264,21 @@ public class CacheExpireIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index-with-expire.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines(), allOf(
-                        not(hasItem(startsWithIgnoringCase("X-Cached"))),
-                        hasItem(startsWithIgnoringCase("Expires: " + formatted))
-                ));
+                assertThat(resp.getHeaderLines())
+                        .noneSatisfy(h -> assertThat(h).startsWithIgnoringCase("X-Cached"))
+                        .anySatisfy(h -> assertThat(h).startsWithIgnoringCase("Expires: " + formatted));
             }
 
-            assertEquals(0, server.getCache().getCacheSize());
-            assertEquals(0, server.getCache().getStats().getHits());
-            assertEquals(2, server.getCache().getStats().getMisses());
+            assertThat(server.getCache().getCacheSize()).isZero();
+            assertThat(server.getCache().getStats().getHits()).isZero();
+            assertThat(server.getCache().getStats().getMisses()).isEqualTo(2);
         }
     }
 
     @Test
-    public void testExpireContentWithoutGet() throws Exception {
+    void expireContentWithoutGet() throws Exception {
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.getPort(), true, false);
 
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir);) {
@@ -319,17 +304,16 @@ public class CacheExpireIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index-with-expire.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines(), allOf(
-                        not(hasItem(startsWithIgnoringCase("X-Cached"))),
-                        hasItem(startsWithIgnoringCase("Expires: " + formatted))
-                ));
+                assertThat(resp.getHeaderLines())
+                        .noneSatisfy(h -> assertThat(h).startsWithIgnoringCase("X-Cached"))
+                        .anySatisfy(h -> assertThat(h).startsWithIgnoringCase("Expires: " + formatted));
             }
 
-            assertEquals(1, server.getCache().getCacheSize());
-            assertEquals(0, server.getCache().getStats().getHits());
-            assertEquals(1, server.getCache().getStats().getMisses());
+            assertThat(server.getCache().getCacheSize()).isOne();
+            assertThat(server.getCache().getStats().getHits()).isZero();
+            assertThat(server.getCache().getStats().getMisses()).isOne();
             TestUtils.waitForCondition(() -> {
                 server.getCache().getInnerCache().evict();
                 return server.getCache().getCacheSize() == 0;

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheIT.java
@@ -114,18 +114,20 @@ public class CacheIT {
 
             List<Map<String, Object>> inspect = server.getCache().inspectCache();
             System.out.println("inspect: " + inspect);
-            assertThat(inspect).hasSize(1);
-            assertThat(inspect.getFirst()).containsEntry("method", "GET");
-            assertThat(inspect.getFirst()).containsEntry("scheme", "http");
-            assertThat(inspect.getFirst()).containsEntry("host", "localhost");
-            assertThat(inspect.getFirst()).containsEntry("uri", "/index.html");
-            assertThat(inspect.getFirst()).containsEntry("cacheKey", "http | GET | localhost | /index.html");
-            // A chunk lands either in a heap or in a direct buffer, never in both, so only the sum is nonzero.
-            assertThat((long) inspect.getFirst().get("heapSize") + (long) inspect.getFirst().get("directSize")).isPositive();
-            assertThat((long) inspect.getFirst().get("totalSize")).isPositive();
-            assertThat((long) inspect.getFirst().get("creationTs")).isGreaterThanOrEqualTo(startTs);
-            assertThat((long) inspect.getFirst().get("expiresTs")).isGreaterThanOrEqualTo(startTs + ContentsCache.DEFAULT_TTL);
-            assertThat(inspect.getFirst()).containsEntry("hits", 2);
+            assertThat(inspect).singleElement().satisfies(entry -> {
+                assertThat(entry).containsAllEntriesOf(Map.of(
+                        "method", "GET",
+                        "scheme", "http",
+                        "host", "localhost",
+                        "uri", "/index.html",
+                        "cacheKey", "http | GET | localhost | /index.html",
+                        "hits", 2));
+                // A chunk lands either in a heap or in a direct buffer, never in both, so only the sum is nonzero.
+                assertThat((long) entry.get("heapSize") + (long) entry.get("directSize")).isPositive();
+                assertThat((long) entry.get("totalSize")).isPositive();
+                assertThat((long) entry.get("creationTs")).isGreaterThanOrEqualTo(startTs);
+                assertThat((long) entry.get("expiresTs")).isGreaterThanOrEqualTo(startTs + ContentsCache.DEFAULT_TTL);
+            });
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheIT.java
@@ -205,7 +205,7 @@ public class CacheIT {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "cacheDisabledForSecureRequestsWithoutPublic={0}")
     @ValueSource(booleans = {true, false})
     void serveFromCacheSsl(boolean cacheDisabledForSecureRequestsWithoutPublic) throws Exception {
         TestUtils.deployResource("localhost.p12", tmpDir);
@@ -434,7 +434,7 @@ public class CacheIT {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "connectionClose={0}")
     @ValueSource(booleans = {false, true})
     void serveFromCacheChunked(boolean connectionClose) throws Exception {
         stubFor(get(urlEqualTo("/index.html"))
@@ -568,7 +568,7 @@ public class CacheIT {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "headerName={0}, headerValue={1}")
     @MethodSource("noCacheHeaderCases")
     void noCacheResponse(String headerName, String headerValue) throws Exception {
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.getPort(), true, false);
@@ -651,7 +651,7 @@ public class CacheIT {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "headerName={0}, headerValue={1}")
     @MethodSource("noCacheHeaderCases")
     void noCacheRequest(String headerName, String headerValue) throws Exception {
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.getPort(), true, false);

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheIT.java
@@ -87,7 +87,7 @@ public class CacheIT {
                 System.out.println("s:" + s);
                 assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
+                assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
@@ -96,7 +96,7 @@ public class CacheIT {
                     String s = resp.toString();
                     System.out.println("s:" + s);
                     assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
 
                 {
@@ -104,7 +104,7 @@ public class CacheIT {
                     String s = resp.toString();
                     System.out.println("s:" + s);
                     assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
             }
 
@@ -152,7 +152,7 @@ public class CacheIT {
                 System.out.println("s:" + s);
                 assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
+                assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
@@ -162,7 +162,7 @@ public class CacheIT {
                     String s = resp.toString();
                     System.out.println("s:" + s);
                     assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
 
                 {
@@ -170,7 +170,7 @@ public class CacheIT {
                     String s = resp.toString();
                     System.out.println("s:" + s);
                     assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
             }
 
@@ -239,7 +239,7 @@ public class CacheIT {
                     System.out.println("s:" + s);
                     assertThat(s).contains("it <b>works</b> !!");
                     resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                    assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
@@ -265,14 +265,14 @@ public class CacheIT {
                     String s = resp.toString();
                     System.out.println("s:" + s);
                     assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: public\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
                     assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached")); // cached due to cache-control: public header presence in second request
+                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached")); // cached due to cache-control: public header presence in second request
                 }
             }
             assertThat(server.getCache().getCacheSize()).isOne();
@@ -289,14 +289,14 @@ public class CacheIT {
                     String s = resp.toString();
                     System.out.println("s:" + s);
                     assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: puBlIc, max-age = 3600\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
                     assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
             }
             assertThat(server.getCache().getCacheSize()).isOne();
@@ -313,14 +313,14 @@ public class CacheIT {
                     String s = resp.toString();
                     System.out.println("s:" + s);
                     assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: public, max-age = 0\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
                     assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
             }
             assertThat(server.getCache().getCacheSize()).isZero();
@@ -358,7 +358,7 @@ public class CacheIT {
                 System.out.println("s:" + s);
                 assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
+                assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", httpPort)) {
@@ -367,7 +367,7 @@ public class CacheIT {
                     String s = resp.toString();
                     System.out.println("s:" + s);
                     assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
             }
 
@@ -378,7 +378,7 @@ public class CacheIT {
                     System.out.println("s:" + s);
                     assertThat(s).contains("it <b>works</b> !!");
                     resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                    assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
@@ -386,7 +386,7 @@ public class CacheIT {
                     System.out.println("s:" + s);
                     assertThat(s).contains("it <b>works</b> !!");
                     resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
             }
 
@@ -399,7 +399,7 @@ public class CacheIT {
                     System.out.println("s:" + s);
                     assertThat(s).contains("it <b>works</b> !!");
                     resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                    assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
@@ -407,7 +407,7 @@ public class CacheIT {
                     System.out.println("s:" + s);
                     assertThat(s).contains("it <b>works</b> !!");
                     resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
             }
 
@@ -417,7 +417,7 @@ public class CacheIT {
                 System.out.println("s:" + s);
                 assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
+                assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", httpPort)) {
@@ -426,7 +426,7 @@ public class CacheIT {
                     String s = resp.toString();
                     System.out.println("s:" + s);
                     assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
             }
         }
@@ -462,7 +462,7 @@ public class CacheIT {
                         \r
                         """);
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
+                assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
@@ -476,7 +476,7 @@ public class CacheIT {
                             0\r
                             \r
                             """);
-                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
@@ -488,7 +488,7 @@ public class CacheIT {
                             0\r
                             \r
                             """);
-                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
                 }
             }
 
@@ -671,14 +671,14 @@ public class CacheIT {
                 String s = resp.toString();
                 System.out.println("s:" + s);
                 assertThat(s).contains("it <b>works</b> !!");
-                assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
+                assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
             }
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n" + headerName + ": " + headerValue + "\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
                 assertThat(s).contains("it <b>works</b> !!");
-                assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
+                assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
             }
 
             EndpointStats epstats = server.getProxyRequestsManager().getEndpointStats(key);

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheIT.java
@@ -83,28 +83,18 @@ public class CacheIT {
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
-                String s = resp.toString();
-                System.out.println("s:" + s);
-                assertThat(s).contains("it <b>works</b> !!");
-                resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
+                assertServedFromOrigin(resp);
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
-                    String s = resp.toString();
-                    System.out.println("s:" + s);
-                    assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
+                    assertServedFromCache(resp);
                 }
 
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
-                    String s = resp.toString();
-                    System.out.println("s:" + s);
-                    assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
+                    assertServedFromCache(resp);
                 }
             }
 
@@ -150,29 +140,19 @@ public class CacheIT {
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
-                String s = resp.toString();
-                System.out.println("s:" + s);
-                assertThat(s).contains("it <b>works</b> !!");
-                resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
+                assertServedFromOrigin(resp);
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 {
                     // Ctrl-F5
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: no-cache\r\n\r\n");
-                    String s = resp.toString();
-                    System.out.println("s:" + s);
-                    assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
+                    assertServedFromOrigin(resp);
                 }
 
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
-                    String s = resp.toString();
-                    System.out.println("s:" + s);
-                    assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
+                    assertServedFromCache(resp);
                 }
             }
 
@@ -237,11 +217,7 @@ public class CacheIT {
             try (RawHttpClient client = new RawHttpClient("localhost", port, true)) {
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
-                    String s = resp.toString();
-                    System.out.println("s:" + s);
-                    assertThat(s).contains("it <b>works</b> !!");
-                    resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                    assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
+                    assertServedFromOrigin(resp);
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
@@ -264,10 +240,7 @@ public class CacheIT {
             try (RawHttpClient client = new RawHttpClient("localhost", port, true)) {
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: public\r\n\r\n");
-                    String s = resp.toString();
-                    System.out.println("s:" + s);
-                    assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
+                    assertServedFromOrigin(resp);
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: public\r\n\r\n");
@@ -288,17 +261,11 @@ public class CacheIT {
             try (RawHttpClient client = new RawHttpClient("localhost", port, true)) {
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: puBlIc, max-age=3600\r\n\r\n");
-                    String s = resp.toString();
-                    System.out.println("s:" + s);
-                    assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
+                    assertServedFromOrigin(resp);
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: puBlIc, max-age = 3600\r\n\r\n");
-                    String s = resp.toString();
-                    System.out.println("s:" + s);
-                    assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
+                    assertServedFromCache(resp);
                 }
             }
             assertThat(server.getCache().getCacheSize()).isOne();
@@ -312,17 +279,11 @@ public class CacheIT {
             try (RawHttpClient client = new RawHttpClient("localhost", port, true)) {
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: public, max-age = 0\r\n\r\n");
-                    String s = resp.toString();
-                    System.out.println("s:" + s);
-                    assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
+                    assertServedFromOrigin(resp);
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: public, max-age = 0\r\n\r\n");
-                    String s = resp.toString();
-                    System.out.println("s:" + s);
-                    assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
+                    assertServedFromOrigin(resp);
                 }
             }
             assertThat(server.getCache().getCacheSize()).isZero();
@@ -356,39 +317,24 @@ public class CacheIT {
 
             try (RawHttpClient client = new RawHttpClient("localhost", httpPort)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
-                String s = resp.toString();
-                System.out.println("s:" + s);
-                assertThat(s).contains("it <b>works</b> !!");
-                resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
+                assertServedFromOrigin(resp);
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", httpPort)) {
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
-                    String s = resp.toString();
-                    System.out.println("s:" + s);
-                    assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
+                    assertServedFromCache(resp);
                 }
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", httpsPort, true)) {
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
-                    String s = resp.toString();
-                    System.out.println("s:" + s);
-                    assertThat(s).contains("it <b>works</b> !!");
-                    resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                    assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
+                    assertServedFromOrigin(resp);
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
-                    String s = resp.toString();
-                    System.out.println("s:" + s);
-                    assertThat(s).contains("it <b>works</b> !!");
-                    resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
+                    assertServedFromCache(resp);
                 }
             }
 
@@ -397,38 +343,23 @@ public class CacheIT {
             try (RawHttpClient client = new RawHttpClient("localhost", httpsPort, true)) {
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
-                    String s = resp.toString();
-                    System.out.println("s:" + s);
-                    assertThat(s).contains("it <b>works</b> !!");
-                    resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                    assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
+                    assertServedFromOrigin(resp);
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
-                    String s = resp.toString();
-                    System.out.println("s:" + s);
-                    assertThat(s).contains("it <b>works</b> !!");
-                    resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
+                    assertServedFromCache(resp);
                 }
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", httpPort)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
-                String s = resp.toString();
-                System.out.println("s:" + s);
-                assertThat(s).contains("it <b>works</b> !!");
-                resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
+                assertServedFromOrigin(resp);
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", httpPort)) {
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
-                    String s = resp.toString();
-                    System.out.println("s:" + s);
-                    assertThat(s).contains("it <b>works</b> !!");
-                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
+                    assertServedFromCache(resp);
                 }
             }
         }
@@ -670,17 +601,11 @@ public class CacheIT {
                             .withBody("it <b>works</b> !!")));
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n" + headerName + ": " + headerValue + "\r\n\r\n");
-                String s = resp.toString();
-                System.out.println("s:" + s);
-                assertThat(s).contains("it <b>works</b> !!");
-                assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
+                assertServedFromOrigin(resp);
             }
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n" + headerName + ": " + headerValue + "\r\n\r\n");
-                String s = resp.toString();
-                System.out.println("s:" + s);
-                assertThat(s).contains("it <b>works</b> !!");
-                assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
+                assertServedFromOrigin(resp);
             }
 
             EndpointStats epstats = server.getProxyRequestsManager().getEndpointStats(key);
@@ -721,6 +646,19 @@ public class CacheIT {
             assertThat(server.getCache().getStats().getHits()).isOne();
             assertThat(server.getCache().getStats().getMisses()).isOne();
         }
+    }
+
+
+    /** The payload came back and the proxy marked it as a cache hit. */
+    private static void assertServedFromCache(final RawHttpClient.HttpResponse response) {
+        assertThat(response.toString()).contains("it <b>works</b> !!");
+        assertThat(response.getHeaderLines()).anySatisfy(header -> assertThat(header).contains("X-Cached"));
+    }
+
+    /** The payload came back from the backend, with no cache-hit marker. */
+    private static void assertServedFromOrigin(final RawHttpClient.HttpResponse response) {
+        assertThat(response.toString()).contains("it <b>works</b> !!");
+        assertThat(response.getHeaderLines()).noneSatisfy(header -> assertThat(header).contains("X-Cached"));
     }
 
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CacheIT.java
@@ -23,16 +23,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_FORWARDED_STRATEGY;
 import static org.carapaceproxy.server.config.NetworkListenerConfiguration.DEFAULT_SSL_PROTOCOLS;
 import static org.carapaceproxy.server.config.SSLCertificateConfiguration.CertificateMode.STATIC;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static reactor.netty.http.HttpProtocol.HTTP11;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -58,7 +52,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -71,7 +64,7 @@ public class CacheIT {
     public File tmpDir;
 
     @Test
-    public void testServeFromCache() throws Exception {
+    void serveFromCache() throws Exception {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -92,9 +85,9 @@ public class CacheIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
@@ -102,42 +95,42 @@ public class CacheIT {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("it <b>works</b> !!"));
-                    assertTrue(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertThat(s).contains("it <b>works</b> !!");
+                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
                 }
 
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("it <b>works</b> !!"));
-                    assertTrue(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertThat(s).contains("it <b>works</b> !!");
+                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
                 }
             }
 
-            assertEquals(1, server.getCache().getCacheSize());
-            assertEquals(2, server.getCache().getStats().getHits());
-            assertEquals(1, server.getCache().getStats().getMisses());
+            assertThat(server.getCache().getCacheSize()).isOne();
+            assertThat(server.getCache().getStats().getHits()).isEqualTo(2);
+            assertThat(server.getCache().getStats().getMisses()).isOne();
 
             List<Map<String, Object>> inspect = server.getCache().inspectCache();
             System.out.println("inspect: " + inspect);
-            assertThat(inspect.size(), is(1));
-            assertThat(inspect.getFirst().get("method"), is("GET"));
-            assertThat(inspect.getFirst().get("scheme"), is("http"));
-            assertThat(inspect.getFirst().get("host"), is("localhost"));
-            assertThat(inspect.getFirst().get("uri"), is("/index.html"));
-            assertThat(inspect.getFirst().get("cacheKey"), is("http | GET | localhost | /index.html"));
-            assertThat(inspect.getFirst().get("heapSize"), is(not(0)));
-            assertThat(inspect.getFirst().get("directSize"), is(not(0)));
-            assertThat(inspect.getFirst().get("totalSize"), is(not(0)));
-            assertTrue((long) inspect.getFirst().get("creationTs") >= startTs);
-            assertTrue((long) inspect.getFirst().get("expiresTs") >= startTs + ContentsCache.DEFAULT_TTL);
-            assertThat(inspect.getFirst().get("hits"), is(2));
+            assertThat(inspect).hasSize(1);
+            assertThat(inspect.getFirst()).containsEntry("method", "GET");
+            assertThat(inspect.getFirst()).containsEntry("scheme", "http");
+            assertThat(inspect.getFirst()).containsEntry("host", "localhost");
+            assertThat(inspect.getFirst()).containsEntry("uri", "/index.html");
+            assertThat(inspect.getFirst()).containsEntry("cacheKey", "http | GET | localhost | /index.html");
+            // A chunk lands either in a heap or in a direct buffer, never in both, so only the sum is nonzero.
+            assertThat((long) inspect.getFirst().get("heapSize") + (long) inspect.getFirst().get("directSize")).isPositive();
+            assertThat((long) inspect.getFirst().get("totalSize")).isPositive();
+            assertThat((long) inspect.getFirst().get("creationTs")).isGreaterThanOrEqualTo(startTs);
+            assertThat((long) inspect.getFirst().get("expiresTs")).isGreaterThanOrEqualTo(startTs + ContentsCache.DEFAULT_TTL);
+            assertThat(inspect.getFirst()).containsEntry("hits", 2);
         }
     }
 
     @Test
-    public void testNotServeFromCacheIfCachableButClientsDisablesCache() throws Exception {
+    void notServeFromCacheIfCachableButClientsDisablesCache() throws Exception {
 
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
@@ -157,9 +150,9 @@ public class CacheIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
@@ -168,28 +161,28 @@ public class CacheIT {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: no-cache\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("it <b>works</b> !!"));
-                    assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertThat(s).contains("it <b>works</b> !!");
+                    assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
                 }
 
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("it <b>works</b> !!"));
-                    assertTrue(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertThat(s).contains("it <b>works</b> !!");
+                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
                 }
             }
 
-            assertEquals(1, server.getCache().getCacheSize());
-            assertEquals(1, server.getCache().getStats().getHits());
-            assertEquals(1, server.getCache().getStats().getMisses());
+            assertThat(server.getCache().getCacheSize()).isOne();
+            assertThat(server.getCache().getStats().getHits()).isOne();
+            assertThat(server.getCache().getStats().getMisses()).isOne();
         }
 
     }
 
     @Test
-    public void testBootSslRelativeCertificatePath() throws Exception {
+    void bootSslRelativeCertificatePath() throws Exception {
         TestUtils.deployResource("localhost.p12", tmpDir);
 
         stubFor(get(urlEqualTo("/index.html"))
@@ -211,8 +204,8 @@ public class CacheIT {
     }
 
     @ParameterizedTest
-    @CsvSource({"true", "false"})
-    public void testServeFromCacheSsl(boolean cacheDisabledForSecureRequestsWithoutPublic) throws Exception {
+    @ValueSource(booleans = {true, false})
+    void serveFromCacheSsl(boolean cacheDisabledForSecureRequestsWithoutPublic) throws Exception {
         TestUtils.deployResource("localhost.p12", tmpDir);
 
         stubFor(get(urlEqualTo("/index.html"))
@@ -244,24 +237,24 @@ public class CacheIT {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("it <b>works</b> !!"));
+                    assertThat(s).contains("it <b>works</b> !!");
                     resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                    assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("it <b>works</b> !!"));
+                    assertThat(s).contains("it <b>works</b> !!");
                     resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                    assertEquals(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")), !cacheDisabledForSecureRequestsWithoutPublic);
+                    assertThat(!cacheDisabledForSecureRequestsWithoutPublic).isEqualTo(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
                 }
             }
 
             int expected = cacheDisabledForSecureRequestsWithoutPublic ? 0 : 1;
-            assertEquals(expected, server.getCache().getCacheSize());
-            assertEquals(expected, server.getCache().getStats().getHits());
-            assertEquals(expected, server.getCache().getStats().getMisses());
+            assertThat(server.getCache().getCacheSize()).isEqualTo(expected);
+            assertThat(server.getCache().getStats().getHits()).isEqualTo(expected);
+            assertThat(server.getCache().getStats().getMisses()).isEqualTo(expected);
             server.getCache().getStats().resetCacheMetrics();
             server.getCache().clear();
 
@@ -271,21 +264,21 @@ public class CacheIT {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: public\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("it <b>works</b> !!"));
-                    assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertThat(s).contains("it <b>works</b> !!");
+                    assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: public\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("it <b>works</b> !!"));
-                    assertTrue(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached"))); // cached due to cache-control: public header presence in second request
+                    assertThat(s).contains("it <b>works</b> !!");
+                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached")); // cached due to cache-control: public header presence in second request
                 }
             }
-            assertEquals(1, server.getCache().getCacheSize());
-            assertEquals(1, server.getCache().getStats().getHits());
-            assertEquals(1, server.getCache().getStats().getMisses());
-            assertThat(server.getCache().inspectCache().getFirst().get("scheme"), is("https"));
+            assertThat(server.getCache().getCacheSize()).isOne();
+            assertThat(server.getCache().getStats().getHits()).isOne();
+            assertThat(server.getCache().getStats().getMisses()).isOne();
+            assertThat(server.getCache().inspectCache().getFirst()).containsEntry("scheme", "https");
             server.getCache().getStats().resetCacheMetrics();
             server.getCache().clear();
 
@@ -295,21 +288,21 @@ public class CacheIT {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: puBlIc, max-age=3600\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("it <b>works</b> !!"));
-                    assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertThat(s).contains("it <b>works</b> !!");
+                    assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: puBlIc, max-age = 3600\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("it <b>works</b> !!"));
-                    assertTrue(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertThat(s).contains("it <b>works</b> !!");
+                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
                 }
             }
-            assertEquals(1, server.getCache().getCacheSize());
-            assertEquals(1, server.getCache().getStats().getHits());
-            assertEquals(1, server.getCache().getStats().getMisses());
-            assertThat(server.getCache().inspectCache().getFirst().get("scheme"), is("https"));
+            assertThat(server.getCache().getCacheSize()).isOne();
+            assertThat(server.getCache().getStats().getHits()).isOne();
+            assertThat(server.getCache().getStats().getMisses()).isOne();
+            assertThat(server.getCache().inspectCache().getFirst()).containsEntry("scheme", "https");
             server.getCache().getStats().resetCacheMetrics();
             server.getCache().clear();
 
@@ -319,25 +312,25 @@ public class CacheIT {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: public, max-age = 0\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("it <b>works</b> !!"));
-                    assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertThat(s).contains("it <b>works</b> !!");
+                    assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nCache-Control: public, max-age = 0\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("it <b>works</b> !!"));
-                    assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertThat(s).contains("it <b>works</b> !!");
+                    assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
                 }
             }
-            assertEquals(0, server.getCache().getCacheSize());
-            assertEquals(0, server.getCache().getStats().getHits());
-            assertEquals(0, server.getCache().getStats().getMisses());
+            assertThat(server.getCache().getCacheSize()).isZero();
+            assertThat(server.getCache().getStats().getHits()).isZero();
+            assertThat(server.getCache().getStats().getMisses()).isZero();
         }
     }
 
     @Test
-    public void testServeFromCacheWithRequestProtocol() throws Exception {
+    void serveFromCacheWithRequestProtocol() throws Exception {
         TestUtils.deployResource("localhost.p12", tmpDir);
 
         stubFor(get(urlEqualTo("/index.html"))
@@ -363,9 +356,9 @@ public class CacheIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", httpPort)) {
@@ -373,8 +366,8 @@ public class CacheIT {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("it <b>works</b> !!"));
-                    assertTrue(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertThat(s).contains("it <b>works</b> !!");
+                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
                 }
             }
 
@@ -383,17 +376,17 @@ public class CacheIT {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("it <b>works</b> !!"));
+                    assertThat(s).contains("it <b>works</b> !!");
                     resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                    assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("it <b>works</b> !!"));
+                    assertThat(s).contains("it <b>works</b> !!");
                     resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                    assertTrue(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
                 }
             }
 
@@ -404,17 +397,17 @@ public class CacheIT {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("it <b>works</b> !!"));
+                    assertThat(s).contains("it <b>works</b> !!");
                     resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                    assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("it <b>works</b> !!"));
+                    assertThat(s).contains("it <b>works</b> !!");
                     resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                    assertTrue(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
                 }
             }
 
@@ -422,9 +415,9 @@ public class CacheIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", httpPort)) {
@@ -432,8 +425,8 @@ public class CacheIT {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("it <b>works</b> !!"));
-                    assertTrue(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                    assertThat(s).contains("it <b>works</b> !!");
+                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
                 }
             }
         }
@@ -462,14 +455,14 @@ public class CacheIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest(firstRequest);
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("""
+                assertThat(s).contains("""
                         12\r
                         it <b>works</b> !!\r
                         0\r
                         \r
-                        """));
+                        """);
                 resp.getHeaderLines().forEach(h -> System.out.println("HEADER LINE :" + h));
-                assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
@@ -477,36 +470,36 @@ public class CacheIT {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("""
+                    assertThat(s).contains("""
                             12\r
                             it <b>works</b> !!\r
                             0\r
                             \r
-                            """));
-                    assertTrue(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                            """);
+                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
                 }
                 {
                     RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                     String s = resp.toString();
                     System.out.println("s:" + s);
-                    assertTrue(s.contains("""
+                    assertThat(s).contains("""
                             12\r
                             it <b>works</b> !!\r
                             0\r
                             \r
-                            """));
-                    assertTrue(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                            """);
+                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
                 }
             }
 
-            assertEquals(1, server.getCache().getCacheSize());
-            assertEquals(2, server.getCache().getStats().getHits());
-            assertEquals(1, server.getCache().getStats().getMisses());
+            assertThat(server.getCache().getCacheSize()).isOne();
+            assertThat(server.getCache().getStats().getHits()).isEqualTo(2);
+            assertThat(server.getCache().getStats().getMisses()).isOne();
         }
     }
 
     @Test
-    public void testNotCachableResourceWithQueryString() throws Exception {
+    void notCachableResourceWithQueryString() throws Exception {
         stubFor(get(urlEqualTo("/index.html?_nocache"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -524,23 +517,23 @@ public class CacheIT {
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.get("/index.html?_nocache").toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.get("/index.html?_nocache").toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
             }
 
-            assertEquals(0, server.getCache().getCacheSize());
-            assertEquals(0, server.getCache().getStats().getHits());
-            assertEquals(0, server.getCache().getStats().getMisses());
+            assertThat(server.getCache().getCacheSize()).isZero();
+            assertThat(server.getCache().getStats().getHits()).isZero();
+            assertThat(server.getCache().getStats().getMisses()).isZero();
         }
     }
 
     @Test
-    public void testImagesCachableWithQueryString() throws Exception {
+    void imagesCachableWithQueryString() throws Exception {
         stubFor(get(urlEqualTo("/index.png?_nocache"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -558,18 +551,18 @@ public class CacheIT {
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.get("/index.png?_nocache").toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.get("/index.png?_nocache").toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
             }
 
-            assertEquals(1, server.getCache().getCacheSize());
-            assertEquals(1, server.getCache().getStats().getHits());
-            assertEquals(1, server.getCache().getStats().getMisses());
+            assertThat(server.getCache().getCacheSize()).isOne();
+            assertThat(server.getCache().getStats().getHits()).isOne();
+            assertThat(server.getCache().getStats().getMisses()).isOne();
         }
     }
 
@@ -596,17 +589,17 @@ public class CacheIT {
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.get("/index.png?_nocache").toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.get("/index.png?_nocache").toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
             }
-            assertEquals(0, server.getCache().getCacheSize());
-            assertEquals(0, server.getCache().getStats().getHits());
-            assertEquals(2, server.getCache().getStats().getMisses());
+            assertThat(server.getCache().getCacheSize()).isZero();
+            assertThat(server.getCache().getStats().getHits()).isZero();
+            assertThat(server.getCache().getStats().getMisses()).isEqualTo(2);
         }
     }
 
@@ -625,7 +618,7 @@ public class CacheIT {
     }
 
     @Test
-    public void testNoCacheResponse_cachable() throws Exception {
+    void noCacheResponseCachable() throws Exception {
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.getPort(), true, false);
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir)) {
             server.start();
@@ -642,17 +635,17 @@ public class CacheIT {
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.get("/index.png?_nocache").toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.get("/index.png?_nocache").toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
             }
-            assertEquals(1, server.getCache().getCacheSize());
-            assertEquals(1, server.getCache().getStats().getHits());
-            assertEquals(1, server.getCache().getStats().getMisses());
+            assertThat(server.getCache().getCacheSize()).isOne();
+            assertThat(server.getCache().getStats().getHits()).isOne();
+            assertThat(server.getCache().getStats().getMisses()).isOne();
         }
     }
 
@@ -677,27 +670,27 @@ public class CacheIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n" + headerName + ": " + headerValue + "\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
-                assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                assertThat(s).contains("it <b>works</b> !!");
+                assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
             }
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n" + headerName + ": " + headerValue + "\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
-                assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                assertThat(s).contains("it <b>works</b> !!");
+                assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
             }
 
             EndpointStats epstats = server.getProxyRequestsManager().getEndpointStats(key);
-            assertNotNull(epstats);
-            assertEquals(0, server.getCache().getCacheSize());
-            assertEquals(0, server.getCache().getStats().getHits());
-            assertEquals(0, server.getCache().getStats().getMisses());
+            assertThat(epstats).isNotNull();
+            assertThat(server.getCache().getCacheSize()).isZero();
+            assertThat(server.getCache().getStats().getHits()).isZero();
+            assertThat(server.getCache().getStats().getMisses()).isZero();
         }
     }
 
     @Test
-    public void testNoCacheRequest_cachable() throws Exception {
+    void noCacheRequestCachable() throws Exception {
         TestEndpointMapper mapper = new TestEndpointMapper("localhost", wireMockRule.getPort(), true, false);
         try (HttpProxyServer server = HttpProxyServer.buildForTests("localhost", 0, mapper, tmpDir);) {
             server.start();
@@ -714,17 +707,17 @@ public class CacheIT {
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.get("/index.html").toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.get("/index.html").toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
             }
-            assertEquals(1, server.getCache().getCacheSize());
-            assertEquals(1, server.getCache().getStats().getHits());
-            assertEquals(1, server.getCache().getStats().getMisses());
+            assertThat(server.getCache().getCacheSize()).isOne();
+            assertThat(server.getCache().getStats().getHits()).isOne();
+            assertThat(server.getCache().getStats().getMisses()).isOne();
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CaffeineCacheImplTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CaffeineCacheImplTest.java
@@ -19,11 +19,7 @@
  */
 package org.carapaceproxy.server.cache;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import io.netty.buffer.Unpooled;
@@ -53,7 +49,7 @@ public class CaffeineCacheImplTest {
     private final Logger logger = LoggerFactory.getLogger(CaffeineCacheImplTest.class);
 
     @AfterEach
-    public void afterEach() {
+    void afterEach() {
         stats.resetCacheMetrics();
     }
 
@@ -160,110 +156,110 @@ public class CaffeineCacheImplTest {
         } else {
             cache.evict();
             Thread.sleep(1000);
-            assertThat(evictedResources.size(), is(0));
+            assertThat(evictedResources).isEmpty();
         }
     }
 
     @Test
-    public void simpleTest() throws Exception {
+    void simpleTest() throws Exception {
         initializeCache(0);
 
         // Put 1
         CacheEntry e1 = genCacheEntry("res_1", 100, 0);
         cache.put(e1.key, e1.payload);
-        assertThat(cache.get(e1.key), is(e1.payload));
+        assertThat(cache.get(e1.key)).isEqualTo(e1.payload);
 
-        assertThat(cache.getSize(), is(1));
-        assertThat(cache.getMemSize(), is(e1.getMemUsage()));
+        assertThat(cache.getSize()).isOne();
+        assertThat(cache.getMemSize()).isEqualTo(e1.getMemUsage());
 
-        assertThat(stats.getDirectMemoryUsed(), is(equalTo(e1.payload.getDirectSize())));
-        assertThat(stats.getHeapMemoryUsed(), is(e1.payload.getHeapSize()));
-        assertThat(stats.getTotalMemoryUsed(), is(e1.getMemUsage()));
-        assertThat(stats.getHits(), is(1L));
-        assertThat(stats.getMisses(), is(0L));
+        assertThat(stats.getDirectMemoryUsed()).isEqualTo(e1.payload.getDirectSize());
+        assertThat(stats.getHeapMemoryUsed()).isEqualTo(e1.payload.getHeapSize());
+        assertThat(stats.getTotalMemoryUsed()).isEqualTo(e1.getMemUsage());
+        assertThat(stats.getHits()).isOne();
+        assertThat(stats.getMisses()).isZero();
 
         // Put 2
         CacheEntry e2 = genCacheEntry("res_2", 200, 0);
         cache.put(e2.key, e2.payload);
-        assertThat(cache.get(e2.key), is(e2.payload));
+        assertThat(cache.get(e2.key)).isEqualTo(e2.payload);
 
-        assertThat(cache.getSize(), is(2));
-        assertThat(cache.getMemSize(), is(e1.getMemUsage() + e2.getMemUsage()));
+        assertThat(cache.getSize()).isEqualTo(2);
+        assertThat(cache.getMemSize()).isEqualTo(e1.getMemUsage() + e2.getMemUsage());
 
-        assertThat(stats.getDirectMemoryUsed(), is(e1.payload.getDirectSize() + e2.payload.getDirectSize()));
-        assertThat(stats.getHeapMemoryUsed(), is(e1.payload.getHeapSize() + e2.payload.getHeapSize()));
-        assertThat(stats.getTotalMemoryUsed(), is(e1.getMemUsage() + e2.getMemUsage()));
-        assertThat(stats.getHits(), is(2L));
-        assertThat(stats.getMisses(), is(0L));
+        assertThat(stats.getDirectMemoryUsed()).isEqualTo(e1.payload.getDirectSize() + e2.payload.getDirectSize());
+        assertThat(stats.getHeapMemoryUsed()).isEqualTo(e1.payload.getHeapSize() + e2.payload.getHeapSize());
+        assertThat(stats.getTotalMemoryUsed()).isEqualTo(e1.getMemUsage() + e2.getMemUsage());
+        assertThat(stats.getHits()).isEqualTo(2L);
+        assertThat(stats.getMisses()).isZero();
 
         // Put 2b (replace 2)
         CacheEntry e2b = genCacheEntry("res_2", 300, 0);
-        assertThat(e2b.key, equalTo(e2.key));
+        assertThat(e2b.key).isEqualTo(e2.key);
         cache.put(e2b.key, e2b.payload);
-        assertThat(cache.get(e2b.key), is(e2b.payload));
+        assertThat(cache.get(e2b.key)).isEqualTo(e2b.payload);
 
         runEviction(cache, 1);
-        assertThat(evictedResources.size(), is(1));
-        assertThat(evictedResources.get(0).key, is(e2.key));
-        assertThat(evictedResources.get(0).payload, is(e2.payload));
-        assertThat(evictedResources.get(0).removalCause, is(RemovalCause.REPLACED));
+        assertThat(evictedResources).hasSize(1);
+        assertThat(evictedResources.get(0).key).isEqualTo(e2.key);
+        assertThat(evictedResources.get(0).payload).isEqualTo(e2.payload);
+        assertThat(evictedResources.get(0).removalCause).isEqualTo(RemovalCause.REPLACED);
         evictedResources.clear();
 
-        assertThat(cache.getSize(), is(2));
-        assertThat(cache.getMemSize(), is(e1.getMemUsage() + e2b.getMemUsage()));
+        assertThat(cache.getSize()).isEqualTo(2);
+        assertThat(cache.getMemSize()).isEqualTo(e1.getMemUsage() + e2b.getMemUsage());
 
-        assertThat(stats.getDirectMemoryUsed(), is(e1.payload.getDirectSize() + e2b.payload.getDirectSize()));
-        assertThat(stats.getHeapMemoryUsed(), is(e1.payload.getHeapSize() + e2b.payload.getHeapSize()));
-        assertThat(stats.getTotalMemoryUsed(), is(e1.getMemUsage() + e2b.getMemUsage()));
-        assertThat(stats.getHits(), is(3L));
-        assertThat(stats.getMisses(), is(0L));
+        assertThat(stats.getDirectMemoryUsed()).isEqualTo(e1.payload.getDirectSize() + e2b.payload.getDirectSize());
+        assertThat(stats.getHeapMemoryUsed()).isEqualTo(e1.payload.getHeapSize() + e2b.payload.getHeapSize());
+        assertThat(stats.getTotalMemoryUsed()).isEqualTo(e1.getMemUsage() + e2b.getMemUsage());
+        assertThat(stats.getHits()).isEqualTo(3L);
+        assertThat(stats.getMisses()).isZero();
 
         // Remove 1
         cache.remove(e1.key);
-        assertThat(cache.get(e1.key), is(nullValue()));
+        assertThat(cache.get(e1.key)).isNull();
 
         runEviction(cache, 1);
-        assertThat(evictedResources.size(), is(1));
-        assertThat(evictedResources.get(0).key, is(e1.key));
-        assertThat(evictedResources.get(0).payload, is(e1.payload));
-        assertThat(evictedResources.get(0).removalCause, is(RemovalCause.EXPLICIT));
+        assertThat(evictedResources).hasSize(1);
+        assertThat(evictedResources.get(0).key).isEqualTo(e1.key);
+        assertThat(evictedResources.get(0).payload).isEqualTo(e1.payload);
+        assertThat(evictedResources.get(0).removalCause).isEqualTo(RemovalCause.EXPLICIT);
         evictedResources.clear();
 
-        assertThat(cache.getSize(), is(1));
-        assertThat(cache.getMemSize(), is(e2b.getMemUsage()));
+        assertThat(cache.getSize()).isOne();
+        assertThat(cache.getMemSize()).isEqualTo(e2b.getMemUsage());
 
-        assertThat(stats.getDirectMemoryUsed(), is(e2b.payload.getDirectSize()));
-        assertThat(stats.getHeapMemoryUsed(), is(e2b.payload.getHeapSize()));
-        assertThat(stats.getTotalMemoryUsed(), is(e2b.getMemUsage()));
-        assertThat(stats.getHits(), is(3L));
-        assertThat(stats.getMisses(), is(1L));
+        assertThat(stats.getDirectMemoryUsed()).isEqualTo(e2b.payload.getDirectSize());
+        assertThat(stats.getHeapMemoryUsed()).isEqualTo(e2b.payload.getHeapSize());
+        assertThat(stats.getTotalMemoryUsed()).isEqualTo(e2b.getMemUsage());
+        assertThat(stats.getHits()).isEqualTo(3L);
+        assertThat(stats.getMisses()).isOne();
 
         // Remove 2
         cache.remove(e2.key);
-        assertThat(cache.get(e2.key), is(nullValue()));
+        assertThat(cache.get(e2.key)).isNull();
 
         runEviction(cache, 1);
-        assertThat(evictedResources.size(), is(1));
-        assertThat(evictedResources.get(0).key, is(e2b.key));
-        assertThat(evictedResources.get(0).payload, is(e2b.payload));
-        assertThat(evictedResources.get(0).removalCause, is(RemovalCause.EXPLICIT));
+        assertThat(evictedResources).hasSize(1);
+        assertThat(evictedResources.get(0).key).isEqualTo(e2b.key);
+        assertThat(evictedResources.get(0).payload).isEqualTo(e2b.payload);
+        assertThat(evictedResources.get(0).removalCause).isEqualTo(RemovalCause.EXPLICIT);
         evictedResources.clear();
 
-        assertThat(cache.getSize(), is(0));
-        assertThat(cache.getMemSize(), is(0L));
+        assertThat(cache.getSize()).isZero();
+        assertThat(cache.getMemSize()).isZero();
 
-        assertThat(stats.getDirectMemoryUsed(), is(0L));
-        assertThat(stats.getHeapMemoryUsed(), is(0L));
-        assertThat(stats.getTotalMemoryUsed(), is(0L));
-        assertThat(stats.getHits(), is(3L));
-        assertThat(stats.getMisses(), is(2L));
+        assertThat(stats.getDirectMemoryUsed()).isZero();
+        assertThat(stats.getHeapMemoryUsed()).isZero();
+        assertThat(stats.getTotalMemoryUsed()).isZero();
+        assertThat(stats.getHits()).isEqualTo(3L);
+        assertThat(stats.getMisses()).isEqualTo(2L);
 
         // Close
         cache.close();
     }
 
     @Test
-    public void testMaxSize() throws Exception {
+    void maxSize() throws Exception {
         final int maxSize = 1000;
         initializeCache(maxSize);
 
@@ -278,12 +274,12 @@ public class CaffeineCacheImplTest {
             System.out.println("Adding element " + e.key.uri + " of size=" + e.getMemUsage());
             entries.add(e);
             cache.put(e.key, e.payload);
-            assertThat(cache.get(e.key), is(e.payload));
+            assertThat(cache.get(e.key)).isEqualTo(e.payload);
             System.out.println(" > cache.memSize=" + cache.getMemSize());
             totSize += e.getMemUsage();
             // In the last insertion cache.getMemSize() will exceed the maximum
             if (totSize <= maxSize) {
-                assertThat(cache.getMemSize(), equalTo(totSize));
+                assertThat(cache.getMemSize()).isEqualTo(totSize);
             } else {
                 ok = true;
             }
@@ -293,7 +289,7 @@ public class CaffeineCacheImplTest {
 
         // Now we should have put in our cache much elements as it can contain + 1. The first one should be evicted.
         runEviction(cache, 1);
-        assertThat(evictedResources.size(), is(1));
+        assertThat(evictedResources).hasSize(1);
 
         // Doesn't work. It currently seems that the eviction process always evitcts the last entered key, which is
         // undoubtedly a serious issue
@@ -307,18 +303,18 @@ public class CaffeineCacheImplTest {
 //        }
 //        entries.remove(0);
         CacheEntry evictedEntry = evictedResources.get(0);
-        assertTrue(entries.remove(evictedEntry));
+        assertThat(entries.remove(evictedEntry)).isTrue();
 
-        assertThat((int) cache.getMemSize(), equalTo(entries.stream().mapToInt(e -> (int) e.getMemUsage()).sum()));
-        assertThat((int) cache.getSize(), is(entries.size()));
+        assertThat((int) cache.getMemSize()).isEqualTo(entries.stream().mapToInt(e -> (int) e.getMemUsage()).sum());
+        assertThat((int) cache.getSize()).isEqualTo(entries.size());
 
-        assertThat((int) stats.getDirectMemoryUsed(), is(entries.stream().mapToInt(e -> (int) e.payload.directSize).sum()));
-        assertThat((int) stats.getHeapMemoryUsed(), is(entries.stream().mapToInt(e -> (int) e.payload.heapSize).sum()));
-        assertThat((int) stats.getTotalMemoryUsed(), is(entries.stream().mapToInt(e -> (int) e.getMemUsage()).sum()));
+        assertThat((int) stats.getDirectMemoryUsed()).isEqualTo(entries.stream().mapToInt(e -> (int) e.payload.directSize).sum());
+        assertThat((int) stats.getHeapMemoryUsed()).isEqualTo(entries.stream().mapToInt(e -> (int) e.payload.heapSize).sum());
+        assertThat((int) stats.getTotalMemoryUsed()).isEqualTo(entries.stream().mapToInt(e -> (int) e.getMemUsage()).sum());
     }
 
     @Test
-    public void testExipiration() throws Exception {
+    void exipiration() throws Exception {
         initializeCache(0);
 
         List<CacheEntry> entries = new ArrayList<>();
@@ -328,11 +324,11 @@ public class CaffeineCacheImplTest {
             System.out.println("Adding element " + e.key.uri + " with expireTs=" + new java.sql.Timestamp(expireTs));
             entries.add(e);
             cache.put(e.key, e.payload);
-            assertThat(cache.get(e.key), is(e.payload));
+            assertThat(cache.get(e.key)).isEqualTo(e.payload);
 
             expireTs += 10000;
         }
-        assertThat((int) cache.getSize(), is(10));
+        assertThat((int) cache.getSize()).isEqualTo(10);
 
         // No entries should be removed
         Executors.newSingleThreadExecutor().execute(() -> {
@@ -344,18 +340,18 @@ public class CaffeineCacheImplTest {
             }
         });
         runEviction(cache, 0);
-        assertThat(evictedResources.size(), is(0));
+        assertThat(evictedResources).isEmpty();
 
         // Only the first entry should be removed
         Thread.sleep(1000);
         runEviction(cache, 1);
-        assertThat(evictedResources.size(), is(1));
-        assertThat(evictedResources.get(0), equalTo(entries.get(0)));
-        assertThat(evictedResources.get(0).removalCause, equalTo(RemovalCause.EXPIRED));
+        assertThat(evictedResources).hasSize(1);
+        assertThat(evictedResources.get(0)).isEqualTo(entries.get(0));
+        assertThat(evictedResources.get(0).removalCause).isEqualTo(RemovalCause.EXPIRED);
         evictedResources.clear();
         entries.remove(0);
 
-        assertThat((int) cache.getSize(), is(10 - 1));
+        assertThat((int) cache.getSize()).isEqualTo(10 - 1);
 
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CaffeineCacheImplTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CaffeineCacheImplTest.java
@@ -194,7 +194,6 @@ public class CaffeineCacheImplTest {
 
         // Put 2b (replace 2)
         CacheEntry e2b = genCacheEntry("res_2", 300, 0);
-        assertThat(e2b.key).isEqualTo(e2.key);
         cache.put(e2b.key, e2b.payload);
         assertThat(cache.get(e2b.key)).isEqualTo(e2b.payload);
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/CaffeineCacheImplTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/CaffeineCacheImplTest.java
@@ -199,10 +199,11 @@ public class CaffeineCacheImplTest {
         assertThat(cache.get(e2b.key)).isEqualTo(e2b.payload);
 
         runEviction(cache, 1);
-        assertThat(evictedResources).hasSize(1);
-        assertThat(evictedResources.get(0).key).isEqualTo(e2.key);
-        assertThat(evictedResources.get(0).payload).isEqualTo(e2.payload);
-        assertThat(evictedResources.get(0).removalCause).isEqualTo(RemovalCause.REPLACED);
+        assertThat(evictedResources).singleElement().satisfies(it -> {
+            assertThat(it.key).isEqualTo(e2.key);
+            assertThat(it.payload).isEqualTo(e2.payload);
+            assertThat(it.removalCause).isEqualTo(RemovalCause.REPLACED);
+        });
         evictedResources.clear();
 
         assertThat(cache.getSize()).isEqualTo(2);
@@ -219,10 +220,11 @@ public class CaffeineCacheImplTest {
         assertThat(cache.get(e1.key)).isNull();
 
         runEviction(cache, 1);
-        assertThat(evictedResources).hasSize(1);
-        assertThat(evictedResources.get(0).key).isEqualTo(e1.key);
-        assertThat(evictedResources.get(0).payload).isEqualTo(e1.payload);
-        assertThat(evictedResources.get(0).removalCause).isEqualTo(RemovalCause.EXPLICIT);
+        assertThat(evictedResources).singleElement().satisfies(it -> {
+            assertThat(it.key).isEqualTo(e1.key);
+            assertThat(it.payload).isEqualTo(e1.payload);
+            assertThat(it.removalCause).isEqualTo(RemovalCause.EXPLICIT);
+        });
         evictedResources.clear();
 
         assertThat(cache.getSize()).isOne();
@@ -239,10 +241,11 @@ public class CaffeineCacheImplTest {
         assertThat(cache.get(e2.key)).isNull();
 
         runEviction(cache, 1);
-        assertThat(evictedResources).hasSize(1);
-        assertThat(evictedResources.get(0).key).isEqualTo(e2b.key);
-        assertThat(evictedResources.get(0).payload).isEqualTo(e2b.payload);
-        assertThat(evictedResources.get(0).removalCause).isEqualTo(RemovalCause.EXPLICIT);
+        assertThat(evictedResources).singleElement().satisfies(it -> {
+            assertThat(it.key).isEqualTo(e2b.key);
+            assertThat(it.payload).isEqualTo(e2b.payload);
+            assertThat(it.removalCause).isEqualTo(RemovalCause.EXPLICIT);
+        });
         evictedResources.clear();
 
         assertThat(cache.getSize()).isZero();
@@ -345,9 +348,10 @@ public class CaffeineCacheImplTest {
         // Only the first entry should be removed
         Thread.sleep(1000);
         runEviction(cache, 1);
-        assertThat(evictedResources).hasSize(1);
-        assertThat(evictedResources.get(0)).isEqualTo(entries.get(0));
-        assertThat(evictedResources.get(0).removalCause).isEqualTo(RemovalCause.EXPIRED);
+        assertThat(evictedResources).singleElement().satisfies(it -> {
+            assertThat(it).isEqualTo(entries.get(0));
+            assertThat(it.removalCause).isEqualTo(RemovalCause.EXPIRED);
+        });
         evictedResources.clear();
         entries.remove(0);
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/NotModifiedIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/NotModifiedIT.java
@@ -71,7 +71,7 @@ public class NotModifiedIT {
                 assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h ->
                     System.out.println("HEADER LINE :" + h));
-                assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
+                assertThat(resp.getHeaderLines()).noneSatisfy(h -> assertThat(h).contains("X-Cached"));
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
@@ -83,9 +83,9 @@ public class NotModifiedIT {
                     assertThat(resp.getStatusLine().trim()).isEqualTo("HTTP/1.1 304 Not Modified");
                     resp.getHeaderLines().forEach(h ->
                         System.out.println("HEADER LINE :" + h));
-                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
-                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("expires"));
-                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("last-modified"));
+                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("expires"));
+                    assertThat(resp.getHeaderLines()).anySatisfy(h -> assertThat(h).contains("last-modified"));
                     assertThat(resp.getBodyString()).isEmpty();
                 }
             }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/cache/NotModifiedIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/cache/NotModifiedIT.java
@@ -24,9 +24,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -49,7 +47,7 @@ public class NotModifiedIT {
     public File tmpDir;
 
     @Test
-    public void testServeFromCacheAnswer304() throws Exception {
+    void serveFromCacheAnswer304() throws Exception {
 
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
@@ -70,10 +68,10 @@ public class NotModifiedIT {
                 RawHttpClient.HttpResponse resp = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
                 String s = resp.toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
                 resp.getHeaderLines().forEach(h ->
                     System.out.println("HEADER LINE :" + h));
-                assertFalse(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
+                assertThat(resp.getHeaderLines()).noneMatch(h -> h.contains("X-Cached"));
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
@@ -82,19 +80,19 @@ public class NotModifiedIT {
                             + "Host: localhost\r\n"
                             + "If-Modified-Since: " + HttpUtils.formatDateHeader(new java.util.Date(System.currentTimeMillis())) + "\r\n"
                             + "\r\n");
-                    assertEquals("HTTP/1.1 304 Not Modified", resp.getStatusLine().trim());
+                    assertThat(resp.getStatusLine().trim()).isEqualTo("HTTP/1.1 304 Not Modified");
                     resp.getHeaderLines().forEach(h ->
                         System.out.println("HEADER LINE :" + h));
-                    assertTrue(resp.getHeaderLines().stream().anyMatch(h -> h.contains("X-Cached")));
-                    assertTrue(resp.getHeaderLines().stream().anyMatch(h -> h.contains("expires")));
-                    assertTrue(resp.getHeaderLines().stream().anyMatch(h -> h.contains("last-modified")));
-                    assertTrue(resp.getBodyString().isEmpty());
+                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("X-Cached"));
+                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("expires"));
+                    assertThat(resp.getHeaderLines()).anyMatch(h -> h.contains("last-modified"));
+                    assertThat(resp.getBodyString()).isEmpty();
                 }
             }
 
-            assertEquals(1, server.getCache().getCacheSize());
-            assertEquals(1, server.getCache().getStats().getHits());
-            assertEquals(1, server.getCache().getStats().getMisses());
+            assertThat(server.getCache().getCacheSize()).isOne();
+            assertThat(server.getCache().getStats().getHits()).isOne();
+            assertThat(server.getCache().getStats().getMisses()).isOne();
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/ACMEClientTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/ACMEClientTest.java
@@ -19,8 +19,8 @@
  */
 package org.carapaceproxy.server.certificates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -34,54 +34,54 @@ import org.shredzone.acme4j.Status;
 import org.shredzone.acme4j.challenge.Challenge;
 import org.shredzone.acme4j.util.KeyPairUtils;
 
-public class ACMEClientTest {
+class ACMEClientTest {
 
     private final ACMEClient client = new ACMEClient(KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE), true);
 
     @Test
-    public void testCheckResponseForChallengeReturnsRefreshedStatus() throws Exception {
+    void checkResponseForChallengeReturnsRefreshedStatus() throws Exception {
         Challenge challenge = mock(Challenge.class);
         when(challenge.getStatus()).thenReturn(Status.PROCESSING, Status.VALID);
 
-        assertEquals(Status.VALID, client.checkResponseForChallenge(challenge));
+        assertThat(client.checkResponseForChallenge(challenge)).isEqualTo(Status.VALID);
         verify(challenge).fetch();
     }
 
     @Test
-    public void testCheckResponseForChallengeSkipsFetchWhenAlreadyValid() throws Exception {
+    void checkResponseForChallengeSkipsFetchWhenAlreadyValid() throws Exception {
         Challenge challenge = mock(Challenge.class);
         when(challenge.getStatus()).thenReturn(Status.VALID);
 
-        assertEquals(Status.VALID, client.checkResponseForChallenge(challenge));
+        assertThat(client.checkResponseForChallenge(challenge)).isEqualTo(Status.VALID);
         verify(challenge, never()).fetch();
     }
 
     @Test
-    public void testCheckResponseForChallengeSkipsFetchWhenInvalid() throws Exception {
+    void checkResponseForChallengeSkipsFetchWhenInvalid() throws Exception {
         Challenge challenge = mock(Challenge.class);
         when(challenge.getStatus()).thenReturn(Status.INVALID);
 
-        assertEquals(Status.INVALID, client.checkResponseForChallenge(challenge));
+        assertThat(client.checkResponseForChallenge(challenge)).isEqualTo(Status.INVALID);
         verify(challenge, never()).fetch();
     }
 
     @Test
-    public void testCheckResponseForOrderReturnsFetchedStatus() throws Exception {
+    void checkResponseForOrderReturnsFetchedStatus() throws Exception {
         Order order = mockOrder();
         when(order.getStatus()).thenReturn(Status.VALID);
 
-        assertEquals(Status.VALID, client.checkResponseForOrder(order));
+        assertThat(client.checkResponseForOrder(order)).isEqualTo(Status.VALID);
         verify(order, times(1)).fetch();
     }
 
     @Test
-    public void testCheckResponseForOrderFetchesOncePerPoll() throws Exception {
+    void checkResponseForOrderFetchesOncePerPoll() throws Exception {
         // a freshly bound order has no cached state and any accessor would lazy-fetch,
         // so the explicit eager fetch has to be the only server round-trip of the poll
         Order order = mockOrder();
         when(order.getStatus()).thenReturn(Status.PROCESSING);
 
-        assertEquals(Status.PROCESSING, client.checkResponseForOrder(order));
+        assertThat(client.checkResponseForOrder(order)).isEqualTo(Status.PROCESSING);
         verify(order, times(1)).fetch();
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/AcmeFailureClassifierTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/AcmeFailureClassifierTest.java
@@ -19,8 +19,7 @@
  */
 package org.carapaceproxy.server.certificates;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
@@ -35,44 +34,44 @@ import org.shredzone.acme4j.exception.AcmeRateLimitedException;
 import org.shredzone.acme4j.exception.AcmeServerException;
 import org.shredzone.acme4j.toolbox.JSON;
 
-public class AcmeFailureClassifierTest {
+class AcmeFailureClassifierTest {
 
     @Test
-    public void testRejections() throws Exception {
+    void rejections() throws Exception {
         // the persisted state is unusable, retrying it won't help
-        assertFalse(AcmeFailureClassifier.isTransient(new AcmeException("unknown order")));
-        assertFalse(AcmeFailureClassifier.isTransient(new AcmeProtocolException("malformed CA response")));
-        assertFalse(AcmeFailureClassifier.isTransient(new AcmeLazyLoadingException(
-                Order.class, URI.create("https://localhost/order").toURL(), new AcmeException("unknown order"))));
-        assertFalse(AcmeFailureClassifier.isTransient(
-                new AcmeServerException(problemOfType("urn:ietf:params:acme:error:unauthorized"))));
+        assertThat(AcmeFailureClassifier.isTransient(new AcmeException("unknown order"))).isFalse();
+        assertThat(AcmeFailureClassifier.isTransient(new AcmeProtocolException("malformed CA response"))).isFalse();
+        assertThat(AcmeFailureClassifier.isTransient(new AcmeLazyLoadingException(
+                Order.class, URI.create("https://localhost/order").toURL(), new AcmeException("unknown order")))).isFalse();
+        assertThat(AcmeFailureClassifier.isTransient(
+                new AcmeServerException(problemOfType("urn:ietf:params:acme:error:unauthorized")))).isFalse();
     }
 
     @Test
-    public void testTransientFailures() throws Exception {
+    void transientFailures() throws Exception {
         // worth retrying in the same state
-        assertTrue(AcmeFailureClassifier.isTransient(new AcmeNetworkException(new IOException("io"))));
-        assertTrue(AcmeFailureClassifier.isTransient(new AcmeRateLimitedException(
-                problemOfType("urn:ietf:params:acme:error:rateLimited"), null, List.of())));
-        assertTrue(AcmeFailureClassifier.isTransient(
-                new AcmeServerException(problemOfType("urn:ietf:params:acme:error:serverInternal"))));
-        assertTrue(AcmeFailureClassifier.isTransient(
-                new AcmeServerException(problemOfType("urn:ietf:params:acme:error:badNonce"))));
+        assertThat(AcmeFailureClassifier.isTransient(new AcmeNetworkException(new IOException("io")))).isTrue();
+        assertThat(AcmeFailureClassifier.isTransient(new AcmeRateLimitedException(
+                problemOfType("urn:ietf:params:acme:error:rateLimited"), null, List.of()))).isTrue();
+        assertThat(AcmeFailureClassifier.isTransient(
+                new AcmeServerException(problemOfType("urn:ietf:params:acme:error:serverInternal")))).isTrue();
+        assertThat(AcmeFailureClassifier.isTransient(
+                new AcmeServerException(problemOfType("urn:ietf:params:acme:error:badNonce")))).isTrue();
         // a 5xx without a problem document, e.g., from a load balancer
-        assertTrue(AcmeFailureClassifier.isTransient(new AcmeException("HTTP 503")));
+        assertThat(AcmeFailureClassifier.isTransient(new AcmeException("HTTP 503"))).isTrue();
         // unwrapping a lazily-loaded resource failure preserves the transient classification
-        assertTrue(AcmeFailureClassifier.isTransient(new AcmeLazyLoadingException(
+        assertThat(AcmeFailureClassifier.isTransient(new AcmeLazyLoadingException(
                 Order.class,
                 URI.create("https://localhost/order").toURL(),
-                new AcmeNetworkException(new IOException("connection reset")))));
+                new AcmeNetworkException(new IOException("connection reset"))))).isTrue();
         // a message-less failure must not blow up the message match
-        assertFalse(AcmeFailureClassifier.isTransient(new AcmeException((String) null)));
+        assertThat(AcmeFailureClassifier.isTransient(new AcmeException((String) null))).isFalse();
     }
 
     @Test
-    public void testNonAcmeFailures() {
+    void nonAcmeFailures() {
         // an unexpected local failure must be counted too, or it would retry invisibly forever
-        assertFalse(AcmeFailureClassifier.isTransient(new IllegalStateException("boom")));
+        assertThat(AcmeFailureClassifier.isTransient(new IllegalStateException("boom"))).isFalse();
     }
 
     private static Problem problemOfType(String type) throws Exception {

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesIT.java
@@ -484,9 +484,7 @@ public class CertificatesIT extends UseAdminServer {
 
         // the overwritten row was restored, so the failed update cannot go live
         CertificateData restored = store.loadCertificateForDomain("localhost2");
-        assertThat(restored.getChain()).isEqualTo(previous.getChain());
-        assertThat(restored.getState()).isEqualTo(previous.getState());
-        assertThat(restored.getProvider()).isEqualTo(previous.getProvider());
+        assertThat(restored).usingRecursiveComparison().isEqualTo(previous);
     }
 
     @Test

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesIT.java
@@ -479,7 +479,8 @@ public class CertificatesIT extends UseAdminServer {
         // unknown provider bypassing the API pre-validation: the configuration apply fails
         CertificateData update = new CertificateData("localhost2", null, DynamicCertificateState.WAITING);
         update.setProvider("ghost");
-        assertThatThrownBy(() -> server.updateDynamicCertificateForDomain(update)).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> server.updateDynamicCertificateForDomain(update)).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Invalid value 'ghost' for certificate.2.provider: no such ACME provider");
 
         // the overwritten row was restored, so the failed update cannot go live
         CertificateData restored = store.loadCertificateForDomain("localhost2");

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesIT.java
@@ -23,6 +23,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static java.util.Set.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64DecodeCertificateChain;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_DAYS_BEFORE_RENEWAL;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
@@ -30,16 +33,6 @@ import static org.carapaceproxy.server.config.AcmeProviderConfiguration.DEFAULT_
 import static org.carapaceproxy.utils.CertificatesTestUtils.generateSampleChain;
 import static org.carapaceproxy.utils.CertificatesTestUtils.uploadCertificate;
 import static org.carapaceproxy.utils.CertificatesUtils.createKeystore;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -93,7 +86,7 @@ import org.carapaceproxy.utils.TestUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.shredzone.acme4j.Login;
 import org.shredzone.acme4j.Order;
 import org.shredzone.acme4j.util.KeyPairUtils;
@@ -177,7 +170,7 @@ public class CertificatesIT extends UseAdminServer {
      * - Make request expected updated certificate
      */
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         configureAndStartServer();
         int port = server.getLocalPort();
 
@@ -185,9 +178,9 @@ public class CertificatesIT extends UseAdminServer {
         Certificate[] chain0;
         try (RawHttpClient client = new RawHttpClient("localhost", port, true, "localhost")) {
             RawHttpClient.HttpResponse resp = client.get("/index.html", credentials);
-            assertEquals("it <b>works</b> !!", resp.getBodyString());
+            assertThat(resp.getBodyString()).isEqualTo("it <b>works</b> !!");
             chain0 = client.getServerCertificate();
-            assertNotNull(chain0);
+            assertThat(chain0).isNotNull();
         }
 
         // Update settings adding manual certificate (but without upload it)
@@ -197,17 +190,17 @@ public class CertificatesIT extends UseAdminServer {
 
         DynamicCertificatesManager dynCertMan = server.getDynamicCertificatesManager();
         CertificateData data = dynCertMan.getCertificateDataForDomain("localhost");
-        assertNotNull(data);
-        assertTrue(data.isManual());
+        assertThat(data).isNotNull();
+        assertThat(data.isManual()).isTrue();
 
         // Request #1: still expected default certificate
         Certificate[] chain1;
         try (RawHttpClient client = new RawHttpClient("localhost", port, true, "localhost")) {
             RawHttpClient.HttpResponse resp = client.get("/index.html", credentials);
-            assertEquals("it <b>works</b> !!", resp.getBodyString());
+            assertThat(resp.getBodyString()).isEqualTo("it <b>works</b> !!");
             chain1 = client.getServerCertificate();
-            assertNotNull(chain1);
-            assertEquals(chain0[0], chain1[0]);
+            assertThat(chain1).isNotNull();
+            assertThat(chain1[0]).isEqualTo(chain0[0]);
         }
 
         // Upload manual certificate
@@ -217,21 +210,21 @@ public class CertificatesIT extends UseAdminServer {
             uploadedChain = generateSampleChain(endUserKeyPair, false);
             byte[] chainData = createKeystore(uploadedChain, endUserKeyPair.getPrivate());
             HttpResponse resp = uploadCertificate("localhost", null, chainData, client, credentials);
-            assertTrue(resp.getBodyString().contains("SUCCESS"));
+            assertThat(resp.getBodyString()).contains("SUCCESS");
             data = dynCertMan.getCertificateDataForDomain("localhost");
-            assertNotNull(data);
-            assertTrue(data.isManual());
-            assertSame(data.getState(), DynamicCertificateState.AVAILABLE);
+            assertThat(data).isNotNull();
+            assertThat(data.isManual()).isTrue();
+            assertThat(data.getState()).isSameAs(DynamicCertificateState.AVAILABLE);
         }
 
         // Request #2: expected uploaded certificate
         Certificate[] chain2;
         try (RawHttpClient client = new RawHttpClient("localhost", port, true, "localhost")) {
             RawHttpClient.HttpResponse resp = client.get("/index.html", credentials);
-            assertEquals("it <b>works</b> !!", resp.getBodyString());
+            assertThat(resp.getBodyString()).isEqualTo("it <b>works</b> !!");
             chain2 = client.getServerCertificate();
-            assertNotNull(chain2);
-            assertEquals(uploadedChain[0], chain2[0]);
+            assertThat(chain2).isNotNull();
+            assertThat(chain2[0]).isEqualTo(uploadedChain[0]);
         }
 
         // Update manual certificate
@@ -239,36 +232,36 @@ public class CertificatesIT extends UseAdminServer {
         try (RawHttpClient client = new RawHttpClient("localhost", DEFAULT_ADMIN_PORT)) {
             KeyPair endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
             uploadedChain2 = generateSampleChain(endUserKeyPair, false);
-            assertNotEquals(uploadedChain[0], uploadedChain2[0]);
+            assertThat(uploadedChain2[0]).isNotEqualTo(uploadedChain[0]);
             byte[] chainData = createKeystore(uploadedChain2, endUserKeyPair.getPrivate());
             HttpResponse resp = uploadCertificate("localhost", null, chainData, client, credentials);
-            assertTrue(resp.getBodyString().contains("SUCCESS"));
+            assertThat(resp.getBodyString()).contains("SUCCESS");
             data = dynCertMan.getCertificateDataForDomain("localhost");
-            assertNotNull(data);
-            assertTrue(data.isManual());
-            assertSame(data.getState(), DynamicCertificateState.AVAILABLE);
+            assertThat(data).isNotNull();
+            assertThat(data.isManual()).isTrue();
+            assertThat(data.getState()).isSameAs(DynamicCertificateState.AVAILABLE);
         }
 
         // Request #3: expected last uploaded certificate
         Certificate[] chain3;
         try (RawHttpClient client = new RawHttpClient("localhost", port, true, "localhost")) {
             RawHttpClient.HttpResponse resp = client.get("/index.html", credentials);
-            assertEquals("it <b>works</b> !!", resp.getBodyString());
+            assertThat(resp.getBodyString()).isEqualTo("it <b>works</b> !!");
             chain3 = client.getServerCertificate();
-            assertNotNull(chain3);
-            assertEquals(uploadedChain2[0], chain3[0]);
+            assertThat(chain3).isNotNull();
+            assertThat(chain3[0]).isEqualTo(uploadedChain2[0]);
         }
 
         // this calls "reloadFromDB" > "manual" flag has to be retained even if not stored in db.
         dynCertMan.setStateOfCertificate("localhost", DynamicCertificateState.WAITING);
         data = dynCertMan.getCertificateDataForDomain("localhost");
-        assertNotNull(data);
-        assertTrue(data.isManual());
+        assertThat(data).isNotNull();
+        assertThat(data.isManual()).isTrue();
     }
 
     @ParameterizedTest
-    @CsvSource({"acme", "manual"})
-    public void testUploadTypedCertificate(String type) throws Exception {
+    @ValueSource(strings = {"acme", "manual"})
+    void uploadTypedCertificate(String type) throws Exception {
         configureAndStartServer();
         int port = server.getLocalPort();
         DynamicCertificatesManager dynCertsMan = server.getDynamicCertificatesManager();
@@ -279,12 +272,12 @@ public class CertificatesIT extends UseAdminServer {
         try (RawHttpClient client = new RawHttpClient("localhost", DEFAULT_ADMIN_PORT)) {
             HttpResponse resp = uploadCertificate("localhost", "type=" + type, new byte[0], client, credentials);
             if (type.equals("manual")) {
-                assertTrue(resp.getBodyString().contains("ERROR: certificate data required"));
+                assertThat(resp.getBodyString()).contains("ERROR: certificate data required");
             } else {
                 CertificateData data = dynCertsMan.getCertificateDataForDomain("localhost");
-                assertNotNull(data);
-                assertFalse(data.isManual());
-                assertEquals(DynamicCertificateState.WAITING, dynCertsMan.getStateOfCertificate("localhost")); // no certificate-data uploaded
+                assertThat(data).isNotNull();
+                assertThat(data.isManual()).isFalse();
+                assertThat(dynCertsMan.getStateOfCertificate("localhost")).isEqualTo(DynamicCertificateState.WAITING); // no certificate-data uploaded
             }
         }
 
@@ -294,26 +287,26 @@ public class CertificatesIT extends UseAdminServer {
             Certificate[] chain = generateSampleChain(endUserKeyPair, false);
             byte[] chainData = createKeystore(chain, endUserKeyPair.getPrivate());
             HttpResponse resp = uploadCertificate("localhost", "type=" + type, chainData, client, credentials);
-            assertTrue(resp.getBodyString().contains("SUCCESS"));
+            assertThat(resp.getBodyString()).contains("SUCCESS");
             CertificateData data = dynCertsMan.getCertificateDataForDomain("localhost");
-            assertNotNull(data);
-            assertEquals(type.equals("manual"), data.isManual());
-            assertEquals(DynamicCertificateState.AVAILABLE, dynCertsMan.getStateOfCertificate("localhost"));
+            assertThat(data).isNotNull();
+            assertThat(data.isManual()).isEqualTo(type.equals("manual"));
+            assertThat(dynCertsMan.getStateOfCertificate("localhost")).isEqualTo(DynamicCertificateState.AVAILABLE);
 
             // check uploaded certificate
             try (RawHttpClient c = new RawHttpClient("localhost", port, true, "localhost")) {
                 RawHttpClient.HttpResponse r = c.get("/index.html", credentials);
-                assertEquals("it <b>works</b> !!", r.getBodyString());
+                assertThat(r.getBodyString()).isEqualTo("it <b>works</b> !!");
                 Certificate[] obtainedChain = c.getServerCertificate();
-                assertNotNull(obtainedChain);
-                assertEquals(chain[0], obtainedChain[0]);
+                assertThat(obtainedChain).isNotNull();
+                assertThat(obtainedChain[0]).isEqualTo(chain[0]);
             }
         }
 
         // Uploading trush: bad "type"
         try (RawHttpClient client = new RawHttpClient("localhost", DEFAULT_ADMIN_PORT)) {
             HttpResponse resp = uploadCertificate("localhost", "type=undefined", new byte[0], client, credentials);
-            assertTrue(resp.getBodyString().contains("ERROR: illegal type"));
+            assertThat(resp.getBodyString()).contains("ERROR: illegal type");
         }
 
         // Uploading same certificate but with different type (will be update)
@@ -323,35 +316,35 @@ public class CertificatesIT extends UseAdminServer {
             Certificate[] chain = generateSampleChain(endUserKeyPair, false);
             byte[] chainData = createKeystore(chain, endUserKeyPair.getPrivate());
             HttpResponse resp = uploadCertificate("localhost", "type=" + otherType, chainData, client, credentials);
-            assertTrue(resp.getBodyString().contains("SUCCESS"));
+            assertThat(resp.getBodyString()).contains("SUCCESS");
             CertificateData data = dynCertsMan.getCertificateDataForDomain("localhost");
-            assertNotNull(data);
-            assertEquals(otherType.equals("manual"), data.isManual());
-            assertEquals(DynamicCertificateState.AVAILABLE, dynCertsMan.getStateOfCertificate("localhost"));
+            assertThat(data).isNotNull();
+            assertThat(data.isManual()).isEqualTo(otherType.equals("manual"));
+            assertThat(dynCertsMan.getStateOfCertificate("localhost")).isEqualTo(DynamicCertificateState.AVAILABLE);
 
             // check uploaded certificate
             try (RawHttpClient c = new RawHttpClient("localhost", port, true, "localhost")) {
                 RawHttpClient.HttpResponse r = c.get("/index.html", credentials);
-                assertEquals("it <b>works</b> !!", r.getBodyString());
+                assertThat(r.getBodyString()).isEqualTo("it <b>works</b> !!");
                 Certificate[] obtainedChain = c.getServerCertificate();
-                assertNotNull(obtainedChain);
-                assertEquals(chain[0], obtainedChain[0]);
+                assertThat(obtainedChain).isNotNull();
+                assertThat(obtainedChain[0]).isEqualTo(chain[0]);
             }
 
             resp = uploadCertificate("localhost", "type=" + type, new byte[0], client, credentials);
             if (type.equals("acme")) {
-                assertTrue(resp.getBodyString().contains("SUCCESS"));
+                assertThat(resp.getBodyString()).contains("SUCCESS");
                 data = dynCertsMan.getCertificateDataForDomain("localhost");
-                assertNotNull(data);
-                assertFalse(data.isManual());
-                assertEquals(DynamicCertificateState.WAITING, dynCertsMan.getStateOfCertificate("localhost")); // no certificate-data uploaded
+                assertThat(data).isNotNull();
+                assertThat(data.isManual()).isFalse();
+                assertThat(dynCertsMan.getStateOfCertificate("localhost")).isEqualTo(DynamicCertificateState.WAITING); // no certificate-data uploaded
             }
         }
     }
 
     @ParameterizedTest
-    @CsvSource({"acme", "manual"})
-    public void testUploadTypedCertificatesWithDaysBeforeRenewal(String type) throws Exception {
+    @ValueSource(strings = {"acme", "manual"})
+    void uploadTypedCertificatesWithDaysBeforeRenewal(String type) throws Exception {
         configureAndStartServer();
         int port = server.getLocalPort();
         DynamicCertificatesManager dynCertsMan = server.getDynamicCertificatesManager();
@@ -363,67 +356,67 @@ public class CertificatesIT extends UseAdminServer {
             // Create
             HttpResponse resp = uploadCertificate("localhost2", "type=" + type + "&daysbeforerenewal=10", chainData, client, credentials);
             if (type.equals("manual")) {
-                assertTrue(resp.getBodyString().contains("ERROR: param 'daysbeforerenewal' available for type 'acme' only"));
+                assertThat(resp.getBodyString()).contains("ERROR: param 'daysbeforerenewal' available for type 'acme' only");
             } else {
                 CertificateData data = dynCertsMan.getCertificateDataForDomain("localhost2");
-                assertNotNull(data);
-                assertEquals(10, data.getDaysBeforeRenewal());
+                assertThat(data).isNotNull();
+                assertThat(data.getDaysBeforeRenewal()).isEqualTo(10);
             }
             // negative value
             resp = uploadCertificate("localhost-negative", "type=" + type + "&daysbeforerenewal=-10", chainData, client, credentials);
             if (type.equals("manual")) {
-                assertTrue(resp.getBodyString().contains("ERROR: param 'daysbeforerenewal' available for type 'acme' only"));
+                assertThat(resp.getBodyString()).contains("ERROR: param 'daysbeforerenewal' available for type 'acme' only");
             } else {
-                assertTrue(resp.getBodyString().contains("ERROR: param 'daysbeforerenewal' has to be a positive number"));
+                assertThat(resp.getBodyString()).contains("ERROR: param 'daysbeforerenewal' has to be a positive number");
             }
             // default value
             uploadCertificate("localhost-default", "type=" + type, chainData, client, credentials);
             CertificateData data = dynCertsMan.getCertificateDataForDomain("localhost-default");
-            assertNotNull(data);
-            assertEquals(type.equals("manual") ? 0 : DEFAULT_DAYS_BEFORE_RENEWAL, data.getDaysBeforeRenewal());
+            assertThat(data).isNotNull();
+            assertThat(data.getDaysBeforeRenewal()).isEqualTo(type.equals("manual") ? 0 : DEFAULT_DAYS_BEFORE_RENEWAL);
 
             // Update
             uploadCertificate("localhost2", "type=" + type + "&daysbeforerenewal=45", chainData, client, credentials);
             if (type.equals("manual")) {
-                assertTrue(resp.getBodyString().contains("ERROR: param 'daysbeforerenewal' available for type 'acme' only"));
+                assertThat(resp.getBodyString()).contains("ERROR: param 'daysbeforerenewal' available for type 'acme' only");
             } else {
                 data = dynCertsMan.getCertificateDataForDomain("localhost2");
-                assertNotNull(data);
-                assertEquals(45, data.getDaysBeforeRenewal());
+                assertThat(data).isNotNull();
+                assertThat(data.getDaysBeforeRenewal()).isEqualTo(45);
             }
             // negative value
             resp = uploadCertificate("localhost2", "type=" + type + "&daysbeforerenewal=-10", chainData, client, credentials);
             if (type.equals("manual")) {
-                assertTrue(resp.getBodyString().contains("ERROR: param 'daysbeforerenewal' available for type 'acme' only"));
+                assertThat(resp.getBodyString()).contains("ERROR: param 'daysbeforerenewal' available for type 'acme' only");
             } else {
-                assertTrue(resp.getBodyString().contains("ERROR: param 'daysbeforerenewal' has to be a positive number"));
+                assertThat(resp.getBodyString()).contains("ERROR: param 'daysbeforerenewal' has to be a positive number");
             }
             // default value
             uploadCertificate("localhost2", "type=" + type, chainData, client, credentials);
             data = dynCertsMan.getCertificateDataForDomain("localhost2");
-            assertNotNull(data);
-            assertEquals(type.equals("manual") ? 0 : DEFAULT_DAYS_BEFORE_RENEWAL, data.getDaysBeforeRenewal());
+            assertThat(data).isNotNull();
+            assertThat(data.getDaysBeforeRenewal()).isEqualTo(type.equals("manual") ? 0 : DEFAULT_DAYS_BEFORE_RENEWAL);
             // changing the type (acme <-> manual)
             String other = type.equals("manual") ? "acme" : "manual";
             uploadCertificate("localhost2", "type=" + other, chainData, client, credentials);
             data = dynCertsMan.getCertificateDataForDomain("localhost2");
-            assertNotNull(data);
-            assertEquals(other.equals("manual") ? 0 : DEFAULT_DAYS_BEFORE_RENEWAL, data.getDaysBeforeRenewal());
+            assertThat(data).isNotNull();
+            assertThat(data.getDaysBeforeRenewal()).isEqualTo(other.equals("manual") ? 0 : DEFAULT_DAYS_BEFORE_RENEWAL);
             SSLCertificateConfiguration config = server.getCurrentConfiguration().getCertificates().get("localhost2");
-            assertEquals(other.equals("manual") ? 0 : DEFAULT_DAYS_BEFORE_RENEWAL, config.getDaysBeforeRenewal());
+            assertThat(config.getDaysBeforeRenewal()).isEqualTo(other.equals("manual") ? 0 : DEFAULT_DAYS_BEFORE_RENEWAL);
             // checking for "certificate.X.daysbeforerenewal" property delete
             ConfigurationStore store = server.getDynamicConfigurationStore();
-            assertEquals(other.equals("acme"), store.anyPropertyMatches((k, v) -> {
+            assertThat(store.anyPropertyMatches((k, v) -> {
                 if (k.matches("certificate\\.[0-9]+\\.hostname") && v.equals("localhost2")) {
                     return store.getProperty(k.replace("hostname", "daysbeforerenewal"), null) != null;
                 }
                 return false;
-            }));
+            })).isEqualTo(other.equals("acme"));
         }
     }
 
     @Test
-    public void testUploadTypedCertificatesWithProvider() throws Exception {
+    void uploadTypedCertificatesWithProvider() throws Exception {
         configureAndStartServer();
         DynamicCertificatesManager dynCertsMan = server.getDynamicCertificatesManager();
         KeyPair endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
@@ -439,36 +432,36 @@ public class CertificatesIT extends UseAdminServer {
             // provider is an ACME-only parameter
             HttpResponse resp = uploadCertificate(
                     "localhost2", "type=manual&provider=custom", chainData, client, credentials);
-            assertTrue(resp.getBodyString().contains("ERROR: param 'provider' available for type 'acme' only"));
+            assertThat(resp.getBodyString()).contains("ERROR: param 'provider' available for type 'acme' only");
 
             // unknown provider
             resp = uploadCertificate("localhost2", "type=acme&provider=unknown", chainData, client, credentials);
-            assertTrue(resp.getBodyString().contains("ERROR: unknown ACME provider"));
+            assertThat(resp.getBodyString()).contains("ERROR: unknown ACME provider");
 
             // custom provider
             resp = uploadCertificate("localhost2", "type=acme&provider=custom", chainData, client, credentials);
-            assertTrue(resp.getBodyString().contains("SUCCESS"));
+            assertThat(resp.getBodyString()).contains("SUCCESS");
             CertificateData data = dynCertsMan.getCertificateDataForDomain("localhost2");
-            assertNotNull(data);
-            assertEquals("custom", data.getProvider());
-            assertEquals("custom", server.getCurrentConfiguration().getCertificates().get("localhost2").getProvider());
+            assertThat(data).isNotNull();
+            assertThat(data.getProvider()).isEqualTo("custom");
+            assertThat(server.getCurrentConfiguration().getCertificates().get("localhost2").getProvider()).isEqualTo("custom");
             ConfigurationStore store = server.getDynamicConfigurationStore();
-            assertTrue(store.anyPropertyMatches((k, v) ->
+            assertThat(store.anyPropertyMatches((k, v) ->
                     k.matches("certificate\\.[0-9]+\\.provider") && v.equals("custom")
-            ));
+            )).isTrue();
 
             // update back to the default provider: the property gets removed
             resp = uploadCertificate("localhost2", "type=acme", chainData, client, credentials);
-            assertTrue(resp.getBodyString().contains("SUCCESS"));
+            assertThat(resp.getBodyString()).contains("SUCCESS");
             data = dynCertsMan.getCertificateDataForDomain("localhost2");
-            assertNotNull(data);
-            assertEquals(DEFAULT_PROVIDER_NAME, data.getProvider());
-            assertFalse(store.anyPropertyMatches((k, v) -> k.matches("certificate\\.[0-9]+\\.provider")));
+            assertThat(data).isNotNull();
+            assertThat(data.getProvider()).isEqualTo(DEFAULT_PROVIDER_NAME);
+            assertThat(store.anyPropertyMatches((k, v) -> k.matches("certificate\\.[0-9]+\\.provider"))).isFalse();
         }
     }
 
     @Test
-    public void testFailedConfigurationApplyRestoresCertificateData() throws Exception {
+    void failedConfigurationApplyRestoresCertificateData() throws Exception {
         configureAndStartServer();
         KeyPair endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
         Certificate[] chain = generateSampleChain(endUserKeyPair, false);
@@ -477,26 +470,26 @@ public class CertificatesIT extends UseAdminServer {
         // an existing certificate with data
         try (RawHttpClient client = new RawHttpClient("localhost", DEFAULT_ADMIN_PORT)) {
             HttpResponse resp = uploadCertificate("localhost2", "type=acme", chainData, client, credentials);
-            assertTrue(resp.getBodyString().contains("SUCCESS"));
+            assertThat(resp.getBodyString()).contains("SUCCESS");
         }
         ConfigurationStore store = server.getDynamicConfigurationStore();
         CertificateData previous = store.loadCertificateForDomain("localhost2");
-        assertNotNull(previous.getChain());
+        assertThat(previous.getChain()).isNotNull();
 
         // unknown provider bypassing the API pre-validation: the configuration apply fails
         CertificateData update = new CertificateData("localhost2", null, DynamicCertificateState.WAITING);
         update.setProvider("ghost");
-        assertThrows(IllegalStateException.class, () -> server.updateDynamicCertificateForDomain(update));
+        assertThatThrownBy(() -> server.updateDynamicCertificateForDomain(update)).isInstanceOf(IllegalStateException.class);
 
         // the overwritten row was restored, so the failed update cannot go live
         CertificateData restored = store.loadCertificateForDomain("localhost2");
-        assertEquals(previous.getChain(), restored.getChain());
-        assertEquals(previous.getState(), restored.getState());
-        assertEquals(previous.getProvider(), restored.getProvider());
+        assertThat(restored.getChain()).isEqualTo(previous.getChain());
+        assertThat(restored.getState()).isEqualTo(previous.getState());
+        assertThat(restored.getProvider()).isEqualTo(previous.getProvider());
     }
 
     @Test
-    public void testOCSP() throws Exception {
+    void ocsp() throws Exception {
         configureAndStartServer();
         int port = server.getLocalPort();
         OcspStaplingManager ocspMan = mock(OcspStaplingManager.class);
@@ -512,23 +505,23 @@ public class CertificatesIT extends UseAdminServer {
         byte[] chainData = createKeystore(uploadedChain, endUserKeyPair.getPrivate());
         try (RawHttpClient client = new RawHttpClient("localhost", DEFAULT_ADMIN_PORT)) {
             RawHttpClient.HttpResponse resp = uploadCertificate("localhost", null, chainData, client, credentials);
-            assertTrue(resp.getBodyString().contains("SUCCESS"));
+            assertThat(resp.getBodyString()).contains("SUCCESS");
             CertificateData data = dynCertMan.getCertificateDataForDomain("localhost");
-            assertNotNull(data);
-            assertTrue(data.isManual());
-            assertSame(data.getState(), DynamicCertificateState.AVAILABLE);
+            assertThat(data).isNotNull();
+            assertThat(data.isManual()).isTrue();
+            assertThat(data.getState()).isSameAs(DynamicCertificateState.AVAILABLE);
         }
 
         // check ocsp response
         try (RawHttpClient c = new RawHttpClient("localhost", port, true, "localhost")) {
             RawHttpClient.HttpResponse r = c.get("/index.html", credentials);
-            assertEquals("it <b>works</b> !!", r.getBodyString());
+            assertThat(r.getBodyString()).isEqualTo("it <b>works</b> !!");
             Certificate[] obtainedChain = c.getServerCertificate();
-            assertNotNull(obtainedChain);
-            assertTrue(CertificatesUtils.compareChains(uploadedChain, obtainedChain));
+            assertThat(obtainedChain).isNotNull();
+            assertThat(CertificatesUtils.compareChains(uploadedChain, obtainedChain)).isTrue();
             ExtendedSSLSession session = (ExtendedSSLSession) c.getSSLSocket().getSession();
             List<byte[]> statusResponses = session.getStatusResponses();
-            assertEquals(1, statusResponses.size());
+            assertThat(statusResponses).hasSize(1);
         }
     }
 
@@ -556,7 +549,7 @@ public class CertificatesIT extends UseAdminServer {
     }
 
     @Test
-    public void testCertificatesRenew() throws Exception {
+    void certificatesRenew() throws Exception {
 
         configureAndStartServer();
         int port = server.getLocalPort();
@@ -569,19 +562,19 @@ public class CertificatesIT extends UseAdminServer {
         try (RawHttpClient client = new RawHttpClient("localhost", DEFAULT_ADMIN_PORT)) {
             byte[] chainData = createKeystore(chain1, endUserKeyPair.getPrivate());
             HttpResponse resp = uploadCertificate("localhost", "type=acme&daysbeforerenewal=45", chainData, client, credentials);
-            assertTrue(resp.getBodyString().contains("SUCCESS"));
+            assertThat(resp.getBodyString()).contains("SUCCESS");
             CertificateData data = dcMan.getCertificateDataForDomain("localhost");
-            assertNotNull(data);
-            assertEquals(DynamicCertificateState.AVAILABLE, data.getState());
-            assertEquals(45, data.getDaysBeforeRenewal());
-            assertFalse(data.isManual());
+            assertThat(data).isNotNull();
+            assertThat(data.getState()).isEqualTo(DynamicCertificateState.AVAILABLE);
+            assertThat(data.getDaysBeforeRenewal()).isEqualTo(45);
+            assertThat(data.isManual()).isFalse();
             // check uploaded certificate
             try (RawHttpClient c = new RawHttpClient("localhost", port, true, "localhost")) {
                 RawHttpClient.HttpResponse r = c.get("/index.html", credentials);
-                assertEquals("it <b>works</b> !!", r.getBodyString());
+                assertThat(r.getBodyString()).isEqualTo("it <b>works</b> !!");
                 Certificate[] obtainedChain = c.getServerCertificate();
-                assertNotNull(obtainedChain);
-                assertEquals(chain1[0], obtainedChain[0]);
+                assertThat(obtainedChain).isNotNull();
+                assertThat(obtainedChain[0]).isEqualTo(chain1[0]);
             }
         }
 
@@ -594,7 +587,7 @@ public class CertificatesIT extends UseAdminServer {
         cert.setState(DynamicCertificateState.ORDERING);
         cert.setPendingOrderLocation(URI.create("https://localhost/orderlocation").toURL());
         store.saveCertificate(cert);
-        assertEquals(DynamicCertificateState.ORDERING, dcMan.getStateOfCertificate("localhost"));
+        assertThat(dcMan.getStateOfCertificate("localhost")).isEqualTo(DynamicCertificateState.ORDERING);
 
         // ACME mocking
         ACMEClient ac = mock(ACMEClient.class);
@@ -611,23 +604,23 @@ public class CertificatesIT extends UseAdminServer {
         // Renew
         dcMan.run();
         CertificateData updated = dcMan.getCertificateDataForDomain("localhost");
-        assertNotNull(updated);
-        assertEquals(DynamicCertificateState.AVAILABLE, updated.getState());
-        assertEquals(45, updated.getDaysBeforeRenewal());
-        assertFalse(updated.isManual());
+        assertThat(updated).isNotNull();
+        assertThat(updated.getState()).isEqualTo(DynamicCertificateState.AVAILABLE);
+        assertThat(updated.getDaysBeforeRenewal()).isEqualTo(45);
+        assertThat(updated.isManual()).isFalse();
 
         // Check renewed certificate
         try (RawHttpClient cl = new RawHttpClient("localhost", port, true, "localhost")) {
             RawHttpClient.HttpResponse r = cl.get("/index.html", credentials);
-            assertEquals("it <b>works</b> !!", r.getBodyString());
+            assertThat(r.getBodyString()).isEqualTo("it <b>works</b> !!");
             Certificate[] obtainedChain = cl.getServerCertificate();
-            assertNotNull(obtainedChain);
-            assertEquals(renewed.get(0), obtainedChain[0]);
+            assertThat(obtainedChain).isNotNull();
+            assertThat(obtainedChain[0]).isEqualTo(renewed.get(0));
         }
     }
 
     @Test
-    public void testWildcardsCertificates() throws Exception {
+    void wildcardsCertificates() throws Exception {
         configureAndStartServer();
         DynamicCertificatesManager dynCertsMan = server.getDynamicCertificatesManager();
 
@@ -639,8 +632,8 @@ public class CertificatesIT extends UseAdminServer {
             uploadCertificate("localhost2", null, chainData1, client, credentials);
             CertificateData data = dynCertsMan.getCertificateDataForDomain("localhost2");
             Certificate[] saveChain = base64DecodeCertificateChain(data.getChain());
-            assertNotNull(data);
-            assertArrayEquals(CertificatesUtils.readChainFromKeystore(chainData1), saveChain);
+            assertThat(data).isNotNull();
+            assertThat(saveChain).containsExactly(CertificatesUtils.readChainFromKeystore(chainData1));
 
             // upload wildcard
             endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
@@ -649,19 +642,19 @@ public class CertificatesIT extends UseAdminServer {
             uploadCertificate("*.localhost2", null, chainData2, client, credentials);
             data = dynCertsMan.getCertificateDataForDomain("*.localhost2");
             Certificate[] saveChain2 = base64DecodeCertificateChain(data.getChain());
-            assertNotNull(data);
-            assertArrayEquals(CertificatesUtils.readChainFromKeystore(chainData2), saveChain2);
+            assertThat(data).isNotNull();
+            assertThat(saveChain2).containsExactly(CertificatesUtils.readChainFromKeystore(chainData2));
 
             // exact still different from wildcard
             data = dynCertsMan.getCertificateDataForDomain("localhost2");
             Certificate[] saveChain3 = base64DecodeCertificateChain(data.getChain());
-            assertNotNull(data);
-            assertArrayEquals(CertificatesUtils.readChainFromKeystore(chainData1), saveChain3);
+            assertThat(data).isNotNull();
+            assertThat(saveChain3).containsExactly(CertificatesUtils.readChainFromKeystore(chainData1));
         }
     }
 
     @Test
-    public void testLocalCertificatesStoring() throws Exception {
+    void localCertificatesStoring() throws Exception {
         configureAndStartServer();
         int port = server.getLocalPort();
         DynamicCertificatesManager dcMan = server.getDynamicCertificatesManager();
@@ -673,19 +666,19 @@ public class CertificatesIT extends UseAdminServer {
         try (RawHttpClient client = new RawHttpClient("localhost", DEFAULT_ADMIN_PORT)) {
             byte[] chainData = createKeystore(chain1, endUserKeyPair.getPrivate());
             HttpResponse resp = uploadCertificate("localhost", "type=acme&daysbeforerenewal=45", chainData, client, credentials);
-            assertTrue(resp.getBodyString().contains("SUCCESS"));
+            assertThat(resp.getBodyString()).contains("SUCCESS");
             CertificateData data = dcMan.getCertificateDataForDomain("localhost");
-            assertNotNull(data);
-            assertEquals(DynamicCertificateState.AVAILABLE, data.getState());
-            assertEquals(45, data.getDaysBeforeRenewal());
-            assertFalse(data.isManual());
+            assertThat(data).isNotNull();
+            assertThat(data.getState()).isEqualTo(DynamicCertificateState.AVAILABLE);
+            assertThat(data.getDaysBeforeRenewal()).isEqualTo(45);
+            assertThat(data.isManual()).isFalse();
             // check uploaded certificate
             try (RawHttpClient c = new RawHttpClient("localhost", port, true, "localhost")) {
                 RawHttpClient.HttpResponse r = c.get("/index.html", credentials);
-                assertEquals("it <b>works</b> !!", r.getBodyString());
+                assertThat(r.getBodyString()).isEqualTo("it <b>works</b> !!");
                 Certificate[] obtainedChain = c.getServerCertificate();
-                assertNotNull(obtainedChain);
-                assertEquals(chain1[0], obtainedChain[0]);
+                assertThat(obtainedChain).isNotNull();
+                assertThat(obtainedChain[0]).isEqualTo(chain1[0]);
             }
         }
 
@@ -698,7 +691,7 @@ public class CertificatesIT extends UseAdminServer {
         cert.setState(DynamicCertificateState.ORDERING);
         cert.setPendingOrderLocation(URI.create("https://localhost/orderlocation").toURL());
         store.saveCertificate(cert);
-        assertEquals(DynamicCertificateState.ORDERING, dcMan.getStateOfCertificate("localhost"));
+        assertThat(dcMan.getStateOfCertificate("localhost")).isEqualTo(DynamicCertificateState.ORDERING);
 
         // ACME mocking
         ACMEClient ac = mock(ACMEClient.class);
@@ -718,51 +711,51 @@ public class CertificatesIT extends UseAdminServer {
         server.getCurrentConfiguration().setLocalCertificatesStorePeersIds(Set.of("peerPippo")); // storing enabled on fake peer only
         dcMan.run();
         CertificateData updated = dcMan.getCertificateDataForDomain("localhost");
-        assertNotNull(updated);
-        assertEquals(DynamicCertificateState.AVAILABLE, updated.getState());
-        assertEquals(45, updated.getDaysBeforeRenewal());
-        assertFalse(updated.isManual());
+        assertThat(updated).isNotNull();
+        assertThat(updated.getState()).isEqualTo(DynamicCertificateState.AVAILABLE);
+        assertThat(updated.getDaysBeforeRenewal()).isEqualTo(45);
+        assertThat(updated.isManual()).isFalse();
 
         // Check renewed certificate
         try (RawHttpClient cl = new RawHttpClient("localhost", port, true, "localhost")) {
             RawHttpClient.HttpResponse r = cl.get("/index.html", credentials);
-            assertEquals("it <b>works</b> !!", r.getBodyString());
+            assertThat(r.getBodyString()).isEqualTo("it <b>works</b> !!");
             Certificate[] obtainedChain = cl.getServerCertificate();
-            assertNotNull(obtainedChain);
-            assertEquals(renewed.get(0), obtainedChain[0]);
+            assertThat(obtainedChain).isNotNull();
+            assertThat(obtainedChain[0]).isEqualTo(renewed.get(0));
         }
 
         // local certificate path
         File[] f = certsDir.listFiles((dir, name) -> name.equals("localhost"));
-        assertEquals(0, f.length);
+        assertThat(f).isEmpty();
 
         cert = dcMan.getCertificateDataForDomain("localhost");
         cert.setState(DynamicCertificateState.ORDERING);
         cert.setPendingOrderLocation(URI.create("https://localhost/orderlocation").toURL());
         store.saveCertificate(cert);
-        assertEquals(DynamicCertificateState.ORDERING, dcMan.getStateOfCertificate("localhost"));
+        assertThat(dcMan.getStateOfCertificate("localhost")).isEqualTo(DynamicCertificateState.ORDERING);
         server.getCurrentConfiguration().setLocalCertificatesStorePeersIds(Set.of(server.getPeerId()));
         dcMan.run();
 
         f = certsDir.listFiles((dir, name) -> name.equals("localhost"));
-        assertEquals(1, f.length);
-        assertTrue(f[0].isDirectory());
+        assertThat(f).hasSize(1);
+        assertThat(f[0]).isDirectory();
         File localhostDir = f[0];
 
         f = localhostDir.listFiles((dir, name) -> name.equals("privatekey.pem"));
-        assertEquals(1, f.length);
-        assertTrue(f[0].isFile());
+        assertThat(f).hasSize(1);
+        assertThat(f[0]).isFile();
         String pkPem = Files.readString(f[0].toPath());
         System.out.println("[PRIVARE KEY]: " + pkPem);
         var sw = new StringWriter();
         try (var writer = new PemWriter(sw)) {
             writer.writeObject(new PemObject("", keyPair.getPrivate().getEncoded()));
         }
-        assertEquals(sw.toString(), pkPem);
+        assertThat(pkPem).isEqualTo(sw.toString());
 
         f = localhostDir.listFiles((dir, name) -> name.equals("chain.pem"));
-        assertEquals(1, f.length);
-        assertTrue(f[0].isFile());
+        assertThat(f).hasSize(1);
+        assertThat(f[0]).isFile();
         String chainPem = Files.readString(f[0].toPath());
         System.out.println("[CHAIN]: " + chainPem);
         sw = new StringWriter();
@@ -771,14 +764,14 @@ public class CertificatesIT extends UseAdminServer {
                 writer.writeObject(new PemObject("", renewed.get(i).getEncoded()));
             }
         }
-        assertEquals(sw.toString(), chainPem);
+        assertThat(chainPem).isEqualTo(sw.toString());
 
         f = localhostDir.listFiles((dir, name) -> name.equals("fullchain.pem"));
-        assertEquals(1, f.length);
-        assertTrue(f[0].isFile());
+        assertThat(f).hasSize(1);
+        assertThat(f[0]).isFile();
         String fullchainPem = Files.readString(f[0].toPath());
         System.out.println("[FULLCHAIN]: " + fullchainPem);
-        assertTrue(fullchainPem.endsWith(chainPem));
+        assertThat(fullchainPem).endsWith(chainPem);
 
         // Renew 2
         keyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
@@ -787,44 +780,44 @@ public class CertificatesIT extends UseAdminServer {
         cert.setState(DynamicCertificateState.ORDERING);
         cert.setPendingOrderLocation(URI.create("https://localhost/orderlocation").toURL());
         store.saveCertificate(cert);
-        assertEquals(DynamicCertificateState.ORDERING, dcMan.getStateOfCertificate("localhost"));
+        assertThat(dcMan.getStateOfCertificate("localhost")).isEqualTo(DynamicCertificateState.ORDERING);
         renewed = Arrays.asList((X509Certificate[]) generateSampleChain(keyPair, false));
         when(_cert.getCertificateChain()).thenReturn(renewed);
         dcMan.run();
         updated = dcMan.getCertificateDataForDomain("localhost");
-        assertNotNull(updated);
-        assertEquals(DynamicCertificateState.AVAILABLE, updated.getState());
-        assertEquals(45, updated.getDaysBeforeRenewal());
-        assertFalse(updated.isManual());
+        assertThat(updated).isNotNull();
+        assertThat(updated.getState()).isEqualTo(DynamicCertificateState.AVAILABLE);
+        assertThat(updated.getDaysBeforeRenewal()).isEqualTo(45);
+        assertThat(updated.isManual()).isFalse();
         // Check renewed certificate
         try (RawHttpClient cl = new RawHttpClient("localhost", port, true, "localhost")) {
             RawHttpClient.HttpResponse r = cl.get("/index.html", credentials);
-            assertEquals("it <b>works</b> !!", r.getBodyString());
+            assertThat(r.getBodyString()).isEqualTo("it <b>works</b> !!");
             Certificate[] obtainedChain = cl.getServerCertificate();
-            assertNotNull(obtainedChain);
-            assertEquals(renewed.get(0), obtainedChain[0]);
+            assertThat(obtainedChain).isNotNull();
+            assertThat(obtainedChain[0]).isEqualTo(renewed.get(0));
         }
 
         // local certificate path
         f = certsDir.listFiles((dir, name) -> name.equals("localhost"));
-        assertEquals(1, f.length);
-        assertTrue(f[0].isDirectory());
+        assertThat(f).hasSize(1);
+        assertThat(f[0]).isDirectory();
         localhostDir = f[0];
 
         f = localhostDir.listFiles((dir, name) -> name.equals("privatekey.pem"));
-        assertEquals(1, f.length);
-        assertTrue(f[0].isFile());
+        assertThat(f).hasSize(1);
+        assertThat(f[0]).isFile();
         pkPem = Files.readString(f[0].toPath());
         System.out.println("[PRIVARE KEY]: " + pkPem);
         sw = new StringWriter();
         try (var writer = new PemWriter(sw)) {
             writer.writeObject(new PemObject("", keyPair.getPrivate().getEncoded()));
         }
-        assertEquals(sw.toString(), pkPem);
+        assertThat(pkPem).isEqualTo(sw.toString());
 
         f = localhostDir.listFiles((dir, name) -> name.equals("chain.pem"));
-        assertEquals(1, f.length);
-        assertTrue(f[0].isFile());
+        assertThat(f).hasSize(1);
+        assertThat(f[0]).isFile();
         chainPem = Files.readString(f[0].toPath());
         System.out.println("[CHAIN]: " + chainPem);
         sw = new StringWriter();
@@ -833,14 +826,14 @@ public class CertificatesIT extends UseAdminServer {
                 writer.writeObject(new PemObject("", renewed.get(i).getEncoded()));
             }
         }
-        assertEquals(sw.toString(), chainPem);
+        assertThat(chainPem).isEqualTo(sw.toString());
 
         f = localhostDir.listFiles((dir, name) -> name.equals("fullchain.pem"));
-        assertEquals(1, f.length);
-        assertTrue(f[0].isFile());
+        assertThat(f).hasSize(1);
+        assertThat(f[0]).isFile();
         fullchainPem = Files.readString(f[0].toPath());
         System.out.println("[FULLCHAIN]: " + fullchainPem);
-        assertTrue(fullchainPem.endsWith(chainPem));
+        assertThat(fullchainPem).endsWith(chainPem);
 
         // other cert
         endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
@@ -848,12 +841,12 @@ public class CertificatesIT extends UseAdminServer {
         try (RawHttpClient client = new RawHttpClient("localhost", DEFAULT_ADMIN_PORT)) {
             byte[] chainData = createKeystore(chain2, endUserKeyPair.getPrivate());
             HttpResponse resp = uploadCertificate("localhost2", "type=acme&daysbeforerenewal=45", chainData, client, credentials);
-            assertTrue(resp.getBodyString().contains("SUCCESS"));
+            assertThat(resp.getBodyString()).contains("SUCCESS");
             CertificateData data = dcMan.getCertificateDataForDomain("localhost2");
-            assertNotNull(data);
-            assertEquals(DynamicCertificateState.AVAILABLE, data.getState());
-            assertEquals(45, data.getDaysBeforeRenewal());
-            assertFalse(data.isManual());
+            assertThat(data).isNotNull();
+            assertThat(data.getState()).isEqualTo(DynamicCertificateState.AVAILABLE);
+            assertThat(data.getDaysBeforeRenewal()).isEqualTo(45);
+            assertThat(data.isManual()).isFalse();
         }
 
         // Renew
@@ -864,7 +857,7 @@ public class CertificatesIT extends UseAdminServer {
         cert.setState(DynamicCertificateState.ORDERING);
         cert.setPendingOrderLocation(URI.create("https://localhost/orderlocation").toURL());
         store.saveCertificate(cert);
-        assertEquals(DynamicCertificateState.ORDERING, dcMan.getStateOfCertificate("localhost2"));
+        assertThat(dcMan.getStateOfCertificate("localhost2")).isEqualTo(DynamicCertificateState.ORDERING);
 
         // ACME mocking
         renewed = Arrays.asList((X509Certificate[]) generateSampleChain(keyPair, false));
@@ -875,32 +868,32 @@ public class CertificatesIT extends UseAdminServer {
         dcMan.setAcmeClients(Map.of(DEFAULT_PROVIDER_NAME, ac));
         dcMan.run();
         updated = dcMan.getCertificateDataForDomain("localhost2");
-        assertNotNull(updated);
-        assertEquals(DynamicCertificateState.AVAILABLE, updated.getState());
-        assertEquals(45, updated.getDaysBeforeRenewal());
-        assertFalse(updated.isManual());
+        assertThat(updated).isNotNull();
+        assertThat(updated.getState()).isEqualTo(DynamicCertificateState.AVAILABLE);
+        assertThat(updated.getDaysBeforeRenewal()).isEqualTo(45);
+        assertThat(updated.isManual()).isFalse();
 
         // local certificate path
-        assertEquals(1, certsDir.listFiles((dir, name) -> name.equals("localhost")).length);
+        assertThat(certsDir.listFiles((dir, name) -> name.equals("localhost"))).hasSize(1);
         f = certsDir.listFiles((dir, name) -> name.equals("localhost2"));
-        assertEquals(1, f.length);
-        assertTrue(f[0].isDirectory());
+        assertThat(f).hasSize(1);
+        assertThat(f[0]).isDirectory();
         localhostDir = f[0];
 
         f = localhostDir.listFiles((dir, name) -> name.equals("privatekey.pem"));
-        assertEquals(1, f.length);
-        assertTrue(f[0].isFile());
+        assertThat(f).hasSize(1);
+        assertThat(f[0]).isFile();
         pkPem = Files.readString(f[0].toPath());
         System.out.println("[PRIVARE KEY]: " + pkPem);
         sw = new StringWriter();
         try (var writer = new PemWriter(sw)) {
             writer.writeObject(new PemObject("", keyPair.getPrivate().getEncoded()));
         }
-        assertEquals(sw.toString(), pkPem);
+        assertThat(pkPem).isEqualTo(sw.toString());
 
         f = localhostDir.listFiles((dir, name) -> name.equals("chain.pem"));
-        assertEquals(1, f.length);
-        assertTrue(f[0].isFile());
+        assertThat(f).hasSize(1);
+        assertThat(f[0]).isFile();
         chainPem = Files.readString(f[0].toPath());
         System.out.println("[CHAIN]: " + chainPem);
         sw = new StringWriter();
@@ -909,18 +902,18 @@ public class CertificatesIT extends UseAdminServer {
                 writer.writeObject(new PemObject("", renewed.get(i).getEncoded()));
             }
         }
-        assertEquals(sw.toString(), chainPem);
+        assertThat(chainPem).isEqualTo(sw.toString());
 
         f = localhostDir.listFiles((dir, name) -> name.equals("fullchain.pem"));
-        assertEquals(1, f.length);
-        assertTrue(f[0].isFile());
+        assertThat(f).hasSize(1);
+        assertThat(f[0]).isFile();
         fullchainPem = Files.readString(f[0].toPath());
         System.out.println("[FULLCHAIN]: " + fullchainPem);
-        assertTrue(fullchainPem.endsWith(chainPem));
+        assertThat(fullchainPem).endsWith(chainPem);
     }
 
     @Test
-    public void testCreateCertificateFromUI() throws Exception {
+    void createCertificateFromUI() throws Exception {
         configureAndStartServer();
         int port = server.getLocalPort();
         try (RawHttpClient client = new RawHttpClient("localhost", DEFAULT_ADMIN_PORT)) {
@@ -928,71 +921,71 @@ public class CertificatesIT extends UseAdminServer {
 
             // empty domain name
             var resp = client.post("/api/certificates/", null, form, credentials);
-            assertTrue(resp.isError());
+            assertThat(resp.isError()).isTrue();
             var result = resp.getData(FormValidationResponse.class);
-            assertEquals("domain", result.getField());
-            assertEquals(FormValidationResponse.ERROR_FIELD_REQUIRED, result.getMessage());
+            assertThat(result.getField()).isEqualTo("domain");
+            assertThat(result.getMessage()).isEqualTo(FormValidationResponse.ERROR_FIELD_REQUIRED);
 
             // domain name in subject alternative names
             form.setDomain("test.domain.tld");
-            form.setSubjectAltNames(Set.of("test.domain.tld", "test2.domain.tld"));
+            form.setSubjectAltNames(of("test.domain.tld", "test2.domain.tld"));
             resp = client.post("/api/certificates/", null, form, credentials);
-            assertTrue(resp.isError());
+            assertThat(resp.isError()).isTrue();
             result = resp.getData(FormValidationResponse.class);
-            assertEquals("subjectAltNames", result.getField());
-            assertEquals("Subject alternative names cannot include the Domain", result.getMessage());
+            assertThat(result.getField()).isEqualTo("subjectAltNames");
+            assertThat(result.getMessage()).isEqualTo("Subject alternative names cannot include the Domain");
 
             // invalid certificate type
             form.setDomain("test.domain.tld");
-            form.setSubjectAltNames(Set.of("test1.domain.tld", "test2.domain.tld"));
+            form.setSubjectAltNames(of("test1.domain.tld", "test2.domain.tld"));
             form.setType("manual");
             resp = client.post("/api/certificates/", null, form, credentials);
-            assertTrue(resp.isError());
+            assertThat(resp.isError()).isTrue();
             result = resp.getData(FormValidationResponse.class);
-            assertEquals("type", result.getField());
-            assertEquals(FormValidationResponse.ERROR_FIELD_INVALID, result.getMessage());
+            assertThat(result.getField()).isEqualTo("type");
+            assertThat(result.getMessage()).isEqualTo(FormValidationResponse.ERROR_FIELD_INVALID);
 
             // invalid days before renewal
             form.setDomain("test.domain.tld");
-            form.setSubjectAltNames(Set.of("test1.domain.tld", "test2.domain.tld"));
+            form.setSubjectAltNames(of("test1.domain.tld", "test2.domain.tld"));
             form.setType("acme");
             form.setDaysBeforeRenewal(-1);
             resp = client.post("/api/certificates/", null, form, credentials);
-            assertTrue(resp.isError());
+            assertThat(resp.isError()).isTrue();
             result = resp.getData(FormValidationResponse.class);
-            assertEquals("daysBeforeRenewal", result.getField());
-            assertEquals(FormValidationResponse.ERROR_FIELD_INVALID, result.getMessage());
+            assertThat(result.getField()).isEqualTo("daysBeforeRenewal");
+            assertThat(result.getMessage()).isEqualTo(FormValidationResponse.ERROR_FIELD_INVALID);
 
             // all ok
             form.setDomain("test.domain.tld");
-            form.setSubjectAltNames(Set.of("test1.domain.tld", "test2.domain.tld"));
+            form.setSubjectAltNames(of("test1.domain.tld", "test2.domain.tld"));
             form.setType("acme");
             form.setDaysBeforeRenewal(10);
             resp = client.post("/api/certificates/", null, form, credentials);
-            assertTrue(resp.isCreated());
+            assertThat(resp.isCreated()).isTrue();
             CertificateData data = server.getDynamicCertificatesManager().getCertificateDataForDomain("test.domain.tld");
-            assertNotNull(data);
+            assertThat(data).isNotNull();
             ConfigurationStore store = server.getDynamicConfigurationStore();
             final var indices = getCertificateIndicesWithHostname(store, "test.domain.tld");
             for (final var index : indices) {
-                assertThat(store.getProperty("certificate." + index + ".mode", null), is("acme"));
-                assertThat(store.getValues("certificate." + index + ".san"), is(Set.of("test1.domain.tld", "test2.domain.tld")));
-                assertThat(store.getProperty("certificate." + index +".daysbeforerenewal", null), is("10"));
+                assertThat(store.getProperty("certificate." + index + ".mode", null)).isEqualTo("acme");
+                assertThat(store.getValues("certificate." + index + ".san")).hasSameElementsAs(of("test1.domain.tld", "test2.domain.tld"));
+                assertThat(store.getProperty("certificate." + index + ".daysbeforerenewal", null)).isEqualTo("10");
             }
 
             // domain name already used
             form.setDomain("test.domain.tld");
-            form.setSubjectAltNames(Set.of("test1.domain.tld", "test2.domain.tld"));
+            form.setSubjectAltNames(of("test1.domain.tld", "test2.domain.tld"));
             form.setType("acme");
             form.setDaysBeforeRenewal(10);
             resp = client.post("/api/certificates/", null, form, credentials);
-            assertTrue(resp.isConflict());
+            assertThat(resp.isConflict()).isTrue();
             result = resp.getData(FormValidationResponse.class);
-            assertEquals("domain", result.getField());
-            assertEquals(FormValidationResponse.ERROR_FIELD_DUPLICATED, result.getMessage());
+            assertThat(result.getField()).isEqualTo("domain");
+            assertThat(result.getMessage()).isEqualTo(FormValidationResponse.ERROR_FIELD_DUPLICATED);
 
             resp = client.delete("/api/certificates/test.domain.tld", credentials);
-            assertTrue(resp.isOk());
+            assertThat(resp.isOk()).isTrue();
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesIT.java
@@ -259,7 +259,7 @@ public class CertificatesIT extends UseAdminServer {
         assertThat(data.isManual()).isTrue();
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "type={0}")
     @ValueSource(strings = {"acme", "manual"})
     void uploadTypedCertificate(String type) throws Exception {
         configureAndStartServer();
@@ -342,7 +342,7 @@ public class CertificatesIT extends UseAdminServer {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "type={0}")
     @ValueSource(strings = {"acme", "manual"})
     void uploadTypedCertificatesWithDaysBeforeRenewal(String type) throws Exception {
         configureAndStartServer();

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesIT.java
@@ -190,7 +190,6 @@ public class CertificatesIT extends UseAdminServer {
 
         DynamicCertificatesManager dynCertMan = server.getDynamicCertificatesManager();
         CertificateData data = dynCertMan.getCertificateDataForDomain("localhost");
-        assertThat(data).isNotNull();
         assertThat(data.isManual()).isTrue();
 
         // Request #1: still expected default certificate
@@ -212,7 +211,6 @@ public class CertificatesIT extends UseAdminServer {
             HttpResponse resp = uploadCertificate("localhost", null, chainData, client, credentials);
             assertThat(resp.getBodyString()).contains("SUCCESS");
             data = dynCertMan.getCertificateDataForDomain("localhost");
-            assertThat(data).isNotNull();
             assertThat(data.isManual()).isTrue();
             assertThat(data.getState()).isSameAs(DynamicCertificateState.AVAILABLE);
         }
@@ -237,7 +235,6 @@ public class CertificatesIT extends UseAdminServer {
             HttpResponse resp = uploadCertificate("localhost", null, chainData, client, credentials);
             assertThat(resp.getBodyString()).contains("SUCCESS");
             data = dynCertMan.getCertificateDataForDomain("localhost");
-            assertThat(data).isNotNull();
             assertThat(data.isManual()).isTrue();
             assertThat(data.getState()).isSameAs(DynamicCertificateState.AVAILABLE);
         }
@@ -255,7 +252,6 @@ public class CertificatesIT extends UseAdminServer {
         // this calls "reloadFromDB" > "manual" flag has to be retained even if not stored in db.
         dynCertMan.setStateOfCertificate("localhost", DynamicCertificateState.WAITING);
         data = dynCertMan.getCertificateDataForDomain("localhost");
-        assertThat(data).isNotNull();
         assertThat(data.isManual()).isTrue();
     }
 
@@ -275,7 +271,6 @@ public class CertificatesIT extends UseAdminServer {
                 assertThat(resp.getBodyString()).contains("ERROR: certificate data required");
             } else {
                 CertificateData data = dynCertsMan.getCertificateDataForDomain("localhost");
-                assertThat(data).isNotNull();
                 assertThat(data.isManual()).isFalse();
                 assertThat(dynCertsMan.getStateOfCertificate("localhost")).isEqualTo(DynamicCertificateState.WAITING); // no certificate-data uploaded
             }
@@ -289,7 +284,6 @@ public class CertificatesIT extends UseAdminServer {
             HttpResponse resp = uploadCertificate("localhost", "type=" + type, chainData, client, credentials);
             assertThat(resp.getBodyString()).contains("SUCCESS");
             CertificateData data = dynCertsMan.getCertificateDataForDomain("localhost");
-            assertThat(data).isNotNull();
             assertThat(data.isManual()).isEqualTo(type.equals("manual"));
             assertThat(dynCertsMan.getStateOfCertificate("localhost")).isEqualTo(DynamicCertificateState.AVAILABLE);
 
@@ -318,7 +312,6 @@ public class CertificatesIT extends UseAdminServer {
             HttpResponse resp = uploadCertificate("localhost", "type=" + otherType, chainData, client, credentials);
             assertThat(resp.getBodyString()).contains("SUCCESS");
             CertificateData data = dynCertsMan.getCertificateDataForDomain("localhost");
-            assertThat(data).isNotNull();
             assertThat(data.isManual()).isEqualTo(otherType.equals("manual"));
             assertThat(dynCertsMan.getStateOfCertificate("localhost")).isEqualTo(DynamicCertificateState.AVAILABLE);
 
@@ -335,7 +328,6 @@ public class CertificatesIT extends UseAdminServer {
             if (type.equals("acme")) {
                 assertThat(resp.getBodyString()).contains("SUCCESS");
                 data = dynCertsMan.getCertificateDataForDomain("localhost");
-                assertThat(data).isNotNull();
                 assertThat(data.isManual()).isFalse();
                 assertThat(dynCertsMan.getStateOfCertificate("localhost")).isEqualTo(DynamicCertificateState.WAITING); // no certificate-data uploaded
             }
@@ -359,7 +351,6 @@ public class CertificatesIT extends UseAdminServer {
                 assertThat(resp.getBodyString()).contains("ERROR: param 'daysbeforerenewal' available for type 'acme' only");
             } else {
                 CertificateData data = dynCertsMan.getCertificateDataForDomain("localhost2");
-                assertThat(data).isNotNull();
                 assertThat(data.getDaysBeforeRenewal()).isEqualTo(10);
             }
             // negative value
@@ -372,7 +363,6 @@ public class CertificatesIT extends UseAdminServer {
             // default value
             uploadCertificate("localhost-default", "type=" + type, chainData, client, credentials);
             CertificateData data = dynCertsMan.getCertificateDataForDomain("localhost-default");
-            assertThat(data).isNotNull();
             assertThat(data.getDaysBeforeRenewal()).isEqualTo(type.equals("manual") ? 0 : DEFAULT_DAYS_BEFORE_RENEWAL);
 
             // Update
@@ -381,7 +371,6 @@ public class CertificatesIT extends UseAdminServer {
                 assertThat(resp.getBodyString()).contains("ERROR: param 'daysbeforerenewal' available for type 'acme' only");
             } else {
                 data = dynCertsMan.getCertificateDataForDomain("localhost2");
-                assertThat(data).isNotNull();
                 assertThat(data.getDaysBeforeRenewal()).isEqualTo(45);
             }
             // negative value
@@ -394,13 +383,11 @@ public class CertificatesIT extends UseAdminServer {
             // default value
             uploadCertificate("localhost2", "type=" + type, chainData, client, credentials);
             data = dynCertsMan.getCertificateDataForDomain("localhost2");
-            assertThat(data).isNotNull();
             assertThat(data.getDaysBeforeRenewal()).isEqualTo(type.equals("manual") ? 0 : DEFAULT_DAYS_BEFORE_RENEWAL);
             // changing the type (acme <-> manual)
             String other = type.equals("manual") ? "acme" : "manual";
             uploadCertificate("localhost2", "type=" + other, chainData, client, credentials);
             data = dynCertsMan.getCertificateDataForDomain("localhost2");
-            assertThat(data).isNotNull();
             assertThat(data.getDaysBeforeRenewal()).isEqualTo(other.equals("manual") ? 0 : DEFAULT_DAYS_BEFORE_RENEWAL);
             SSLCertificateConfiguration config = server.getCurrentConfiguration().getCertificates().get("localhost2");
             assertThat(config.getDaysBeforeRenewal()).isEqualTo(other.equals("manual") ? 0 : DEFAULT_DAYS_BEFORE_RENEWAL);
@@ -442,7 +429,6 @@ public class CertificatesIT extends UseAdminServer {
             resp = uploadCertificate("localhost2", "type=acme&provider=custom", chainData, client, credentials);
             assertThat(resp.getBodyString()).contains("SUCCESS");
             CertificateData data = dynCertsMan.getCertificateDataForDomain("localhost2");
-            assertThat(data).isNotNull();
             assertThat(data.getProvider()).isEqualTo("custom");
             assertThat(server.getCurrentConfiguration().getCertificates().get("localhost2").getProvider()).isEqualTo("custom");
             ConfigurationStore store = server.getDynamicConfigurationStore();
@@ -454,7 +440,6 @@ public class CertificatesIT extends UseAdminServer {
             resp = uploadCertificate("localhost2", "type=acme", chainData, client, credentials);
             assertThat(resp.getBodyString()).contains("SUCCESS");
             data = dynCertsMan.getCertificateDataForDomain("localhost2");
-            assertThat(data).isNotNull();
             assertThat(data.getProvider()).isEqualTo(DEFAULT_PROVIDER_NAME);
             assertThat(store.anyPropertyMatches((k, v) -> k.matches("certificate\\.[0-9]+\\.provider"))).isFalse();
         }
@@ -506,7 +491,6 @@ public class CertificatesIT extends UseAdminServer {
             RawHttpClient.HttpResponse resp = uploadCertificate("localhost", null, chainData, client, credentials);
             assertThat(resp.getBodyString()).contains("SUCCESS");
             CertificateData data = dynCertMan.getCertificateDataForDomain("localhost");
-            assertThat(data).isNotNull();
             assertThat(data.isManual()).isTrue();
             assertThat(data.getState()).isSameAs(DynamicCertificateState.AVAILABLE);
         }
@@ -563,7 +547,6 @@ public class CertificatesIT extends UseAdminServer {
             HttpResponse resp = uploadCertificate("localhost", "type=acme&daysbeforerenewal=45", chainData, client, credentials);
             assertThat(resp.getBodyString()).contains("SUCCESS");
             CertificateData data = dcMan.getCertificateDataForDomain("localhost");
-            assertThat(data).isNotNull();
             assertThat(data.getState()).isEqualTo(DynamicCertificateState.AVAILABLE);
             assertThat(data.getDaysBeforeRenewal()).isEqualTo(45);
             assertThat(data.isManual()).isFalse();
@@ -603,7 +586,6 @@ public class CertificatesIT extends UseAdminServer {
         // Renew
         dcMan.run();
         CertificateData updated = dcMan.getCertificateDataForDomain("localhost");
-        assertThat(updated).isNotNull();
         assertThat(updated.getState()).isEqualTo(DynamicCertificateState.AVAILABLE);
         assertThat(updated.getDaysBeforeRenewal()).isEqualTo(45);
         assertThat(updated.isManual()).isFalse();
@@ -667,7 +649,6 @@ public class CertificatesIT extends UseAdminServer {
             HttpResponse resp = uploadCertificate("localhost", "type=acme&daysbeforerenewal=45", chainData, client, credentials);
             assertThat(resp.getBodyString()).contains("SUCCESS");
             CertificateData data = dcMan.getCertificateDataForDomain("localhost");
-            assertThat(data).isNotNull();
             assertThat(data.getState()).isEqualTo(DynamicCertificateState.AVAILABLE);
             assertThat(data.getDaysBeforeRenewal()).isEqualTo(45);
             assertThat(data.isManual()).isFalse();
@@ -710,7 +691,6 @@ public class CertificatesIT extends UseAdminServer {
         server.getCurrentConfiguration().setLocalCertificatesStorePeersIds(Set.of("peerPippo")); // storing enabled on fake peer only
         dcMan.run();
         CertificateData updated = dcMan.getCertificateDataForDomain("localhost");
-        assertThat(updated).isNotNull();
         assertThat(updated.getState()).isEqualTo(DynamicCertificateState.AVAILABLE);
         assertThat(updated.getDaysBeforeRenewal()).isEqualTo(45);
         assertThat(updated.isManual()).isFalse();
@@ -784,7 +764,6 @@ public class CertificatesIT extends UseAdminServer {
         when(_cert.getCertificateChain()).thenReturn(renewed);
         dcMan.run();
         updated = dcMan.getCertificateDataForDomain("localhost");
-        assertThat(updated).isNotNull();
         assertThat(updated.getState()).isEqualTo(DynamicCertificateState.AVAILABLE);
         assertThat(updated.getDaysBeforeRenewal()).isEqualTo(45);
         assertThat(updated.isManual()).isFalse();
@@ -842,7 +821,6 @@ public class CertificatesIT extends UseAdminServer {
             HttpResponse resp = uploadCertificate("localhost2", "type=acme&daysbeforerenewal=45", chainData, client, credentials);
             assertThat(resp.getBodyString()).contains("SUCCESS");
             CertificateData data = dcMan.getCertificateDataForDomain("localhost2");
-            assertThat(data).isNotNull();
             assertThat(data.getState()).isEqualTo(DynamicCertificateState.AVAILABLE);
             assertThat(data.getDaysBeforeRenewal()).isEqualTo(45);
             assertThat(data.isManual()).isFalse();
@@ -867,7 +845,6 @@ public class CertificatesIT extends UseAdminServer {
         dcMan.setAcmeClients(Map.of(DEFAULT_PROVIDER_NAME, ac));
         dcMan.run();
         updated = dcMan.getCertificateDataForDomain("localhost2");
-        assertThat(updated).isNotNull();
         assertThat(updated.getState()).isEqualTo(DynamicCertificateState.AVAILABLE);
         assertThat(updated.getDaysBeforeRenewal()).isEqualTo(45);
         assertThat(updated.isManual()).isFalse();

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesUtilsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesUtilsTest.java
@@ -55,7 +55,6 @@ class CertificatesUtilsTest {
                 .hasSameSizeAs(originalChain);
         for (int i = 0; i < decodedChain.length; i++) {
             Certificate decodedCert = decodedChain[i];
-            assertThat(decodedCert).isNotNull();
             assertThat(decodedCert.getEncoded()).isEqualTo(originalChain[i].getEncoded());
         }
         assertThat(compareChains(originalChain, decodedChain)).isTrue();

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesUtilsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/CertificatesUtilsTest.java
@@ -19,19 +19,15 @@
  */
 package org.carapaceproxy.server.certificates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64DecodeCertificateChain;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64EncodeCertificateChain;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
 import static org.carapaceproxy.utils.CertificatesTestUtils.generateSampleChain;
 import static org.carapaceproxy.utils.CertificatesUtils.compareChains;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.security.KeyPair;
 import java.security.cert.Certificate;
-import java.util.Arrays;
 import org.carapaceproxy.utils.CertificatesUtils;
 import org.junit.jupiter.api.Test;
 import org.shredzone.acme4j.util.KeyPairUtils;
@@ -42,47 +38,48 @@ import java.util.Date;
  *
  * @author paolo.venturi
  */
-public class CertificatesUtilsTest {
+class CertificatesUtilsTest {
 
     @Test
-    public void testCompareCertificatesChains() throws Exception {
+    void compareCertificatesChains() throws Exception {
         KeyPair endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
         Certificate[] originalChain = generateSampleChain(endUserKeyPair, false);
-        assertTrue(compareChains(originalChain, originalChain));
-        assertFalse(compareChains(originalChain, null));
-        assertFalse(compareChains(originalChain, new Certificate[0]));
+        assertThat(compareChains(originalChain, originalChain)).isTrue();
+        assertThat(compareChains(originalChain, null)).isFalse();
+        assertThat(compareChains(originalChain, new Certificate[0])).isFalse();
 
         String encodedChain = base64EncodeCertificateChain(originalChain, endUserKeyPair.getPrivate());
         Certificate[] decodedChain = base64DecodeCertificateChain(encodedChain);
-        assertNotNull(decodedChain);
-        assertEquals(originalChain.length, decodedChain.length);
+        assertThat(decodedChain)
+                .isNotNull()
+                .hasSameSizeAs(originalChain);
         for (int i = 0; i < decodedChain.length; i++) {
             Certificate decodedCert = decodedChain[i];
-            assertNotNull(decodedCert);
-            assertTrue(Arrays.equals(decodedCert.getEncoded(), originalChain[i].getEncoded()));
+            assertThat(decodedCert).isNotNull();
+            assertThat(decodedCert.getEncoded()).isEqualTo(originalChain[i].getEncoded());
         }
-        assertTrue(compareChains(originalChain, decodedChain));
+        assertThat(compareChains(originalChain, decodedChain)).isTrue();
 
         KeyPair endUserKeyPair2 = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
         Certificate[] otherChain = generateSampleChain(endUserKeyPair2, false);
-        assertFalse(compareChains(originalChain, otherChain));
+        assertThat(compareChains(originalChain, otherChain)).isFalse();
     }
 
     @Test
-    public void testCertificatesExpiration() throws Exception {
+    void certificatesExpiration() throws Exception {
         {
             KeyPair endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
             Certificate[] chain = generateSampleChain(endUserKeyPair, false); // not before == not after == today
             Date expiringDate = ((X509Certificate) chain[0]).getNotAfter();
-            assertFalse(CertificatesUtils.isCertificateExpired(expiringDate, 0));
-            assertTrue(CertificatesUtils.isCertificateExpired(expiringDate, 30)); // not after
+            assertThat(CertificatesUtils.isCertificateExpired(expiringDate, 0)).isFalse();
+            assertThat(CertificatesUtils.isCertificateExpired(expiringDate, 30)).isTrue(); // not after
         }
         {
             KeyPair endUserKeyPair = KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE);
             Certificate[] chain = generateSampleChain(endUserKeyPair, true); // not before == not after == today
             Date expiringDate = ((X509Certificate) chain[0]).getNotAfter();
-            assertTrue(CertificatesUtils.isCertificateExpired(expiringDate, 0));
-            assertTrue(CertificatesUtils.isCertificateExpired(expiringDate, 30)); // not after
+            assertThat(CertificatesUtils.isCertificateExpired(expiringDate, 0)).isTrue();
+            assertThat(CertificatesUtils.isCertificateExpired(expiringDate, 30)).isTrue(); // not after
         }
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerIT.java
@@ -20,6 +20,7 @@
 package org.carapaceproxy.server.certificates;
 
 import static org.carapaceproxy.server.config.AcmeProviderConfiguration.DEFAULT_PROVIDER_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.carapaceproxy.configstore.ConfigurationStoreUtils.base64EncodeCertificateChain;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.AVAILABLE;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.DNS_CHALLENGE_WAIT;
@@ -32,9 +33,6 @@ import static org.carapaceproxy.server.certificates.DynamicCertificateState.VERI
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.WAITING;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.DEFAULT_KEYPAIRS_SIZE;
 import static org.carapaceproxy.utils.CertificatesTestUtils.generateSampleChain;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -87,7 +85,7 @@ import org.shredzone.acme4j.Problem;
  *
  * @author paolo.venturi
  */
-public class DynamicCertificatesManagerIT {
+class DynamicCertificatesManagerIT {
 
     static {
         // DynamicCertificatesManager reads the limit into a static final field, so the property must be set
@@ -122,7 +120,7 @@ public class DynamicCertificatesManagerIT {
             "all_ok,true",
             "all_ok,false"
     })
-    public void testCertificateSimpleStateManagement(String runCase, boolean maxedOutTrials) throws Exception {
+    void certificateSimpleStateManagement(String runCase, boolean maxedOutTrials) throws Exception {
         // ACME mocking
         ACMEClient ac = mock(ACMEClient.class);
         Order o = mock(Order.class);
@@ -231,8 +229,8 @@ public class DynamicCertificatesManagerIT {
         assertCertificateState(d0, AVAILABLE, cycleCount, man);
         assertCertificateState(d2, AVAILABLE, 0, man);
         assertCertificateState(d3, AVAILABLE, 0, man);
-        assertNotNull(man.getCertificateForDomain(d2));
-        assertNull(man.getCertificateForDomain(d3)); // empty
+        assertThat(man.getCertificateForDomain(d2)).isNotNull();
+        assertThat(man.getCertificateForDomain(d3)).isNull(); // empty
         man.setStateOfCertificate(d2, WAITING); // has not to be renewed by the manager (saveCounter = 1)
         assertCertificateState(d2, WAITING, 0, man);
 
@@ -251,12 +249,9 @@ public class DynamicCertificatesManagerIT {
             assertCertificateState(d1, ORDERING, expectedCycleCount, man);
         } else if (runCase.startsWith("challenge_status_invalid")) {
             assertCertificateState(d1, REQUEST_FAILED, ++expectedCycleCount, man);
-            assertEquals(
-                    runCase.equals("challenge_status_invalid_with_detail")
-                            ? "CAA record prevents issuance"
-                            : "Challenge response verification failed, status is INVALID",
-                    man.getCertificateDataForDomain(d1).getMessage()
-            );
+            assertThat(man.getCertificateDataForDomain(d1).getMessage()).isEqualTo(runCase.equals("challenge_status_invalid_with_detail")
+                    ? "CAA record prevents issuance"
+                    : "Challenge response verification failed, status is INVALID");
             man.run();
             verify(store, times(++saveCounter)).saveCertificate(any());
             assertCertificateState(d1, maxedOutTrials ? REQUEST_FAILED : WAITING, expectedCycleCount, man);
@@ -317,9 +312,9 @@ public class DynamicCertificatesManagerIT {
     }
 
     private void assertCertificateState(String domain, DynamicCertificateState expectedState, int expectedCycleCount, DynamicCertificatesManager dCMan) {
-        assertEquals(expectedState, dCMan.getStateOfCertificate(domain)); // on db
-        assertEquals(expectedState, dCMan.getCertificateDataForDomain(domain).getState()); // on cache
-        assertEquals(expectedCycleCount, dCMan.getCertificateDataForDomain(domain).getAttemptsCount());
+        assertThat(dCMan.getStateOfCertificate(domain)).isEqualTo(expectedState); // on db
+        assertThat(dCMan.getCertificateDataForDomain(domain).getState()).isEqualTo(expectedState); // on cache
+        assertThat(dCMan.getCertificateDataForDomain(domain).getAttemptsCount()).isEqualTo(expectedCycleCount);
     }
 
     @ParameterizedTest
@@ -328,13 +323,13 @@ public class DynamicCertificatesManagerIT {
     // C) record created and ready -> VERIFYING
     // D) challenge verified -> record deleted
     // E) challenge failed -> record deleted
-    @CsvSource({
+    @ValueSource(strings = {
             "challenge_creation_failed",
             "challenge_check_limit_expired",
             "challenge_failed",
             "challenge_verified",
     })
-    public void testWildcardCertificateStateManagement(String runCase) throws Exception {
+    void wildcardCertificateStateManagement(String runCase) throws Exception {
         final var domain = "*.localhost";
 
         // ACME mocking
@@ -452,13 +447,13 @@ public class DynamicCertificatesManagerIT {
     // C) record created and ready -> VERIFYING
     // D) challenge verified -> record deleted
     // E) challenge failed -> record deleted
-    @CsvSource({
+    @ValueSource(strings = {
             "challenge_creation_failed",
             "challenge_check_limit_expired",
             "challenge_failed",
             "challenge_verified"
     })
-    public void testSanCertificateStateManagement(String runCase) throws Exception {
+    void sanCertificateStateManagement(String runCase) throws Exception {
         final var domain = "*.localhost";
         final var san1 = "test1.localhost";
         final var san2 = "*.localhost2";
@@ -590,10 +585,10 @@ public class DynamicCertificatesManagerIT {
     }
 
     @ParameterizedTest
-    @CsvSource({
+    @ValueSource(strings = {
             "localhost-no-ip-check", "localhost-ip-check-partial", "localhost-ip-check-full"
     })
-    public void testDomainReachabilityCheck(String domainCase) throws Exception {
+    void domainReachabilityCheck(String domainCase) throws Exception {
         final var domain = "localhost";
 
         // ACME mocking
@@ -780,7 +775,7 @@ public class DynamicCertificatesManagerIT {
         if (failureCase.equals("stale")) {
             // failure counted, so the certificate falls back to WAITING and a fresh order
             assertCertificateState(domain, REQUEST_FAILED, 1, man);
-            assertEquals("unknown order", man.getCertificateDataForDomain(domain).getMessage());
+            assertThat(man.getCertificateDataForDomain(domain).getMessage()).isEqualTo("unknown order");
             man.run();
             assertCertificateState(domain, WAITING, 1, man);
         } else {

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerIT.java
@@ -730,7 +730,7 @@ class DynamicCertificatesManagerIT {
                 .createOrderForDomain(eq(new CertificateData("le.local", null, WAITING).getNames()));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "failureCase={0}")
     @ValueSource(strings = {"stale", "transient", "store"})
     void pendingOrderPollFailure(String failureCase) throws Exception {
         // ACME mocking: the pending order cannot be polled back from the CA

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerReloadGuardTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerReloadGuardTest.java
@@ -19,11 +19,10 @@
  */
 package org.carapaceproxy.server.certificates;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.AVAILABLE;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.REQUEST_FAILED;
 import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.hasAnyBindingChange;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import java.util.Set;
@@ -35,46 +34,46 @@ import org.junit.jupiter.api.Test;
  * Each test name describes the high-level behaviour driven by the predicate: when it returns
  * {@code false}, the reload skips {@code server.getListeners().reloadCurrentConfiguration()}.
  */
-public class DynamicCertificatesManagerReloadGuardTest {
+class DynamicCertificatesManagerReloadGuardTest {
 
     private static final byte[] KEYSTORE_A = {0x10, 0x11, 0x12};
     private static final byte[] KEYSTORE_B = {0x20, 0x21, 0x22};
 
     @Test
-    public void testReloadSkipsListenerWhenNoCertChanged() {
+    void reloadSkipsListenerWhenNoCertChanged() {
         final CertificateData stable = certWithKeystore("example.com", KEYSTORE_A);
         final Map<String, CertificateData> old = Map.of("example.com", stable);
         final Map<String, CertificateData> fresh = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_A.clone()));
-        assertFalse(hasAnyBindingChange(old, fresh));
+        assertThat(hasAnyBindingChange(old, fresh)).isFalse();
     }
 
     @Test
-    public void testReloadTriggersListenerOnKeystoreChange() {
+    void reloadTriggersListenerOnKeystoreChange() {
         final Map<String, CertificateData> old = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_A));
         final Map<String, CertificateData> fresh = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_B));
-        assertTrue(hasAnyBindingChange(old, fresh));
+        assertThat(hasAnyBindingChange(old, fresh)).isTrue();
     }
 
     @Test
-    public void testReloadTriggersListenerOnDomainAdded() {
+    void reloadTriggersListenerOnDomainAdded() {
         final Map<String, CertificateData> old = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_A));
         final Map<String, CertificateData> fresh = Map.of(
                 "example.com", certWithKeystore("example.com", KEYSTORE_A.clone()),
                 "second.example.com", certWithKeystore("second.example.com", KEYSTORE_B));
-        assertTrue(hasAnyBindingChange(old, fresh));
+        assertThat(hasAnyBindingChange(old, fresh)).isTrue();
     }
 
     @Test
-    public void testReloadTriggersListenerOnDomainRemoved() {
+    void reloadTriggersListenerOnDomainRemoved() {
         final Map<String, CertificateData> old = Map.of(
                 "example.com", certWithKeystore("example.com", KEYSTORE_A),
                 "second.example.com", certWithKeystore("second.example.com", KEYSTORE_B));
         final Map<String, CertificateData> fresh = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_A.clone()));
-        assertTrue(hasAnyBindingChange(old, fresh));
+        assertThat(hasAnyBindingChange(old, fresh)).isTrue();
     }
 
     @Test
-    public void testReloadSkipsListenerWhenOnlyAttemptsCountIncremented() {
+    void reloadSkipsListenerWhenOnlyAttemptsCountIncremented() {
         // Exact staging symptom: a stuck ACME order ticks attemptsCount+message+state every poll
         // while keystoreData stays at its last successful value (or null on a brand-new domain).
         final CertificateData stuckPrev = certWithKeystore("stuck.example.com", null);
@@ -89,16 +88,16 @@ public class DynamicCertificatesManagerReloadGuardTest {
 
         final Map<String, CertificateData> old = Map.of("stuck.example.com", stuckPrev);
         final Map<String, CertificateData> fresh = Map.of("stuck.example.com", stuckTicked);
-        assertFalse(hasAnyBindingChange(old, fresh));
+        assertThat(hasAnyBindingChange(old, fresh)).isFalse();
     }
 
     @Test
-    public void testReloadTriggersListenerOnSanChange() {
+    void reloadTriggersListenerOnSanChange() {
         final CertificateData oldCert = certWithKeystoreAndSans("example.com", KEYSTORE_A, Set.of("alt.example.com"));
         final CertificateData freshCert = certWithKeystoreAndSans("example.com", KEYSTORE_A.clone(), Set.of("other.example.com"));
         final Map<String, CertificateData> old = Map.of("example.com", oldCert);
         final Map<String, CertificateData> fresh = Map.of("example.com", freshCert);
-        assertTrue(hasAnyBindingChange(old, fresh));
+        assertThat(hasAnyBindingChange(old, fresh)).isTrue();
     }
 
     private static CertificateData certWithKeystore(final String domain, final byte[] keystoreData) {

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerSchedulingTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerSchedulingTest.java
@@ -19,7 +19,7 @@
  */
 package org.carapaceproxy.server.certificates;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -60,13 +60,13 @@ class DynamicCertificatesManagerSchedulingTest {
         // With new period >0 the manager should run whether started before
         config.setDynamicCertificatesManagerPeriod(1);
         man.reloadConfiguration(config);
-        assertEquals(1, man.getPeriod());
+        assertThat(man.getPeriod()).isOne();
         verify(scheduler, times(1)).scheduleWithFixedDelay(any(Runnable.class), eq(0L), eq(1L), eq(TimeUnit.SECONDS)); // once
 
         man.stop();
         config.setDynamicCertificatesManagerPeriod(0);
         man.reloadConfiguration(config);
-        assertEquals(0, man.getPeriod());
+        assertThat(man.getPeriod()).isZero();
         man.start();
         verify(scheduler, times(1)).scheduleWithFixedDelay(any(Runnable.class), eq(0L), eq(1L), eq(TimeUnit.SECONDS)); // never
         man.stop();
@@ -74,7 +74,7 @@ class DynamicCertificatesManagerSchedulingTest {
         // With new period >0 the manager should not run because not started before.
         config.setDynamicCertificatesManagerPeriod(1);
         man.reloadConfiguration(config);
-        assertEquals(1, man.getPeriod());
+        assertThat(man.getPeriod()).isOne();
         verify(scheduler, times(1)).scheduleWithFixedDelay(any(Runnable.class), eq(0L), eq(1L), eq(TimeUnit.SECONDS)); // never
 
         man.start();

--- a/carapace-server/src/test/java/org/carapaceproxy/server/filters/AbstractXTlsFilterTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/filters/AbstractXTlsFilterTest.java
@@ -1,7 +1,7 @@
 package org.carapaceproxy.server.filters;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import java.io.File;
@@ -98,7 +98,7 @@ public abstract class AbstractXTlsFilterTest {
                         Connection: close\r
                         \r
                         """).toString();
-                assertThat(response, containsString(expected));
+                assertThat(response).contains(expected);
             }
         } else {
             try (HttpClient client = HttpClient.newBuilder().version(HttpClient.Version.HTTP_2).build()) {
@@ -106,7 +106,7 @@ public abstract class AbstractXTlsFilterTest {
                         HttpRequest.newBuilder().uri(URI.create((ssl ? "https" : "http") + "://localhost:" + port + "/index.html")).GET().build(),
                         HttpResponse.BodyHandlers.ofString()
                 );
-                assertThat(response.body(), containsString(expected));
+                assertThat(response.body()).contains(expected);
             }
         }
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/filters/ServerHeaderRequestFilterTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/filters/ServerHeaderRequestFilterTest.java
@@ -1,8 +1,6 @@
 package org.carapaceproxy.server.filters;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
@@ -14,10 +12,10 @@ import org.carapaceproxy.core.RequestFilter;
 import org.carapaceproxy.server.config.RequestFilterConfiguration;
 import org.junit.jupiter.api.Test;
 
-public class ServerHeaderRequestFilterTest {
+class ServerHeaderRequestFilterTest {
 
     @Test
-    public void testFactoryFallbackUsesDefaultWhenValueMissing() throws Exception {
+    void factoryFallbackUsesDefaultWhenValueMissing() throws Exception {
         Map<String, String> cfg = new HashMap<>(); // no 'value' key
         RequestFilterConfiguration rfc = new RequestFilterConfiguration(ServerHeaderRequestFilter.TYPE, cfg);
         RequestFilter filter = RequestFilterFactory.buildRequestFilter(rfc);
@@ -27,11 +25,11 @@ public class ServerHeaderRequestFilterTest {
 
         filter.apply(request);
 
-        assertThat(headers.get(HttpHeaderNames.SERVER), is(ServerHeaderRequestFilter.DEFAULT_SERVER));
+        assertThat(headers.get(HttpHeaderNames.SERVER)).isEqualTo(ServerHeaderRequestFilter.DEFAULT_SERVER);
     }
 
     @Test
-    public void testFactoryUsesProvidedValueToOverride() throws Exception {
+    void factoryUsesProvidedValueToOverride() throws Exception {
         Map<String, String> cfg = new HashMap<>();
         cfg.put("value", "MyServer/1.0");
         RequestFilterConfiguration rfc = new RequestFilterConfiguration(ServerHeaderRequestFilter.TYPE, cfg);
@@ -43,11 +41,11 @@ public class ServerHeaderRequestFilterTest {
 
         filter.apply(request);
 
-        assertThat(headers.get(HttpHeaderNames.SERVER), is("MyServer/1.0"));
+        assertThat(headers.get(HttpHeaderNames.SERVER)).isEqualTo("MyServer/1.0");
     }
 
     @Test
-    public void testFactoryEmptyValueRemovesHeader() throws Exception {
+    void factoryEmptyValueRemovesHeader() throws Exception {
         Map<String, String> cfg = new HashMap<>();
         cfg.put("value", "");
         RequestFilterConfiguration rfc = new RequestFilterConfiguration(ServerHeaderRequestFilter.TYPE, cfg);
@@ -60,7 +58,7 @@ public class ServerHeaderRequestFilterTest {
 
         filter.apply(request);
 
-        assertTrue(headers.getAll(HttpHeaderNames.SERVER).isEmpty());
+        assertThat(headers.getAll(HttpHeaderNames.SERVER)).isEmpty();
     }
 }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/filters/SimpleFiltersTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/filters/SimpleFiltersTest.java
@@ -31,10 +31,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class SimpleFiltersTest {
+class SimpleFiltersTest {
 
     @Test
-    public void testRegexpMapUserIdFilter() {
+    void regexpMapUserIdFilter() {
 
         Map<String, String> cases = new HashMap<>();
         cases.put("/test?param1=&sSID=H*29gnay4j68mt9c", "H");
@@ -63,7 +63,7 @@ public class SimpleFiltersTest {
     }
 
     @Test
-    public void testRegexpMapSessionIdFilter() {
+    void regexpMapSessionIdFilter() {
 
         Map<String, String> cases = new HashMap<>();
         cases.put("/test?param1=&sSID=H*29gnay4j68mt9c", "H*29gnay4j68mt9c");

--- a/carapace-server/src/test/java/org/carapaceproxy/server/filters/UrlEncodedQueryStringTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/filters/UrlEncodedQueryStringTest.java
@@ -19,12 +19,10 @@
  */
 package org.carapaceproxy.server.filters;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.carapaceproxy.server.filters.UrlEncodedQueryString.create;
+import static org.carapaceproxy.server.filters.UrlEncodedQueryString.parse;
+
 import java.net.URI;
 import org.junit.jupiter.api.Test;
 
@@ -36,87 +34,87 @@ class UrlEncodedQueryStringTest {
 
     @Test
     void parsesMultiValuedParametersInOrder() {
-        UrlEncodedQueryString q = UrlEncodedQueryString.parse("a=1&b=2&a=3");
-        assertEquals(List.of("1", "3"), q.getValues("a"));
-        assertEquals(List.of("2"), q.getValues("b"));
-        assertEquals("1", q.get("a")); // first value
+        UrlEncodedQueryString q = parse("a=1&b=2&a=3");
+        assertThat(q.getValues("a")).containsExactly("1", "3");
+        assertThat(q.getValues("b")).containsExactly("2");
+        assertThat(q.get("a")).isEqualTo("1"); // first value
     }
 
     @Test
     void splitsOnSemicolonAsWellAsAmpersand() {
-        UrlEncodedQueryString q = UrlEncodedQueryString.parse("a=1;b=2");
-        assertEquals("1", q.get("a"));
-        assertEquals("2", q.get("b"));
+        UrlEncodedQueryString q = parse("a=1;b=2");
+        assertThat(q.get("a")).isEqualTo("1");
+        assertThat(q.get("b")).isEqualTo("2");
     }
 
     @Test
     void namesAreLowercasedOnGetAndContainsButNotOnGetValues() {
-        UrlEncodedQueryString q = UrlEncodedQueryString.parse("A=1");
-        assertEquals("1", q.get("a"));
-        assertTrue(q.contains("a"));
-        assertEquals(List.of("1"), q.getValues("a"));
+        UrlEncodedQueryString q = parse("A=1");
+        assertThat(q.get("a")).isEqualTo("1");
+        assertThat(q.contains("a")).isTrue();
+        assertThat(q.getValues("a")).containsExactly("1");
         // getValues does NOT lowercase its argument, and stored keys are lowercase:
-        assertNull(q.getValues("A"));
+        assertThat(q.getValues("A")).isNull();
     }
 
     @Test
     void valuelessParameterExistsButHasNullValue() {
-        UrlEncodedQueryString q = UrlEncodedQueryString.parse("foo=1&bar");
-        assertTrue(q.contains("bar"));
-        assertNull(q.get("bar"));
-        assertEquals("1", q.get("foo"));
-        assertTrue(q.toString().contains("bar"));
-        assertFalse(q.toString().contains("bar="));
+        UrlEncodedQueryString q = parse("foo=1&bar");
+        assertThat(q.contains("bar")).isTrue();
+        assertThat(q.get("bar")).isNull();
+        assertThat(q.get("foo")).isEqualTo("1");
+        assertThat(q.toString()).contains("bar");
+        assertThat(q.toString()).doesNotContain("bar=");
     }
 
     @Test
     void emptyValueParameterIsDistinctFromValueless() {
-        UrlEncodedQueryString q = UrlEncodedQueryString.parse("foo=1&bar=");
-        assertTrue(q.contains("bar"));
-        assertTrue(q.get("bar").isEmpty());
+        UrlEncodedQueryString q = parse("foo=1&bar=");
+        assertThat(q.contains("bar")).isTrue();
+        assertThat(q.get("bar")).isEmpty();
     }
 
     @Test
     void formDecodesNamesAndValues() {
-        assertEquals("1", UrlEncodedQueryString.parse("%70age=1").get("page"));
-        assertEquals("x y", UrlEncodedQueryString.parse("a=x+y").get("a"));
-        assertEquals(" ", UrlEncodedQueryString.parse("a=%20").get("a"));
+        assertThat(parse("%70age=1").get("page")).isEqualTo("1");
+        assertThat(parse("a=x+y").get("a")).isEqualTo("x y");
+        assertThat(parse("a=%20").get("a")).isEqualTo(" ");
     }
 
     @Test
     void appendAccumulatesSetReplacesRemoveDeletes() {
-        UrlEncodedQueryString q = UrlEncodedQueryString.create();
+        UrlEncodedQueryString q = create();
         q.append("a", "1").append("a", "2");
-        assertEquals(List.of("1", "2"), q.getValues("a"));
+        assertThat(q.getValues("a")).containsExactly("1", "2");
 
         q.set("a", "9");
-        assertEquals(List.of("9"), q.getValues("a"));
+        assertThat(q.getValues("a")).containsExactly("9");
 
         q.remove("a");
-        assertFalse(q.contains("a"));
-        assertTrue(q.isEmpty());
+        assertThat(q.contains("a")).isFalse();
+        assertThat(q.isEmpty()).isTrue();
     }
 
     @Test
     void setNullValueRemovesParameter() {
-        UrlEncodedQueryString q = UrlEncodedQueryString.create();
+        UrlEncodedQueryString q = create();
         q.append("a", "1");
         q.set("a", (String) null);
-        assertFalse(q.contains("a"));
+        assertThat(q.contains("a")).isFalse();
     }
 
     @Test
     void toStringReEncodesAndRoundTrips() throws Exception {
-        assertEquals("a=1&b=2", UrlEncodedQueryString.parse("a=1&b=2").toString());
-        assertEquals("a=x+y", UrlEncodedQueryString.create().append("a", "x y").toString());
+        assertThat(parse("a=1&b=2")).hasToString("a=1&b=2");
+        assertThat(create().append("a", "x y")).hasToString("a=x+y");
 
-        URI applied = UrlEncodedQueryString.parse("a=1&b=2").apply(new URI("http://host/path"));
-        assertEquals("a=1&b=2", applied.getRawQuery());
+        URI applied = parse("a=1&b=2").apply(new URI("http://host/path"));
+        assertThat(applied.getRawQuery()).isEqualTo("a=1&b=2");
     }
 
     @Test
     void equalityIsOrderSensitiveViaToString() {
-        assertEquals(UrlEncodedQueryString.parse("a=1&b=2"), UrlEncodedQueryString.parse("a=1&b=2"));
-        assertNotEquals(UrlEncodedQueryString.parse("b=2&a=1"), UrlEncodedQueryString.parse("a=1&b=2"));
+        assertThat(parse("a=1&b=2")).isEqualTo(parse("a=1&b=2"));
+        assertThat(parse("a=1&b=2")).isNotEqualTo(parse("b=2&a=1"));
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/filters/XForwardedForFilterIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/filters/XForwardedForFilterIT.java
@@ -26,7 +26,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -56,7 +56,7 @@ public class XForwardedForFilterIT {
     public File tmpDir;
 
     @Test
-    public void testXForwardedForFilter() throws Exception {
+    void xForwardedForFilter() throws Exception {
 
         stubFor(get(urlEqualTo("/index.html"))
                 .withHeader("X-Forwarded-For", equalTo("127.0.0.1"))
@@ -75,19 +75,19 @@ public class XForwardedForFilterIT {
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n").toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
             }
 
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nX-Forwarded-For: 1.2.3.4\r\nConnection: close\r\n\r\n").toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
             }
         }
     }
 
     @Test
-    public void testNoXForwardedForFilter() throws Exception {
+    void noXForwardedForFilter() throws Exception {
 
         stubFor(
                 get(urlEqualTo("/index.html"))
@@ -114,12 +114,12 @@ public class XForwardedForFilterIT {
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nX-Forwarded-For: 1.2.3.4\r\nConnection: close\r\n\r\n").toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("it <b>works</b> !!"));
+                assertThat(s).contains("it <b>works</b> !!");
             }
             try (RawHttpClient client = new RawHttpClient("localhost", port)) {
                 String s = client.executeRequest("GET /index.html HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n").toString();
                 System.out.println("s:" + s);
-                assertTrue(s.contains("No X-Forwarded-For"));
+                assertThat(s).contains("No X-Forwarded-For");
             }
         }
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/filters/XForwardedForRequestFilterTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/filters/XForwardedForRequestFilterTest.java
@@ -19,11 +19,9 @@
  */
 package org.carapaceproxy.server.filters;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import java.util.List;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import java.net.InetSocketAddress;
 import org.carapaceproxy.core.ProxyRequest;
@@ -43,7 +41,7 @@ class XForwardedForRequestFilterTest {
 
         new XForwardedForRequestFilter(new MatchAllRequestMatcher()).apply(request);
 
-        assertEquals("127.0.0.1", headers.get(HEADER));
+        assertThat(headers.get(HEADER)).isEqualTo("127.0.0.1");
     }
 
     @Test
@@ -56,7 +54,7 @@ class XForwardedForRequestFilterTest {
 
         new XForwardedForRequestFilter(new MatchAllRequestMatcher()).apply(request);
 
-        assertEquals(List.of("127.0.0.1"), headers.getAll(HEADER));
+        assertThat(headers.getAll(HEADER)).containsExactly("127.0.0.1");
     }
 
     @Test
@@ -69,6 +67,6 @@ class XForwardedForRequestFilterTest {
 
         new XForwardedForRequestFilter(new MatchAllRequestMatcher()).apply(request);
 
-        assertEquals(List.of("1.2.3.4"), headers.getAll(HEADER));
+        assertThat(headers.getAll(HEADER)).containsExactly("1.2.3.4");
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsCipherFilterIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsCipherFilterIT.java
@@ -26,7 +26,7 @@ class XTlsCipherFilterIT extends AbstractXTlsFilterTest {
                 .willReturn(aResponse().withStatus(200).withBody("it <b>absent</b> !!")));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "http1={0}")
     @ValueSource(booleans = {true, false})
     void httpsWithCipherAndProtocol(boolean http1) throws Exception {
         WireMockServer wireMockRule = newWireMock(http1);
@@ -43,7 +43,7 @@ class XTlsCipherFilterIT extends AbstractXTlsFilterTest {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "http1={0}")
     @ValueSource(booleans = {true, false})
     void httpsWithProtocolOnly(boolean http1) throws Exception {
         WireMockServer wireMockRule = newWireMock(http1);

--- a/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsCipherFilterIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsCipherFilterIT.java
@@ -13,7 +13,7 @@ import org.carapaceproxy.server.config.RequestFilterConfiguration;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class XTlsCipherFilterIT extends AbstractXTlsFilterTest {
+class XTlsCipherFilterIT extends AbstractXTlsFilterTest {
 
     private void setupWireMockForCipherFilter(WireMockServer wireMockRule) {
         wireMockRule.stubFor(get(urlEqualTo("/index.html"))
@@ -28,7 +28,7 @@ public class XTlsCipherFilterIT extends AbstractXTlsFilterTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void testHttpsWithCipherAndProtocol(boolean http1) throws Exception {
+    void httpsWithCipherAndProtocol(boolean http1) throws Exception {
         WireMockServer wireMockRule = newWireMock(http1);
         wireMockRule.start();
         try {
@@ -45,7 +45,7 @@ public class XTlsCipherFilterIT extends AbstractXTlsFilterTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void testHttpsWithProtocolOnly(boolean http1) throws Exception {
+    void httpsWithProtocolOnly(boolean http1) throws Exception {
         WireMockServer wireMockRule = newWireMock(http1);
         wireMockRule.start();
         try {

--- a/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsCipherRequestFilterTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsCipherRequestFilterTest.java
@@ -19,11 +19,9 @@
  */
 package org.carapaceproxy.server.filters;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import java.util.List;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import org.carapaceproxy.core.ProxyRequest;
 import org.carapaceproxy.server.mapper.requestmatcher.MatchAllRequestMatcher;
@@ -42,7 +40,7 @@ class XTlsCipherRequestFilterTest {
 
         new XTlsCipherRequestFilter(new MatchAllRequestMatcher()).apply(request);
 
-        assertTrue(headers.getAll(HEADER).isEmpty());
+        assertThat(headers.getAll(HEADER)).isEmpty();
     }
 
     @Test
@@ -55,7 +53,7 @@ class XTlsCipherRequestFilterTest {
 
         new XTlsCipherRequestFilter(new MatchAllRequestMatcher()).apply(request);
 
-        assertEquals("TLS_AES_128_GCM_SHA256", headers.get(HEADER));
+        assertThat(headers.get(HEADER)).isEqualTo("TLS_AES_128_GCM_SHA256");
     }
 
     @Test
@@ -69,6 +67,6 @@ class XTlsCipherRequestFilterTest {
 
         new XTlsCipherRequestFilter(new MatchAllRequestMatcher()).apply(request);
 
-        assertEquals(List.of("TLS_AES_256_GCM_SHA384"), headers.getAll(HEADER));
+        assertThat(headers.getAll(HEADER)).containsExactly("TLS_AES_256_GCM_SHA384");
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsProtocolFilterIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsProtocolFilterIT.java
@@ -24,7 +24,7 @@ class XTlsProtocolFilterIT extends AbstractXTlsFilterTest {
                 .willReturn(aResponse().withStatus(200).withBody("it <b>absent</b> !!")));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "http1={0}")
     @ValueSource(booleans = {true, false})
     void httpsWithFilter(boolean http1) throws Exception {
         WireMockServer wireMockRule = newWireMock(http1);
@@ -40,7 +40,7 @@ class XTlsProtocolFilterIT extends AbstractXTlsFilterTest {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "http1={0}")
     @ValueSource(booleans = {true, false})
     void httpsWithoutFilter(boolean http1) throws Exception {
         WireMockServer wireMockRule = newWireMock(http1);
@@ -58,7 +58,7 @@ class XTlsProtocolFilterIT extends AbstractXTlsFilterTest {
     // Plaintext filter behaviour (!isSecure() -> no header) is covered by the unit
     // XTlsProtocolRequestFilterTest; only the HTTPS cases that need a real TLS handshake stay here.
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "http1={0}")
     @ValueSource(booleans = {true, false})
     void httpWithoutFilter(boolean http1) throws Exception {
         WireMockServer wireMockRule = newWireMock(http1);

--- a/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsProtocolFilterIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsProtocolFilterIT.java
@@ -12,7 +12,7 @@ import org.carapaceproxy.server.config.RequestFilterConfiguration;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class XTlsProtocolFilterIT extends AbstractXTlsFilterTest {
+class XTlsProtocolFilterIT extends AbstractXTlsFilterTest {
 
     private void setupWireMockForProtocolFilter(WireMockServer wireMockRule) {
         wireMockRule.stubFor(get(urlEqualTo("/index.html"))
@@ -26,7 +26,7 @@ public class XTlsProtocolFilterIT extends AbstractXTlsFilterTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void testHttpsWithFilter(boolean http1) throws Exception {
+    void httpsWithFilter(boolean http1) throws Exception {
         WireMockServer wireMockRule = newWireMock(http1);
         wireMockRule.start();
         try {
@@ -42,7 +42,7 @@ public class XTlsProtocolFilterIT extends AbstractXTlsFilterTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void testHttpsWithoutFilter(boolean http1) throws Exception {
+    void httpsWithoutFilter(boolean http1) throws Exception {
         WireMockServer wireMockRule = newWireMock(http1);
         wireMockRule.start();
         try {
@@ -60,7 +60,7 @@ public class XTlsProtocolFilterIT extends AbstractXTlsFilterTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void testHttpWithoutFilter(boolean http1) throws Exception {
+    void httpWithoutFilter(boolean http1) throws Exception {
         WireMockServer wireMockRule = newWireMock(http1);
         wireMockRule.start();
         try {

--- a/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsProtocolRequestFilterTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/filters/XTlsProtocolRequestFilterTest.java
@@ -19,11 +19,9 @@
  */
 package org.carapaceproxy.server.filters;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import java.util.List;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import org.carapaceproxy.core.ProxyRequest;
 import org.carapaceproxy.server.mapper.requestmatcher.MatchAllRequestMatcher;
@@ -42,7 +40,7 @@ class XTlsProtocolRequestFilterTest {
 
         new XTlsProtocolRequestFilter(new MatchAllRequestMatcher()).apply(request);
 
-        assertTrue(headers.getAll(HEADER).isEmpty());
+        assertThat(headers.getAll(HEADER)).isEmpty();
     }
 
     @Test
@@ -55,7 +53,7 @@ class XTlsProtocolRequestFilterTest {
 
         new XTlsProtocolRequestFilter(new MatchAllRequestMatcher()).apply(request);
 
-        assertEquals("TLSv1.2", headers.get(HEADER));
+        assertThat(headers.get(HEADER)).isEqualTo("TLSv1.2");
     }
 
     @Test
@@ -69,6 +67,6 @@ class XTlsProtocolRequestFilterTest {
 
         new XTlsProtocolRequestFilter(new MatchAllRequestMatcher()).apply(request);
 
-        assertEquals(List.of("TLSv1.3"), headers.getAll(HEADER));
+        assertThat(headers.getAll(HEADER)).containsExactly("TLSv1.3");
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperIT.java
@@ -140,7 +140,8 @@ public class BasicStandardEndpointMapperIT {
                 assertThat(s).isEqualTo("it <b>works</b> !!");
             }
 
-            assertThatThrownBy(() -> IOUtils.toString(URI.create("http://localhost:" + port + "/notfound.html"), StandardCharsets.UTF_8)).isInstanceOf(FileNotFoundException.class);
+            assertThatThrownBy(() -> IOUtils.toString(URI.create("http://localhost:" + port + "/notfound.html"), StandardCharsets.UTF_8)).isInstanceOf(FileNotFoundException.class)
+                    .hasMessageContaining("/notfound.html");
 
             {
                 String staticContent = IOUtils.toString(URI.create("http://localhost:" + port + "/static.html"), StandardCharsets.UTF_8);
@@ -151,9 +152,11 @@ public class BasicStandardEndpointMapperIT {
                 assertThat(staticContent).isEqualTo("Test static page");
             }
 
-            assertThatThrownBy(() -> IOUtils.toString(URI.create("http://localhost:" + port + "/error.html"), StandardCharsets.UTF_8)).isInstanceOf(IOException.class);
+            assertThatThrownBy(() -> IOUtils.toString(URI.create("http://localhost:" + port + "/error.html"), StandardCharsets.UTF_8)).isInstanceOf(IOException.class)
+                    .hasMessageContaining("/error.html");
 
-            assertThatThrownBy(() -> IOUtils.toString(URI.create("http://localhost:" + port + "/notmapped.html"), StandardCharsets.UTF_8)).isInstanceOf(FileNotFoundException.class);
+            assertThatThrownBy(() -> IOUtils.toString(URI.create("http://localhost:" + port + "/notmapped.html"), StandardCharsets.UTF_8)).isInstanceOf(FileNotFoundException.class)
+                    .hasMessageContaining("/notmapped.html");
         }
     }
 
@@ -331,7 +334,8 @@ public class BasicStandardEndpointMapperIT {
                 assertThat(s).isEqualTo("it <b>works</b> !!");
             }
             // down.html (request to unreachable backend) has NOT to match to route-deafult BUT get internal-error
-            assertThatThrownBy(() -> IOUtils.toString(URI.create("http://localhost:" + port + "/down.html"), StandardCharsets.UTF_8)).isInstanceOf(IOException.class);
+            assertThatThrownBy(() -> IOUtils.toString(URI.create("http://localhost:" + port + "/down.html"), StandardCharsets.UTF_8)).isInstanceOf(IOException.class)
+                    .hasMessageContaining("/down.html");
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperIT.java
@@ -24,8 +24,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 import static org.carapaceproxy.core.ProxyRequest.PROPERTY_URI;
 import static org.carapaceproxy.core.StaticContentsManager.CLASSPATH_RESOURCE;
 import static org.mockito.ArgumentMatchers.eq;
@@ -409,14 +409,11 @@ public class BasicStandardEndpointMapperIT {
                 String s = IOUtils.toString(URI.create(url), StandardCharsets.UTF_8);
                 assertThat(s).isEqualTo("it <b>works</b> !!");
             }
-            // resource not esists > Not Found
-            try {
-                String url = "http://localhost:" + server.getLocalPort() + "/not-exists.html";
-                String s = IOUtils.toString(URI.create(url), StandardCharsets.UTF_8);
-                fail("Expected Not Found, received " + s + " instead");
-            } catch (Exception ex) {
-                assertThat(ex).isInstanceOf(FileNotFoundException.class);
-            }
+            // resource does not exist > Not Found
+            final String missing = "http://localhost:" + server.getLocalPort() + "/not-exists.html";
+            assertThatExceptionOfType(FileNotFoundException.class)
+                    .isThrownBy(() -> IOUtils.toString(URI.create(missing), StandardCharsets.UTF_8))
+                    .withMessageContaining("/not-exists.html");
         }
     }
 
@@ -471,13 +468,10 @@ public class BasicStandardEndpointMapperIT {
             assertThat(s).isEqualTo(tokenData);
 
             // Test not existent token
-            try {
-                url = "http://localhost:" + server.getLocalPort() + "/.well-known/acme-challenge/not-existent-token";
-                IOUtils.toString(URI.create(url), StandardCharsets.UTF_8);
-                fail("");
-            } catch (Throwable t) {
-                assertThat(t).isInstanceOf(FileNotFoundException.class);
-            }
+            final String missingToken = "http://localhost:" + server.getLocalPort() + "/.well-known/acme-challenge/not-existent-token";
+            assertThatExceptionOfType(FileNotFoundException.class)
+                    .isThrownBy(() -> IOUtils.toString(URI.create(missingToken), StandardCharsets.UTF_8))
+                    .withMessageContaining("not-existent-token");
 
         }
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/BasicStandardEndpointMapperIT.java
@@ -23,14 +23,11 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 import static org.carapaceproxy.core.ProxyRequest.PROPERTY_URI;
 import static org.carapaceproxy.core.StaticContentsManager.CLASSPATH_RESOURCE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
@@ -77,7 +74,7 @@ public class BasicStandardEndpointMapperIT {
     public File tmpDir;
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -128,52 +125,40 @@ public class BasicStandardEndpointMapperIT {
             {
                 // proxy on director 1
                 String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index.html"), StandardCharsets.UTF_8);
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
             }
 
             {
                 // cache on director 2
                 String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index2.html"), StandardCharsets.UTF_8);
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
             }
 
             {
                 // director "all"
                 String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index3.html"), StandardCharsets.UTF_8);
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
             }
 
-            try {
-                IOUtils.toString(URI.create("http://localhost:" + port + "/notfound.html"), StandardCharsets.UTF_8);
-                fail("expected 404");
-            } catch (FileNotFoundException ok) {
-            }
+            assertThatThrownBy(() -> IOUtils.toString(URI.create("http://localhost:" + port + "/notfound.html"), StandardCharsets.UTF_8)).isInstanceOf(FileNotFoundException.class);
 
             {
                 String staticContent = IOUtils.toString(URI.create("http://localhost:" + port + "/static.html"), StandardCharsets.UTF_8);
-                assertEquals("Test static page", staticContent);
+                assertThat(staticContent).isEqualTo("Test static page");
             }
             {
                 String staticContent = IOUtils.toString(URI.create("http://localhost:" + port + "/static.html"), StandardCharsets.UTF_8);
-                assertEquals("Test static page", staticContent);
+                assertThat(staticContent).isEqualTo("Test static page");
             }
 
-            try {
-                IOUtils.toString(URI.create("http://localhost:" + port + "/error.html"), StandardCharsets.UTF_8);
-                fail("expected 500");
-            } catch (IOException ok) {
-            }
+            assertThatThrownBy(() -> IOUtils.toString(URI.create("http://localhost:" + port + "/error.html"), StandardCharsets.UTF_8)).isInstanceOf(IOException.class);
 
-            try {
-                IOUtils.toString(URI.create("http://localhost:" + port + "/notmapped.html"), StandardCharsets.UTF_8);
-                fail("expected 404");
-            } catch (FileNotFoundException ok) {
-            }
+            assertThatThrownBy(() -> IOUtils.toString(URI.create("http://localhost:" + port + "/notmapped.html"), StandardCharsets.UTF_8)).isInstanceOf(FileNotFoundException.class);
         }
     }
 
     @Test
-    public void testRouteErrors() throws Exception {
+    void routeErrors() throws Exception {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -274,28 +259,28 @@ public class BasicStandardEndpointMapperIT {
             {
                 HttpURLConnection conn = (HttpURLConnection) URI.create("http://localhost:" + server.getLocalPort() + "/custom-error.html").toURL().openConnection();
                 System.out.println("response core " +  conn.getResponseCode());
-                assertEquals("h-custom-error-value; h-custom-error-value2;h-custom-error-value3", conn.getHeaderField("h-custom-error"));
-                assertEquals(555, conn.getResponseCode());
+                assertThat(conn.getHeaderField("h-custom-error")).isEqualTo("h-custom-error-value; h-custom-error-value2;h-custom-error-value3");
+                assertThat(conn.getResponseCode()).isEqualTo(555);
             }
 
             // working one
             {
                 HttpURLConnection conn = (HttpURLConnection) URI.create("http://localhost:" + server.getLocalPort() + "/index.html").toURL().openConnection();
-                assertEquals("h-working-one-value; h-working-one-value2;h-working-one-value3", conn.getHeaderField("h-working-one"));
-                assertEquals(200, conn.getResponseCode());
+                assertThat(conn.getHeaderField("h-working-one")).isEqualTo("h-working-one-value; h-working-one-value2;h-working-one-value3");
+                assertThat(conn.getResponseCode()).isEqualTo(200);
             }
 
             // global-custom error (Not Found)
             {
                 HttpURLConnection conn = (HttpURLConnection) URI.create("http://localhost:" + server.getLocalPort() + "/index2.html").toURL().openConnection();
-                assertEquals("h-custom-global-error-value; h-custom-global-error-value2;h-custom-global-error-value3", conn.getHeaderField("h-custom-global-error"));
-                assertEquals(444, conn.getResponseCode());
+                assertThat(conn.getHeaderField("h-custom-global-error")).isEqualTo("h-custom-global-error-value; h-custom-global-error-value2;h-custom-global-error-value3");
+                assertThat(conn.getResponseCode()).isEqualTo(444);
             }
         }
     }
 
     @Test
-    public void testDefaultRoute() throws Exception {
+    void defaultRoute() throws Exception {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -338,24 +323,20 @@ public class BasicStandardEndpointMapperIT {
             // index.html matches with route
             {
                 String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index.html"), StandardCharsets.UTF_8);
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
             }
             // notmapped.html matches with route-default
             {
                 String s = IOUtils.toString(URI.create("http://localhost:" + port + "/notmapped.html"), StandardCharsets.UTF_8);
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
             }
             // down.html (request to unreachable backend) has NOT to match to route-deafult BUT get internal-error
-            try {
-                IOUtils.toString(URI.create("http://localhost:" + port + "/down.html"), StandardCharsets.UTF_8);
-                fail("expected 500");
-            } catch (IOException ok) {
-            }
+            assertThatThrownBy(() -> IOUtils.toString(URI.create("http://localhost:" + port + "/down.html"), StandardCharsets.UTF_8)).isInstanceOf(IOException.class);
         }
     }
 
     @Test
-    public void testAlwaysServeStaticContent() throws Exception {
+    void alwaysServeStaticContent() throws Exception {
 
         stubFor(get(urlEqualTo("/seconda.html"))
                 .willReturn(aResponse()
@@ -416,13 +397,13 @@ public class BasicStandardEndpointMapperIT {
             {
                 String url = "http://localhost:" + server.getLocalPort() + "/index.html";
                 String s = IOUtils.toString(URI.create(url), StandardCharsets.UTF_8);
-                assertEquals("Test static page", s);
+                assertThat(s).isEqualTo("Test static page");
             }
             {
 
                 String url = "http://localhost:" + server.getLocalPort() + "/seconda.html";
                 String s = IOUtils.toString(URI.create(url), StandardCharsets.UTF_8);
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
             }
             // resource not esists > Not Found
             try {
@@ -430,13 +411,13 @@ public class BasicStandardEndpointMapperIT {
                 String s = IOUtils.toString(URI.create(url), StandardCharsets.UTF_8);
                 fail("Expected Not Found, received " + s + " instead");
             } catch (Exception ex) {
-                assertTrue(ex instanceof FileNotFoundException);
+                assertThat(ex).isInstanceOf(FileNotFoundException.class);
             }
         }
     }
 
     @Test
-    public void testServeACMEChallengeToken() throws Exception {
+    void serveACMEChallengeToken() throws Exception {
         try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, tmpDir)) {
             final String tokenName = "test-token";
             final String tokenData = "test-token-data-content";
@@ -483,22 +464,22 @@ public class BasicStandardEndpointMapperIT {
             // Test existent token
             String url = "http://localhost:" + server.getLocalPort() + "/.well-known/acme-challenge/" + tokenName;
             String s = IOUtils.toString(URI.create(url), StandardCharsets.UTF_8);
-            assertEquals(tokenData, s);
+            assertThat(s).isEqualTo(tokenData);
 
             // Test not existent token
             try {
                 url = "http://localhost:" + server.getLocalPort() + "/.well-known/acme-challenge/not-existent-token";
                 IOUtils.toString(URI.create(url), StandardCharsets.UTF_8);
-                fail();
+                fail("");
             } catch (Throwable t) {
-                assertTrue(t instanceof FileNotFoundException);
+                assertThat(t).isInstanceOf(FileNotFoundException.class);
             }
 
         }
     }
 
     @Test
-    public void testCustomAndDebuggingHeaders() throws Exception {
+    void customAndDebuggingHeaders() throws Exception {
         stubFor(get(urlEqualTo("/index.html"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -607,41 +588,41 @@ public class BasicStandardEndpointMapperIT {
             int port = server.getLocalPort();
             {
                 URLConnection conn = URI.create("http://localhost:" + port + "/index.html").toURL().openConnection();
-                assertEquals("header-1-value; header-1-value2;header-1-value3", conn.getHeaderField("custom-header-1"));
-                assertEquals("header-2-value", conn.getHeaderField("custom-header-2"));
+                assertThat(conn.getHeaderField("custom-header-1")).isEqualTo("header-1-value; header-1-value2;header-1-value3");
+                assertThat(conn.getHeaderField("custom-header-2")).isEqualTo("header-2-value");
                 // header mode-set
-                assertEquals("text/custom-text", conn.getHeaderField("Content-Type"));
-                assertFalse(conn.getHeaderFields().toString().contains("text/html"));
+                assertThat(conn.getHeaderField("Content-Type")).isEqualTo("text/custom-text");
+                assertThat(conn.getHeaderFields().toString()).doesNotContain("text/html");
                 // header mode-remove: for this action doesn't exist
-                assertNull(conn.getHeaderField("Transfer-Encoding"));
+                assertThat(conn.getHeaderField("Transfer-Encoding")).isNull();
 
                 // debugging header "Routing-Path"
-                assertEquals("r1;addHeaders;d1;b1", conn.getHeaderField("DebugHeaderCustomName"));
+                assertThat(conn.getHeaderField("DebugHeaderCustomName")).isEqualTo("r1;addHeaders;d1;b1");
             }
             {
                 URLConnection conn = URI.create("http://localhost:" + port + "/index2.html").toURL().openConnection();
-                assertNull(conn.getHeaderField("custom-header-1"));
-                assertEquals("header-2-value", conn.getHeaderField("custom-header-2"));
+                assertThat(conn.getHeaderField("custom-header-1")).isNull();
+                assertThat(conn.getHeaderField("custom-header-2")).isEqualTo("header-2-value");
                 // in this action is text/html as normal
-                assertTrue(conn.getHeaderFields().toString().contains("text/html"));
+                assertThat(conn.getHeaderFields().toString()).contains("text/html");
                 // custom-header-3 values have been merged (default mode-add)
-                assertTrue(conn.getHeaderFields().toString().contains("header-4-overridden-value"));
-                assertTrue(conn.getHeaderFields().toString().contains("header-3-overridden-value"));
+                assertThat(conn.getHeaderFields().toString()).contains("header-4-overridden-value");
+                assertThat(conn.getHeaderFields().toString()).contains("header-3-overridden-value");
                 // in this action still exists
-                assertNotNull(conn.getHeaderField("Transfer-Encoding"));
+                assertThat(conn.getHeaderField("Transfer-Encoding")).isNotNull();
 
                 // debugging header "Routing-Path"
-                assertEquals("r2;addHeader2;d2;b2", conn.getHeaderField("DebugHeaderCustomName"));
+                assertThat(conn.getHeaderField("DebugHeaderCustomName")).isEqualTo("r2;addHeader2;d2;b2");
             }
             {
                 URLConnection conn = URI.create("http://localhost:" + port + "/index3.html").toURL().openConnection();
-                assertEquals("header-1-value; header-1-value2;header-1-value3", conn.getHeaderField("custom-header-1"));
+                assertThat(conn.getHeaderField("custom-header-1")).isEqualTo("header-1-value; header-1-value2;header-1-value3");
             }
         }
     }
 
     @Test
-    public void testActionRedirect() throws Exception {
+    void actionRedirect() throws Exception {
 
         try (HttpProxyServer server = new HttpProxyServer(StandardEndpointMapper::new, tmpDir)) {
             Properties configuration = new Properties();
@@ -706,29 +687,29 @@ public class BasicStandardEndpointMapperIT {
                 // redirect to same host/uri but with https (default port)
                 HttpURLConnection conn = (HttpURLConnection) URI.create("http://localhost:" + port + "/index.html").toURL().openConnection();
                 conn.setInstanceFollowRedirects(false);
-                assertEquals("https://localhost/index.html", conn.getHeaderField("Location"));
-                assertTrue(conn.getHeaderFields().toString().contains("301 Moved Permanently"));
+                assertThat(conn.getHeaderField("Location")).isEqualTo("https://localhost/index.html");
+                assertThat(conn.getHeaderFields().toString()).contains("301 Moved Permanently");
             }
             {
                 // redirect to absolute host:port/uri
                 HttpURLConnection conn = (HttpURLConnection) URI.create("http://localhost:" + port + "/index2.html").toURL().openConnection();
                 conn.setInstanceFollowRedirects(false);
-                assertEquals("http://foo/index0.html", conn.getHeaderField("Location"));
-                assertTrue(conn.getHeaderFields().toString().contains("302 Found"));
+                assertThat(conn.getHeaderField("Location")).isEqualTo("http://foo/index0.html");
+                assertThat(conn.getHeaderFields().toString()).contains("302 Found");
             }
             {
                 // relative redirect (same host:port, different uri)
                 HttpURLConnection conn = (HttpURLConnection) URI.create("http://localhost:" + port + "/index3.html").toURL().openConnection();
                 conn.setInstanceFollowRedirects(false);
-                assertEquals("http://localhost:" + port + "/index0.html", conn.getHeaderField("Location"));
-                assertTrue(conn.getHeaderFields().toString().contains("303 See Other"));
+                assertThat(conn.getHeaderField("Location")).isEqualTo("http://localhost:" + port + "/index0.html");
+                assertThat(conn.getHeaderFields().toString()).contains("303 See Other");
             }
             {
                 // redirect custom
                 HttpURLConnection conn = (HttpURLConnection) URI.create("http://localhost:" + port + "/index4.html").toURL().openConnection();
                 conn.setInstanceFollowRedirects(false);
-                assertEquals("https://192.0.0.1:1234/indexX.html", conn.getHeaderField("Location"));
-                assertTrue(conn.getHeaderFields().toString().contains("307 Temporary Redirect"));
+                assertThat(conn.getHeaderField("Location")).isEqualTo("https://192.0.0.1:1234/indexX.html");
+                assertThat(conn.getHeaderFields().toString()).contains("307 Temporary Redirect");
             }
         }
     }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/ForceBackendIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/ForceBackendIT.java
@@ -24,8 +24,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.carapaceproxy.core.ProxyRequest.PROPERTY_URI;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -60,7 +60,7 @@ public class ForceBackendIT {
     public WireMockExtension backend1 = WireMockExtension.newInstance().configureStaticDsl(true).options(WireMockConfiguration.options().port(0)).build();
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         stubFor(get(urlEqualTo("/index.html?thedirector=director-2"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -81,8 +81,8 @@ public class ForceBackendIT {
             properties.put("mapper.forcedirector.parameter", "thedirector");
             properties.put("mapper.forcebackend.parameter", "thebackend");
             mapper.configure(new PropertiesConfigurationStore(properties));
-            assertEquals("thedirector", mapper.getForceDirectorParameter());
-            assertEquals("thebackend", mapper.getForceBackendParameter());
+            assertThat(mapper.getForceDirectorParameter()).isEqualTo("thedirector");
+            assertThat(mapper.getForceBackendParameter()).isEqualTo("thebackend");
 
             mapper.addBackend(new BackendConfiguration("backend-a", "localhost", backendPort, "/", -1));
             mapper.addBackend(new BackendConfiguration("backend-b", "localhost", backendPort, "/", -1));
@@ -101,12 +101,12 @@ public class ForceBackendIT {
             {
                 // proxy on director 2
                 String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index.html?thedirector=director-2"), StandardCharsets.UTF_8);
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
             }
             {
                 // proxy on backend 2
                 String s = IOUtils.toString(URI.create("http://localhost:" + port + "/index.html?thebackend=backend-b"), StandardCharsets.UTF_8);
-                assertEquals("it <b>works</b> !!", s);
+                assertThat(s).isEqualTo("it <b>works</b> !!");
             }
 
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/HealthCheckHttpsIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/HealthCheckHttpsIT.java
@@ -22,10 +22,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import java.io.File;
@@ -53,7 +51,7 @@ public class HealthCheckHttpsIT {
     public File tmpDir;
 
     @Test
-    public void httpsProbe_withPrivateCA_succeeds() throws Exception {
+    void httpsProbe_withPrivateCA_succeeds() throws Exception {
         final String backendKeystoreAbsolutePath = TestUtils.deployResource("ca.p12", tmpDir);
 
         final WireMockConfiguration wm = options()
@@ -96,19 +94,19 @@ public class HealthCheckHttpsIT {
 
             final Map<EndpointKey, BackendHealthStatus> snapshot = hman.getBackendsSnapshot();
             final BackendHealthStatus status = snapshot.get(bconf.hostPort());
-            assertThat(status, is(not(nullValue())));
+            assertThat(status).isNotNull();
 
             final BackendHealthCheck lastProbe = status.getLastProbe();
-            assertThat(lastProbe, is(not(nullValue())));
-            assertThat("HTTPS health check with CA must succeed", lastProbe.ok(), is(true));
-            assertThat(lastProbe.httpResponse(), is("200 OK"));
+            assertThat(lastProbe).isNotNull();
+            assertThat(lastProbe.ok()).as("HTTPS health check with CA must succeed").isTrue();
+            assertThat(lastProbe.httpResponse()).isEqualTo("200 OK");
         } finally {
             httpsBackend.stop();
         }
     }
 
     @Test
-    public void httpsProbe_withoutCA_againstPrivateCert_fails() throws Exception {
+    void httpsProbe_withoutCA_againstPrivateCert_fails() throws Exception {
         final String backendKeystoreAbsolutePath = TestUtils.deployResource("ca.p12", tmpDir);
 
         final WireMockConfiguration wm = options()
@@ -150,12 +148,12 @@ public class HealthCheckHttpsIT {
 
             final Map<EndpointKey, BackendHealthStatus> snapshot = hman.getBackendsSnapshot();
             final BackendHealthStatus status = snapshot.get(bconf.hostPort());
-            assertThat(status, is(not(nullValue())));
+            assertThat(status).isNotNull();
 
             final BackendHealthCheck lastProbe = status.getLastProbe();
-            assertThat(lastProbe, is(not(nullValue())));
+            assertThat(lastProbe).isNotNull();
             // With private CA and no truststore configured, probe should fail at connection/trust layer
-            assertThat("HTTPS health check without CA must fail", lastProbe.ok(), is(false));
+            assertThat(lastProbe.ok()).as("HTTPS health check without CA must fail").isFalse();
         } finally {
             httpsBackend.stop();
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/HealthCheckHttpsIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/HealthCheckHttpsIT.java
@@ -97,7 +97,6 @@ public class HealthCheckHttpsIT {
             assertThat(status).isNotNull();
 
             final BackendHealthCheck lastProbe = status.getLastProbe();
-            assertThat(lastProbe).isNotNull();
             assertThat(lastProbe.ok()).as("HTTPS health check with CA must succeed").isTrue();
             assertThat(lastProbe.httpResponse()).isEqualTo("200 OK");
         } finally {

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/HealthCheckIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/HealthCheckIT.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import org.carapaceproxy.core.EndpointKey;
 import org.carapaceproxy.core.RuntimeServerConfiguration;
 import org.carapaceproxy.server.backends.BackendHealthCheck;
+import org.carapaceproxy.server.backends.BackendHealthCheck.Result;
 import org.carapaceproxy.server.backends.BackendHealthManager;
 import org.carapaceproxy.server.backends.BackendHealthStatus;
 import org.carapaceproxy.server.config.BackendConfiguration;
@@ -87,12 +88,11 @@ public class HealthCheckIT {
 
             final BackendHealthCheck lastProbe = _status.getLastProbe();
             assertThat(lastProbe).isNotNull();
-            assertThat(lastProbe.path()).isEqualTo("/status.html");
-            assertThat(lastProbe.endTs()).isGreaterThanOrEqualTo(startTs);
-            assertThat(lastProbe.endTs()).isLessThanOrEqualTo(endTs);
-            assertThat(lastProbe.ok()).isTrue();
-            assertThat(lastProbe.httpResponse()).isEqualTo("200 OK");
-            assertThat(lastProbe.httpBody()).isEqualTo("Ok...");
+            assertThat(lastProbe)
+                    .extracting(BackendHealthCheck::path, BackendHealthCheck::result,
+                            BackendHealthCheck::httpResponse, BackendHealthCheck::httpBody)
+                    .containsExactly("/status.html", Result.SUCCESS, "200 OK", "Ok...");
+            assertThat(lastProbe.endTs()).isBetween(startTs, endTs);
         }
         {
             // Backend returns 500, marking it unavailable.
@@ -125,14 +125,11 @@ public class HealthCheckIT {
 
             final BackendHealthCheck lastProbe = _status.getLastProbe();
             assertThat(lastProbe).isNotNull();
-            assertThat(lastProbe.path()).isEqualTo("/status.html");
-            assertThat(lastProbe.endTs()).isGreaterThanOrEqualTo(startTs);
-            assertThat(lastProbe.endTs()).isLessThanOrEqualTo(endTs);
-            assertThat(lastProbe.ok()).isFalse();
-            System.out.println("HTTP MESSAGE: " + lastProbe.httpResponse());
-            System.out.println("STATUS INFO: " + lastProbe.httpBody());
-            assertThat(lastProbe.httpResponse()).isEqualTo("500 Server Error");
-            assertThat(lastProbe.httpBody()).isEqualTo("ERROR");
+            assertThat(lastProbe)
+                    .extracting(BackendHealthCheck::path, BackendHealthCheck::result,
+                            BackendHealthCheck::httpResponse, BackendHealthCheck::httpBody)
+                    .containsExactly("/status.html", Result.FAILURE_STATUS, "500 Server Error", "ERROR");
+            assertThat(lastProbe.endTs()).isBetween(startTs, endTs);
         }
         {
             // Backend remains in error, keeping it unreachable.
@@ -167,14 +164,11 @@ public class HealthCheckIT {
 
             final BackendHealthCheck lastProbe = _status.getLastProbe();
             assertThat(lastProbe).isNotNull();
-            assertThat(lastProbe.path()).isEqualTo("/status.html");
-            assertThat(lastProbe.endTs()).isGreaterThanOrEqualTo(startTs);
-            assertThat(lastProbe.endTs()).isLessThanOrEqualTo(endTs);
-            assertThat(lastProbe.ok()).isFalse();
-            System.out.println("HTTP MESSAGE: " + lastProbe.httpResponse());
-            System.out.println("STATUS INFO: " + lastProbe.httpBody());
-            assertThat(lastProbe.httpResponse()).isEqualTo("500 Server Error");
-            assertThat(lastProbe.httpBody()).isEqualTo("ERROR");
+            assertThat(lastProbe)
+                    .extracting(BackendHealthCheck::path, BackendHealthCheck::result,
+                            BackendHealthCheck::httpResponse, BackendHealthCheck::httpBody)
+                    .containsExactly("/status.html", Result.FAILURE_STATUS, "500 Server Error", "ERROR");
+            assertThat(lastProbe.endTs()).isBetween(startTs, endTs);
         }
         {
             // Backend recovers and returns 201, marking it available again.
@@ -207,14 +201,11 @@ public class HealthCheckIT {
 
             final BackendHealthCheck lastProbe = _status.getLastProbe();
             assertThat(lastProbe).isNotNull();
-            assertThat(lastProbe.path()).isEqualTo("/status.html");
-            assertThat(lastProbe.endTs()).isGreaterThanOrEqualTo(startTs);
-            assertThat(lastProbe.endTs()).isLessThanOrEqualTo(endTs);
-            assertThat(lastProbe.ok()).isTrue();
-            System.out.println("HTTP MESSAGE: " + lastProbe.httpResponse());
-            System.out.println("STATUS INFO: " + lastProbe.httpBody());
-            assertThat(lastProbe.httpResponse()).isEqualTo("201 Created");
-            assertThat(lastProbe.httpBody()).isEqualTo("Ok...");
+            assertThat(lastProbe)
+                    .extracting(BackendHealthCheck::path, BackendHealthCheck::result,
+                            BackendHealthCheck::httpResponse, BackendHealthCheck::httpBody)
+                    .containsExactly("/status.html", Result.SUCCESS, "201 Created", "Ok...");
+            assertThat(lastProbe.endTs()).isBetween(startTs, endTs);
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/HealthCheckIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/HealthCheckIT.java
@@ -23,14 +23,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -60,7 +53,7 @@ public class HealthCheckIT {
     public File tmpDir;
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         final BackendConfiguration b1conf = new BackendConfiguration("myid", "localhost", wireMockRule.getPort(), "/status.html", -1);
         final EndpointMapper mapper = new TestEndpointMapper(b1conf, false);
         final RuntimeServerConfiguration conf = new RuntimeServerConfiguration();
@@ -79,26 +72,27 @@ public class HealthCheckIT {
 
             final Map<EndpointKey, BackendHealthStatus> status = hman.getBackendsSnapshot();
             System.out.println("status=" + status);
-            assertThat(status.size(), is(1));
+            assertThat(status).hasSize(1);
 
             assertStaticBackendConfig(mapper, b1conf.id());
 
             final BackendHealthStatus _status = status.get(b1conf.hostPort());
-            assertThat(_status, is(not(nullValue())));
-            assertThat(_status.getHostPort(), is(b1conf.hostPort()));
-            assertThat(_status.getStatus(), is(BackendHealthStatus.Status.COLD));
-            assertThat(_status.getUnreachableSince(), is(0L));
-            assertThat(_status.getLastUnreachable(), lessThan(_status.getLastReachable()));
-            assertThat(_status.getLastReachable(), allOf(greaterThanOrEqualTo(startTs), lessThanOrEqualTo(endTs)));
+            assertThat(_status).isNotNull();
+            assertThat(_status.getHostPort()).isEqualTo(b1conf.hostPort());
+            assertThat(_status.getStatus()).isEqualTo(BackendHealthStatus.Status.COLD);
+            assertThat(_status.getUnreachableSince()).isZero();
+            assertThat(_status.getLastUnreachable()).isLessThan(_status.getLastReachable());
+            assertThat(_status.getLastReachable())
+                    .isBetween(startTs, endTs);
 
             final BackendHealthCheck lastProbe = _status.getLastProbe();
-            assertThat(lastProbe, is(not(nullValue())));
-            assertThat(lastProbe.path(), is("/status.html"));
-            assertThat(lastProbe.endTs() >= startTs, is(true));
-            assertThat(lastProbe.endTs() <= endTs, is(true));
-            assertThat(lastProbe.ok(), is(true));
-            assertThat(lastProbe.httpResponse(), is("200 OK"));
-            assertThat(lastProbe.httpBody(), is("Ok..."));
+            assertThat(lastProbe).isNotNull();
+            assertThat(lastProbe.path()).isEqualTo("/status.html");
+            assertThat(lastProbe.endTs()).isGreaterThanOrEqualTo(startTs);
+            assertThat(lastProbe.endTs()).isLessThanOrEqualTo(endTs);
+            assertThat(lastProbe.ok()).isTrue();
+            assertThat(lastProbe.httpResponse()).isEqualTo("200 OK");
+            assertThat(lastProbe.httpBody()).isEqualTo("Ok...");
         }
         {
             // Backend returns 500, marking it unavailable.
@@ -114,28 +108,31 @@ public class HealthCheckIT {
 
             final Map<EndpointKey, BackendHealthStatus> status = hman.getBackendsSnapshot();
             System.out.println("status=" + status);
-            assertThat(status.size(), is(1));
+            assertThat(status).hasSize(1);
 
             assertStaticBackendConfig(mapper, b1conf.id());
 
             final BackendHealthStatus _status = status.get(b1conf.hostPort());
-            assertThat(_status, is(not(nullValue())));
-            assertThat(_status.getHostPort(), is(b1conf.hostPort()));
-            assertThat(_status.getStatus(), is(BackendHealthStatus.Status.DOWN));
-            assertThat(_status.getLastReachable(), allOf(lessThanOrEqualTo(startTs), lessThanOrEqualTo(endTs)));
-            assertThat(_status.getUnreachableSince(), allOf(greaterThanOrEqualTo(startTs), lessThanOrEqualTo(endTs)));
-            assertThat(_status.getLastUnreachable(), is(_status.getUnreachableSince()));
+            assertThat(_status).isNotNull();
+            assertThat(_status.getHostPort()).isEqualTo(b1conf.hostPort());
+            assertThat(_status.getStatus()).isEqualTo(BackendHealthStatus.Status.DOWN);
+            assertThat(_status.getLastReachable())
+                    .isLessThanOrEqualTo(startTs)
+                    .isLessThanOrEqualTo(endTs);
+            assertThat(_status.getUnreachableSince())
+                    .isBetween(startTs, endTs);
+            assertThat(_status.getLastUnreachable()).isEqualTo(_status.getUnreachableSince());
 
             final BackendHealthCheck lastProbe = _status.getLastProbe();
-            assertThat(lastProbe, is(not(nullValue())));
-            assertThat(lastProbe.path(), is("/status.html"));
-            assertThat(lastProbe.endTs() >= startTs, is(true));
-            assertThat(lastProbe.endTs() <= endTs, is(true));
-            assertThat(lastProbe.ok(), is(false));
+            assertThat(lastProbe).isNotNull();
+            assertThat(lastProbe.path()).isEqualTo("/status.html");
+            assertThat(lastProbe.endTs()).isGreaterThanOrEqualTo(startTs);
+            assertThat(lastProbe.endTs()).isLessThanOrEqualTo(endTs);
+            assertThat(lastProbe.ok()).isFalse();
             System.out.println("HTTP MESSAGE: " + lastProbe.httpResponse());
             System.out.println("STATUS INFO: " + lastProbe.httpBody());
-            assertThat(lastProbe.httpResponse(), is("500 Server Error"));
-            assertThat(lastProbe.httpBody(), is("ERROR"));
+            assertThat(lastProbe.httpResponse()).isEqualTo("500 Server Error");
+            assertThat(lastProbe.httpBody()).isEqualTo("ERROR");
         }
         {
             // Backend remains in error, keeping it unreachable.
@@ -151,28 +148,33 @@ public class HealthCheckIT {
 
             final Map<EndpointKey, BackendHealthStatus> status = hman.getBackendsSnapshot();
             System.out.println("status=" + status);
-            assertThat(status.size(), is(1));
+            assertThat(status).hasSize(1);
 
             assertStaticBackendConfig(mapper, b1conf.id());
 
             final BackendHealthStatus _status = status.get(b1conf.hostPort());
-            assertThat(_status, is(not(nullValue())));
-            assertThat(_status.getHostPort(), is(b1conf.hostPort()));
-            assertThat(_status.getStatus(), is(BackendHealthStatus.Status.DOWN));
-            assertThat(_status.getLastReachable(), allOf(lessThanOrEqualTo(startTs), lessThanOrEqualTo(endTs)));
-            assertThat(_status.getUnreachableSince(), allOf(lessThanOrEqualTo(startTs), lessThanOrEqualTo(endTs)));
-            assertThat(_status.getLastUnreachable(), allOf(greaterThanOrEqualTo(startTs), lessThanOrEqualTo(endTs)));
+            assertThat(_status).isNotNull();
+            assertThat(_status.getHostPort()).isEqualTo(b1conf.hostPort());
+            assertThat(_status.getStatus()).isEqualTo(BackendHealthStatus.Status.DOWN);
+            assertThat(_status.getLastReachable())
+                    .isLessThanOrEqualTo(startTs)
+                    .isLessThanOrEqualTo(endTs);
+            assertThat(_status.getUnreachableSince())
+                    .isLessThanOrEqualTo(startTs)
+                    .isLessThanOrEqualTo(endTs);
+            assertThat(_status.getLastUnreachable())
+                    .isBetween(startTs, endTs);
 
             final BackendHealthCheck lastProbe = _status.getLastProbe();
-            assertThat(lastProbe, is(not(nullValue())));
-            assertThat(lastProbe.path(), is("/status.html"));
-            assertThat(lastProbe.endTs() >= startTs, is(true));
-            assertThat(lastProbe.endTs() <= endTs, is(true));
-            assertThat(lastProbe.ok(), is(false));
+            assertThat(lastProbe).isNotNull();
+            assertThat(lastProbe.path()).isEqualTo("/status.html");
+            assertThat(lastProbe.endTs()).isGreaterThanOrEqualTo(startTs);
+            assertThat(lastProbe.endTs()).isLessThanOrEqualTo(endTs);
+            assertThat(lastProbe.ok()).isFalse();
             System.out.println("HTTP MESSAGE: " + lastProbe.httpResponse());
             System.out.println("STATUS INFO: " + lastProbe.httpBody());
-            assertThat(lastProbe.httpResponse(), is("500 Server Error"));
-            assertThat(lastProbe.httpBody(), is("ERROR"));
+            assertThat(lastProbe.httpResponse()).isEqualTo("500 Server Error");
+            assertThat(lastProbe.httpBody()).isEqualTo("ERROR");
         }
         {
             // Backend recovers and returns 201, marking it available again.
@@ -188,36 +190,39 @@ public class HealthCheckIT {
 
             final Map<EndpointKey, BackendHealthStatus> status = hman.getBackendsSnapshot();
             System.out.println("status=" + status);
-            assertThat(status.size(), is(1));
+            assertThat(status).hasSize(1);
 
             assertStaticBackendConfig(mapper, b1conf.id());
 
             final BackendHealthStatus _status = status.get(b1conf.hostPort());
-            assertThat(_status, is(not(nullValue())));
-            assertThat(_status.getHostPort(), is(b1conf.hostPort()));
-            assertThat(_status.getStatus(), is(BackendHealthStatus.Status.COLD));
-            assertThat(_status.getUnreachableSince(), is(0L));
-            assertThat(_status.getLastUnreachable(), allOf(lessThanOrEqualTo(startTs), lessThanOrEqualTo(endTs)));
-            assertThat(_status.getLastReachable(), allOf(greaterThanOrEqualTo(startTs), lessThanOrEqualTo(endTs)));
+            assertThat(_status).isNotNull();
+            assertThat(_status.getHostPort()).isEqualTo(b1conf.hostPort());
+            assertThat(_status.getStatus()).isEqualTo(BackendHealthStatus.Status.COLD);
+            assertThat(_status.getUnreachableSince()).isZero();
+            assertThat(_status.getLastUnreachable())
+                    .isLessThanOrEqualTo(startTs)
+                    .isLessThanOrEqualTo(endTs);
+            assertThat(_status.getLastReachable())
+                    .isBetween(startTs, endTs);
 
             final BackendHealthCheck lastProbe = _status.getLastProbe();
-            assertThat(lastProbe, is(not(nullValue())));
-            assertThat(lastProbe.path(), is("/status.html"));
-            assertThat(lastProbe.endTs() >= startTs, is(true));
-            assertThat(lastProbe.endTs() <= endTs, is(true));
-            assertThat(lastProbe.ok(), is(true));
+            assertThat(lastProbe).isNotNull();
+            assertThat(lastProbe.path()).isEqualTo("/status.html");
+            assertThat(lastProbe.endTs()).isGreaterThanOrEqualTo(startTs);
+            assertThat(lastProbe.endTs()).isLessThanOrEqualTo(endTs);
+            assertThat(lastProbe.ok()).isTrue();
             System.out.println("HTTP MESSAGE: " + lastProbe.httpResponse());
             System.out.println("STATUS INFO: " + lastProbe.httpBody());
-            assertThat(lastProbe.httpResponse(), is("201 Created"));
-            assertThat(lastProbe.httpBody(), is("Ok..."));
+            assertThat(lastProbe.httpResponse()).isEqualTo("201 Created");
+            assertThat(lastProbe.httpBody()).isEqualTo("Ok...");
         }
     }
 
     private void assertStaticBackendConfig(final EndpointMapper mapper, final String backendId) {
         final BackendConfiguration bconf = mapper.getBackends().get(backendId);
-        assertThat(bconf.id(), is("myid"));
-        assertThat(bconf.host(), is("localhost"));
-        assertThat(bconf.port(), is(wireMockRule.getPort()));
-        assertThat(bconf.probePath(), is("/status.html"));
+        assertThat(bconf.id()).isEqualTo("myid");
+        assertThat(bconf.host()).isEqualTo("localhost");
+        assertThat(bconf.port()).isEqualTo(wireMockRule.getPort());
+        assertThat(bconf.probePath()).isEqualTo("/status.html");
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/HealthCheckIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/HealthCheckIT.java
@@ -85,12 +85,7 @@ public class HealthCheckIT {
             assertThat(_status.getLastReachable())
                     .isBetween(startTs, endTs);
 
-            final BackendHealthCheck lastProbe = _status.getLastProbe();
-            assertThat(lastProbe)
-                    .extracting(BackendHealthCheck::path, BackendHealthCheck::result,
-                            BackendHealthCheck::httpResponse, BackendHealthCheck::httpBody)
-                    .containsExactly("/status.html", Result.SUCCESS, "200 OK", "Ok...");
-            assertThat(lastProbe.endTs()).isBetween(startTs, endTs);
+            assertLastProbe(_status, Result.SUCCESS, "200 OK", "Ok...", startTs, endTs);
         }
         {
             // Backend returns 500, marking it unavailable.
@@ -119,12 +114,7 @@ public class HealthCheckIT {
                     .isBetween(startTs, endTs);
             assertThat(_status.getLastUnreachable()).isEqualTo(_status.getUnreachableSince());
 
-            final BackendHealthCheck lastProbe = _status.getLastProbe();
-            assertThat(lastProbe)
-                    .extracting(BackendHealthCheck::path, BackendHealthCheck::result,
-                            BackendHealthCheck::httpResponse, BackendHealthCheck::httpBody)
-                    .containsExactly("/status.html", Result.FAILURE_STATUS, "500 Server Error", "ERROR");
-            assertThat(lastProbe.endTs()).isBetween(startTs, endTs);
+            assertLastProbe(_status, Result.FAILURE_STATUS, "500 Server Error", "ERROR", startTs, endTs);
         }
         {
             // Backend remains in error, keeping it unreachable.
@@ -154,12 +144,7 @@ public class HealthCheckIT {
             assertThat(_status.getLastUnreachable())
                     .isBetween(startTs, endTs);
 
-            final BackendHealthCheck lastProbe = _status.getLastProbe();
-            assertThat(lastProbe)
-                    .extracting(BackendHealthCheck::path, BackendHealthCheck::result,
-                            BackendHealthCheck::httpResponse, BackendHealthCheck::httpBody)
-                    .containsExactly("/status.html", Result.FAILURE_STATUS, "500 Server Error", "ERROR");
-            assertThat(lastProbe.endTs()).isBetween(startTs, endTs);
+            assertLastProbe(_status, Result.FAILURE_STATUS, "500 Server Error", "ERROR", startTs, endTs);
         }
         {
             // Backend recovers and returns 201, marking it available again.
@@ -188,12 +173,7 @@ public class HealthCheckIT {
             assertThat(_status.getLastReachable())
                     .isBetween(startTs, endTs);
 
-            final BackendHealthCheck lastProbe = _status.getLastProbe();
-            assertThat(lastProbe)
-                    .extracting(BackendHealthCheck::path, BackendHealthCheck::result,
-                            BackendHealthCheck::httpResponse, BackendHealthCheck::httpBody)
-                    .containsExactly("/status.html", Result.SUCCESS, "201 Created", "Ok...");
-            assertThat(lastProbe.endTs()).isBetween(startTs, endTs);
+            assertLastProbe(_status, Result.SUCCESS, "201 Created", "Ok...", startTs, endTs);
         }
     }
 
@@ -204,4 +184,17 @@ public class HealthCheckIT {
         assertThat(bconf.port()).isEqualTo(wireMockRule.getPort());
         assertThat(bconf.probePath()).isEqualTo("/status.html");
     }
+
+    /** Every probe in this test hits /status.html; only the outcome and the response differ. */
+    private static void assertLastProbe(final BackendHealthStatus status, final Result result,
+                                        final String httpResponse, final String httpBody,
+                                        final long startTs, final long endTs) {
+        final BackendHealthCheck lastProbe = status.getLastProbe();
+        assertThat(lastProbe)
+                .extracting(BackendHealthCheck::path, BackendHealthCheck::result,
+                        BackendHealthCheck::httpResponse, BackendHealthCheck::httpBody)
+                .containsExactly("/status.html", result, httpResponse, httpBody);
+        assertThat(lastProbe.endTs()).isBetween(startTs, endTs);
+    }
+
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/HealthCheckIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/HealthCheckIT.java
@@ -78,7 +78,6 @@ public class HealthCheckIT {
             assertStaticBackendConfig(mapper, b1conf.id());
 
             final BackendHealthStatus _status = status.get(b1conf.hostPort());
-            assertThat(_status).isNotNull();
             assertThat(_status.getHostPort()).isEqualTo(b1conf.hostPort());
             assertThat(_status.getStatus()).isEqualTo(BackendHealthStatus.Status.COLD);
             assertThat(_status.getUnreachableSince()).isZero();
@@ -87,7 +86,6 @@ public class HealthCheckIT {
                     .isBetween(startTs, endTs);
 
             final BackendHealthCheck lastProbe = _status.getLastProbe();
-            assertThat(lastProbe).isNotNull();
             assertThat(lastProbe)
                     .extracting(BackendHealthCheck::path, BackendHealthCheck::result,
                             BackendHealthCheck::httpResponse, BackendHealthCheck::httpBody)
@@ -113,18 +111,15 @@ public class HealthCheckIT {
             assertStaticBackendConfig(mapper, b1conf.id());
 
             final BackendHealthStatus _status = status.get(b1conf.hostPort());
-            assertThat(_status).isNotNull();
             assertThat(_status.getHostPort()).isEqualTo(b1conf.hostPort());
             assertThat(_status.getStatus()).isEqualTo(BackendHealthStatus.Status.DOWN);
             assertThat(_status.getLastReachable())
-                    .isLessThanOrEqualTo(startTs)
-                    .isLessThanOrEqualTo(endTs);
+                    .isLessThanOrEqualTo(startTs);
             assertThat(_status.getUnreachableSince())
                     .isBetween(startTs, endTs);
             assertThat(_status.getLastUnreachable()).isEqualTo(_status.getUnreachableSince());
 
             final BackendHealthCheck lastProbe = _status.getLastProbe();
-            assertThat(lastProbe).isNotNull();
             assertThat(lastProbe)
                     .extracting(BackendHealthCheck::path, BackendHealthCheck::result,
                             BackendHealthCheck::httpResponse, BackendHealthCheck::httpBody)
@@ -150,20 +145,16 @@ public class HealthCheckIT {
             assertStaticBackendConfig(mapper, b1conf.id());
 
             final BackendHealthStatus _status = status.get(b1conf.hostPort());
-            assertThat(_status).isNotNull();
             assertThat(_status.getHostPort()).isEqualTo(b1conf.hostPort());
             assertThat(_status.getStatus()).isEqualTo(BackendHealthStatus.Status.DOWN);
             assertThat(_status.getLastReachable())
-                    .isLessThanOrEqualTo(startTs)
-                    .isLessThanOrEqualTo(endTs);
+                    .isLessThanOrEqualTo(startTs);
             assertThat(_status.getUnreachableSince())
-                    .isLessThanOrEqualTo(startTs)
-                    .isLessThanOrEqualTo(endTs);
+                    .isLessThanOrEqualTo(startTs);
             assertThat(_status.getLastUnreachable())
                     .isBetween(startTs, endTs);
 
             final BackendHealthCheck lastProbe = _status.getLastProbe();
-            assertThat(lastProbe).isNotNull();
             assertThat(lastProbe)
                     .extracting(BackendHealthCheck::path, BackendHealthCheck::result,
                             BackendHealthCheck::httpResponse, BackendHealthCheck::httpBody)
@@ -189,18 +180,15 @@ public class HealthCheckIT {
             assertStaticBackendConfig(mapper, b1conf.id());
 
             final BackendHealthStatus _status = status.get(b1conf.hostPort());
-            assertThat(_status).isNotNull();
             assertThat(_status.getHostPort()).isEqualTo(b1conf.hostPort());
             assertThat(_status.getStatus()).isEqualTo(BackendHealthStatus.Status.COLD);
             assertThat(_status.getUnreachableSince()).isZero();
             assertThat(_status.getLastUnreachable())
-                    .isLessThanOrEqualTo(startTs)
-                    .isLessThanOrEqualTo(endTs);
+                    .isLessThanOrEqualTo(startTs);
             assertThat(_status.getLastReachable())
                     .isBetween(startTs, endTs);
 
             final BackendHealthCheck lastProbe = _status.getLastProbe();
-            assertThat(lastProbe).isNotNull();
             assertThat(lastProbe)
                     .extracting(BackendHealthCheck::path, BackendHealthCheck::result,
                             BackendHealthCheck::httpResponse, BackendHealthCheck::httpBody)

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/requestmatcher/RequestMatcherTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/requestmatcher/RequestMatcherTest.java
@@ -43,7 +43,7 @@ import reactor.netty.http.server.HttpServerRequest;
 class RequestMatcherTest {
 
     @Test
-    void test() throws Exception {
+    void matchesUriMethodSchemeAndProtocol() throws Exception {
         HttpServerRequest serverRequest = mock(HttpServerRequest.class);
         when(serverRequest.uri()).thenReturn("/test.html");
         when(serverRequest.fullPath()).thenReturn("/test.html");
@@ -55,105 +55,105 @@ class RequestMatcherTest {
 
         {
             RequestMatcher matcher = new RequestMatchParser("all").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
             assertThat(matcher.getDescription()).isEqualTo("all requests");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~ \".*test.*\"").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
             assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test.*\"");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~ \".*testio.*\"").parse();
-            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isFalse();
             assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*testio.*\"");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("secure").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
             assertThat(matcher.getDescription()).isEqualTo("secure request");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("not secure").parse();
-            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isFalse();
             assertThat(matcher.getDescription()).isEqualTo("not secure request");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~ \".*test\\.html\" and secure").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
             assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test\\.html\" and secure request");
         }
         {
             // spaces ignored
             RequestMatcher matcher = new RequestMatchParser("request.uri   ~   \".*test.*\" and not secure").parse();
-            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isFalse();
             assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test.*\" and not secure request");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" or not secure").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
             assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test.*\" or not secure request");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("not secure or request.uri ~\".*test.*\"").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
             assertThat(matcher.getDescription()).isEqualTo("not secure request or request.uri ~ \".*test.*\"");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" and (not secure or secure)").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
             assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test.*\" and (not secure request or secure request)");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" and (not secure or not secure)").parse();
-            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isFalse();
             assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test.*\" and (not secure request or not secure request)");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("not (not secure or not secure) and request.uri ~\".*test.*\"").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
             assertThat(matcher.getDescription()).isEqualTo("not (not secure request or not secure request) and request.uri ~ \".*test.*\"");
         }
         {
             RequestMatcher matcher = new RequestMatchParser(
                     "request.uri ~\".*test.*\" and (not (not secure or not secure) or (not secure or not secure))"
             ).parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
             assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test.*\" and (not (not secure request or not secure request) or "
                     + "(not secure request or not secure request))");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" and (not (not secure or not secure) "
                     + "and (not secure or not secure)) and request.uri ~\".*test.html\"").parse();
-            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isFalse();
             assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test.*\" and (not (not secure request or not secure request) "
                     + "and (not secure request or not secure request)) and request.uri ~ \".*test.html\"");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" and (not (not secure or not secure) "
                     + "and (not secure or not secure)) or not request.uri ~\".*\\.css\"").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
             assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test.*\" and (not (not secure request or not secure request) "
                     + "and (not secure request or not secure request)) or not request.uri ~ \".*\\.css\"");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*\\.css*\" or request.uri ~\".*\\.html\"").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
             assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*\\.css*\" or request.uri ~ \".*\\.html\"");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*\\.css*\" and request.uri ~\".*\\.html\"").parse();
-            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isFalse();
             assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*\\.css*\" and request.uri ~ \".*\\.html\"");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("not (not request.uri ~\".*\\.html\")").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
             assertThat(matcher.getDescription()).isEqualTo("not (not request.uri ~ \".*\\.html\")");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("not request.uri ~\".*\\.css*\" and not (not request.uri ~\".*\\.html\")").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
             assertThat(matcher.getDescription()).isEqualTo("not request.uri ~ \".*\\.css*\" and not (not request.uri ~ \".*\\.html\")");
         }
 
@@ -196,23 +196,23 @@ class RequestMatcherTest {
         // Fist one condition considered
         {
             RequestMatcher matcher = new RequestMatchParser("not secure all").parse();
-            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isFalse();
             assertThat(matcher.getDescription()).isEqualTo("not secure request");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("not secure request.uri ~\".*test.*\"").parse();
-            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isFalse();
             assertThat(matcher.getDescription()).isEqualTo("not secure request");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" all").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
             assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test.*\"");
         }
     }
 
     @Test
-    void test2() throws Exception {
+    void matchesHeadersCookiesAndAddresses() throws Exception {
         DefaultHttpHeaders headers = new DefaultHttpHeaders();
         headers.add(HttpHeaders.COOKIE, "test-cookie");
         headers.add(HttpHeaders.CONTENT_DISPOSITION, "inline");
@@ -237,67 +237,67 @@ class RequestMatcherTest {
                     + " and (not request.headers." + HttpHeaders.USER_AGENT + " = \"chrome\"" // user agent not set
                     + " and not secure)"
             ).parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
 
             matcher = new RequestMatchParser(
                     "request.headers." + HttpHeaders.USER_AGENT + " = \"\"" // user agent not set
             ).parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
 
             matcher = new RequestMatchParser(
                     "request.headers." + HttpHeaders.USER_AGENT + " = \"\""
                     + // user agent not set
                     " and request.headers." + HttpHeaders.ACCEPT + " = \"\"" // not set
             ).parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
         }
         // Test content-type
         {
             RequestMatcher matcher = new RequestMatchParser("request.content-type = \"text/html\"").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
             matcher = new RequestMatchParser("request.content-type = \"application/octet-stream\"").parse();
-            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isFalse();
             matcher = new RequestMatchParser(
                     "not request.content-type ~ \".*test.*\""
                     + " or request.content-type = \"application/octet-stream\""
                     + " or request.content-type ~ \".*html\""
             ).parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
         }
         // Test method
         {
             RequestMatcher matcher = new RequestMatchParser("request.method = \"GET\"").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
             matcher = new RequestMatchParser("request.method = \"POST\"").parse();
-            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isFalse();
             matcher = new RequestMatchParser("not request.method = \"POST\" and request.method = \"GET\"").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
         }
         // Test listener.hostport
         {
             RequestMatcher matcher = new RequestMatchParser("listener.hostport = \"localhost:8080\"").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
 
             matcher = new RequestMatchParser("listener.hostport ~ \"localhost:.*\"").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
 
             matcher = new RequestMatchParser("listener.hostport ~ \".*:8080\"").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
 
             matcher = new RequestMatchParser("listener.hostport ~ \"loc.*:80.*\"").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
 
             matcher = new RequestMatchParser("listener.hostport ~ \"some.*:8050\"").parse();
-            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isFalse();
         }
         // Test listener.ipaddress
         {
             RequestMatcher matcher = new RequestMatchParser("listener.ipaddress = \"127.0.0.2\"").parse();
-            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
         }
         {
             RequestMatcher matcher = new RequestMatchParser("listener.ipaddress = \"127.0.1.2\"").parse();
-            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.matches(request)).as(matcher.getDescription()).isFalse();
         }
     }
 
@@ -317,6 +317,6 @@ class RequestMatcherTest {
         ProxyRequest request = new ProxyRequest(serverRequest, null, null);
 
         RequestMatcher matcher = new RequestMatchParser("request.uri ~ \"/admin/.*\"").parse();
-        assertThat(matcher.matches(request)).isTrue();
+        assertThat(matcher.matches(request)).as(matcher.getDescription()).isTrue();
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/mapper/requestmatcher/RequestMatcherTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/mapper/requestmatcher/RequestMatcherTest.java
@@ -19,9 +19,8 @@
  */
 package org.carapaceproxy.server.mapper.requestmatcher;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import herddb.utils.TestUtils;
@@ -30,7 +29,6 @@ import io.netty.handler.codec.http.HttpMethod;
 import java.net.InetSocketAddress;
 import javax.ws.rs.core.HttpHeaders;
 import org.carapaceproxy.core.ProxyRequest;
-import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.core.EndpointKey;
 import org.carapaceproxy.server.mapper.requestmatcher.parser.ParseException;
 import org.carapaceproxy.server.mapper.requestmatcher.parser.RequestMatchParser;
@@ -42,10 +40,10 @@ import reactor.netty.http.server.HttpServerRequest;
  *
  * @author paolo.venturi
  */
-public class RequestMatcherTest {
+class RequestMatcherTest {
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         HttpServerRequest serverRequest = mock(HttpServerRequest.class);
         when(serverRequest.uri()).thenReturn("/test.html");
         when(serverRequest.fullPath()).thenReturn("/test.html");
@@ -57,168 +55,164 @@ public class RequestMatcherTest {
 
         {
             RequestMatcher matcher = new RequestMatchParser("all").parse();
-            assertTrue(matcher.matches(request));
-            assertEquals("all requests", matcher.getDescription());
+            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.getDescription()).isEqualTo("all requests");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~ \".*test.*\"").parse();
-            assertTrue(matcher.matches(request));
-            assertEquals("request.uri ~ \".*test.*\"", matcher.getDescription());
+            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test.*\"");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~ \".*testio.*\"").parse();
-            assertFalse(matcher.matches(request));
-            assertEquals("request.uri ~ \".*testio.*\"", matcher.getDescription());
+            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*testio.*\"");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("secure").parse();
-            assertTrue(matcher.matches(request));
-            assertEquals("secure request", matcher.getDescription());
+            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.getDescription()).isEqualTo("secure request");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("not secure").parse();
-            assertFalse(matcher.matches(request));
-            assertEquals("not secure request", matcher.getDescription());
+            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.getDescription()).isEqualTo("not secure request");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~ \".*test\\.html\" and secure").parse();
-            assertTrue(matcher.matches(request));
-            assertEquals("request.uri ~ \".*test\\.html\" and secure request", matcher.getDescription());
+            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test\\.html\" and secure request");
         }
         {
             // spaces ignored
             RequestMatcher matcher = new RequestMatchParser("request.uri   ~   \".*test.*\" and not secure").parse();
-            assertFalse(matcher.matches(request));
-            assertEquals("request.uri ~ \".*test.*\" and not secure request", matcher.getDescription());
+            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test.*\" and not secure request");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" or not secure").parse();
-            assertTrue(matcher.matches(request));
-            assertEquals("request.uri ~ \".*test.*\" or not secure request", matcher.getDescription());
+            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test.*\" or not secure request");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("not secure or request.uri ~\".*test.*\"").parse();
-            assertTrue(matcher.matches(request));
-            assertEquals("not secure request or request.uri ~ \".*test.*\"", matcher.getDescription());
+            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.getDescription()).isEqualTo("not secure request or request.uri ~ \".*test.*\"");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" and (not secure or secure)").parse();
-            assertTrue(matcher.matches(request));
-            assertEquals("request.uri ~ \".*test.*\" and (not secure request or secure request)", matcher.getDescription());
+            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test.*\" and (not secure request or secure request)");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" and (not secure or not secure)").parse();
-            assertFalse(matcher.matches(request));
-            assertEquals("request.uri ~ \".*test.*\" and (not secure request or not secure request)", matcher.getDescription());
+            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test.*\" and (not secure request or not secure request)");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("not (not secure or not secure) and request.uri ~\".*test.*\"").parse();
-            assertTrue(matcher.matches(request));
-            assertEquals("not (not secure request or not secure request) and request.uri ~ \".*test.*\"", matcher.getDescription());
+            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.getDescription()).isEqualTo("not (not secure request or not secure request) and request.uri ~ \".*test.*\"");
         }
         {
             RequestMatcher matcher = new RequestMatchParser(
                     "request.uri ~\".*test.*\" and (not (not secure or not secure) or (not secure or not secure))"
             ).parse();
-            assertTrue(matcher.matches(request));
-            assertEquals(
-                    "request.uri ~ \".*test.*\" and (not (not secure request or not secure request) or "
-                    + "(not secure request or not secure request))", matcher.getDescription()
-            );
+            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test.*\" and (not (not secure request or not secure request) or "
+                    + "(not secure request or not secure request))");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" and (not (not secure or not secure) "
                     + "and (not secure or not secure)) and request.uri ~\".*test.html\"").parse();
-            assertFalse(matcher.matches(request));
-            assertEquals("request.uri ~ \".*test.*\" and (not (not secure request or not secure request) "
-                    + "and (not secure request or not secure request)) and request.uri ~ \".*test.html\"", matcher.getDescription()
-            );
+            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test.*\" and (not (not secure request or not secure request) "
+                    + "and (not secure request or not secure request)) and request.uri ~ \".*test.html\"");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" and (not (not secure or not secure) "
                     + "and (not secure or not secure)) or not request.uri ~\".*\\.css\"").parse();
-            assertTrue(matcher.matches(request));
-            assertEquals("request.uri ~ \".*test.*\" and (not (not secure request or not secure request) "
-                    + "and (not secure request or not secure request)) or not request.uri ~ \".*\\.css\"", matcher.getDescription()
-            );
+            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test.*\" and (not (not secure request or not secure request) "
+                    + "and (not secure request or not secure request)) or not request.uri ~ \".*\\.css\"");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*\\.css*\" or request.uri ~\".*\\.html\"").parse();
-            assertTrue(matcher.matches(request));
-            assertEquals("request.uri ~ \".*\\.css*\" or request.uri ~ \".*\\.html\"", matcher.getDescription());
+            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*\\.css*\" or request.uri ~ \".*\\.html\"");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*\\.css*\" and request.uri ~\".*\\.html\"").parse();
-            assertFalse(matcher.matches(request));
-            assertEquals("request.uri ~ \".*\\.css*\" and request.uri ~ \".*\\.html\"", matcher.getDescription());
+            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*\\.css*\" and request.uri ~ \".*\\.html\"");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("not (not request.uri ~\".*\\.html\")").parse();
-            assertTrue(matcher.matches(request));
-            assertEquals("not (not request.uri ~ \".*\\.html\")", matcher.getDescription());
+            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.getDescription()).isEqualTo("not (not request.uri ~ \".*\\.html\")");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("not request.uri ~\".*\\.css*\" and not (not request.uri ~\".*\\.html\")").parse();
-            assertTrue(matcher.matches(request));
-            assertEquals("not request.uri ~ \".*\\.css*\" and not (not request.uri ~ \".*\\.html\")", matcher.getDescription());
+            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.getDescription()).isEqualTo("not request.uri ~ \".*\\.css*\" and not (not request.uri ~ \".*\\.html\")");
         }
 
         // property name does not exist -> error
         {
             RequestMatcher matcher = new RequestMatchParser("request.notex ~\".*test.*\"").parse();
-            assertEquals("request.notex ~ \".*test.*\"", matcher.getDescription());
-            TestUtils.assertThrows(IllegalArgumentException.class, () -> matcher.matches(request));
+            assertThat(matcher.getDescription()).isEqualTo("request.notex ~ \".*test.*\"");
+            assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> matcher.matches(request));
         }
         // Broken one: invalid regexp syntax
-        TestUtils.assertThrows(TokenMgrError.class, () -> {
+        assertThatExceptionOfType(TokenMgrError.class).isThrownBy(() -> {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~'.*test.*'").parse();
             matcher.matches(request);
         });
-        TestUtils.assertThrows(TokenMgrError.class, () -> {
+        assertThatExceptionOfType(TokenMgrError.class).isThrownBy(() -> {
             RequestMatcher matcher = new RequestMatchParser("request.uri '.*test.*'").parse();
             matcher.matches(request);
         });
 
         // Broken ones: all not alone
-        TestUtils.assertThrows(ParseException.class, () -> {
+        assertThatExceptionOfType(ParseException.class).isThrownBy(() -> {
             RequestMatcher matcher = new RequestMatchParser("all request.uri ~\".*test.*\"").parse();
         });
-        TestUtils.assertThrows(ParseException.class, () -> {
+        assertThatExceptionOfType(ParseException.class).isThrownBy(() -> {
             RequestMatcher matcher = new RequestMatchParser("all request.uri").parse();
         });
-        TestUtils.assertThrows(ParseException.class, () -> {
+        assertThatExceptionOfType(ParseException.class).isThrownBy(() -> {
             RequestMatcher matcher = new RequestMatchParser("all secure").parse();
         });
-        TestUtils.assertThrows(ParseException.class, () -> {
+        assertThatExceptionOfType(ParseException.class).isThrownBy(() -> {
             RequestMatcher matcher = new RequestMatchParser("all not secure").parse();
         });
-        TestUtils.assertThrows(ParseException.class, () -> {
+        assertThatExceptionOfType(ParseException.class).isThrownBy(() -> {
             RequestMatcher matcher = new RequestMatchParser("not secure or all").parse();
         });
-        TestUtils.assertThrows(ParseException.class, () -> {
+        assertThatExceptionOfType(ParseException.class).isThrownBy(() -> {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" and all").parse();
         });
 
         // Fist one condition considered
         {
             RequestMatcher matcher = new RequestMatchParser("not secure all").parse();
-            assertFalse(matcher.matches(request));
-            assertEquals("not secure request", matcher.getDescription());
+            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.getDescription()).isEqualTo("not secure request");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("not secure request.uri ~\".*test.*\"").parse();
-            assertFalse(matcher.matches(request));
-            assertEquals("not secure request", matcher.getDescription());
+            assertThat(matcher.matches(request)).isFalse();
+            assertThat(matcher.getDescription()).isEqualTo("not secure request");
         }
         {
             RequestMatcher matcher = new RequestMatchParser("request.uri ~\".*test.*\" all").parse();
-            assertTrue(matcher.matches(request));
-            assertEquals("request.uri ~ \".*test.*\"", matcher.getDescription());
+            assertThat(matcher.matches(request)).isTrue();
+            assertThat(matcher.getDescription()).isEqualTo("request.uri ~ \".*test.*\"");
         }
     }
 
     @Test
-    public void test2() throws ParseException, ConfigurationNotValidException {
+    void test2() throws Exception {
         DefaultHttpHeaders headers = new DefaultHttpHeaders();
         headers.add(HttpHeaders.COOKIE, "test-cookie");
         headers.add(HttpHeaders.CONTENT_DISPOSITION, "inline");
@@ -243,72 +237,72 @@ public class RequestMatcherTest {
                     + " and (not request.headers." + HttpHeaders.USER_AGENT + " = \"chrome\"" // user agent not set
                     + " and not secure)"
             ).parse();
-            assertTrue(matcher.matches(request));
+            assertThat(matcher.matches(request)).isTrue();
 
             matcher = new RequestMatchParser(
                     "request.headers." + HttpHeaders.USER_AGENT + " = \"\"" // user agent not set
             ).parse();
-            assertTrue(matcher.matches(request));
+            assertThat(matcher.matches(request)).isTrue();
 
             matcher = new RequestMatchParser(
                     "request.headers." + HttpHeaders.USER_AGENT + " = \"\""
                     + // user agent not set
                     " and request.headers." + HttpHeaders.ACCEPT + " = \"\"" // not set
             ).parse();
-            assertTrue(matcher.matches(request));
+            assertThat(matcher.matches(request)).isTrue();
         }
         // Test content-type
         {
             RequestMatcher matcher = new RequestMatchParser("request.content-type = \"text/html\"").parse();
-            assertTrue(matcher.matches(request));
+            assertThat(matcher.matches(request)).isTrue();
             matcher = new RequestMatchParser("request.content-type = \"application/octet-stream\"").parse();
-            assertFalse(matcher.matches(request));
+            assertThat(matcher.matches(request)).isFalse();
             matcher = new RequestMatchParser(
                     "not request.content-type ~ \".*test.*\""
                     + " or request.content-type = \"application/octet-stream\""
                     + " or request.content-type ~ \".*html\""
             ).parse();
-            assertTrue(matcher.matches(request));
+            assertThat(matcher.matches(request)).isTrue();
         }
         // Test method
         {
             RequestMatcher matcher = new RequestMatchParser("request.method = \"GET\"").parse();
-            assertTrue(matcher.matches(request));
+            assertThat(matcher.matches(request)).isTrue();
             matcher = new RequestMatchParser("request.method = \"POST\"").parse();
-            assertFalse(matcher.matches(request));
+            assertThat(matcher.matches(request)).isFalse();
             matcher = new RequestMatchParser("not request.method = \"POST\" and request.method = \"GET\"").parse();
-            assertTrue(matcher.matches(request));
+            assertThat(matcher.matches(request)).isTrue();
         }
         // Test listener.hostport
         {
             RequestMatcher matcher = new RequestMatchParser("listener.hostport = \"localhost:8080\"").parse();
-            assertTrue(matcher.matches(request));
+            assertThat(matcher.matches(request)).isTrue();
 
             matcher = new RequestMatchParser("listener.hostport ~ \"localhost:.*\"").parse();
-            assertTrue(matcher.matches(request));
+            assertThat(matcher.matches(request)).isTrue();
 
             matcher = new RequestMatchParser("listener.hostport ~ \".*:8080\"").parse();
-            assertTrue(matcher.matches(request));
+            assertThat(matcher.matches(request)).isTrue();
 
             matcher = new RequestMatchParser("listener.hostport ~ \"loc.*:80.*\"").parse();
-            assertTrue(matcher.matches(request));
+            assertThat(matcher.matches(request)).isTrue();
 
             matcher = new RequestMatchParser("listener.hostport ~ \"some.*:8050\"").parse();
-            assertFalse(matcher.matches(request));
+            assertThat(matcher.matches(request)).isFalse();
         }
         // Test listener.ipaddress
         {
             RequestMatcher matcher = new RequestMatchParser("listener.ipaddress = \"127.0.0.2\"").parse();
-            assertTrue(matcher.matches(request));
+            assertThat(matcher.matches(request)).isTrue();
         }
         {
             RequestMatcher matcher = new RequestMatchParser("listener.ipaddress = \"127.0.1.2\"").parse();
-            assertFalse(matcher.matches(request));
+            assertThat(matcher.matches(request)).isFalse();
         }
     }
 
     @Test
-    public void testAbsoluteFormRequestTargetMatchesPathRule() throws Exception {
+    void absoluteFormRequestTargetMatchesPathRule() throws Exception {
         // An absolute-form request target (scheme://authority/path) is valid HTTP/1.1 and
         // is forwarded to the backend as just "/path" (see ProxyRequest.getUri()). A
         // path-anchored route/ACL must therefore still match on "/path"; otherwise it can
@@ -323,6 +317,6 @@ public class RequestMatcherTest {
         ProxyRequest request = new ProxyRequest(serverRequest, null, null);
 
         RequestMatcher matcher = new RequestMatchParser("request.uri ~ \"/admin/.*\"").parse();
-        assertTrue(matcher.matches(request));
+        assertThat(matcher.matches(request)).isTrue();
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/users/FileUserRealmIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/users/FileUserRealmIT.java
@@ -19,11 +19,8 @@
  */
 package org.carapaceproxy.users;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.carapaceproxy.core.HttpProxyServer.buildForTests;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -64,7 +61,7 @@ public class FileUserRealmIT {
     }
 
     @Test
-    public void testFileUserRealm() throws Exception {
+    void fileUserRealm() throws Exception {
         try (HttpProxyServer server = buildForTests("localhost", 0, new TestEndpointMapper("localhost", 0), tmpDir)) {
             Properties prop = new Properties();
             prop.setProperty("http.admin.enabled", "true");
@@ -90,21 +87,21 @@ public class FileUserRealmIT {
             UserRealm userRealm = server.getRealm();
             Collection<String> resultUsers = userRealm.listUsers();
 
-            assertThat(resultUsers.size(), is(users.size()));
+            assertThat(resultUsers).hasSize(users.size());
             for (String username : users.keySet()) {
                 String login = userRealm.login(username, users.get(username));
 
-                assertNotNull(login); // login success
-                assertThat(username, is(login));
+                assertThat(login).isNotNull(); // login success
+                assertThat(username).isEqualTo(login);
             }
 
             String wrongLogin = userRealm.login("wrong", "login");
-            assertNull(wrongLogin);
+            assertThat(wrongLogin).isNull();
         }
     }
 
     @Test
-    public void testFileUserRealmRefresh() throws Exception {
+    void fileUserRealmRefresh() throws Exception {
         try (HttpProxyServer server = buildForTests("localhost", 0, new TestEndpointMapper("localhost", 0), tmpDir)) {
             Map<String, String> users = new HashMap<>();
             users.put("test1", "pass1");
@@ -127,7 +124,7 @@ public class FileUserRealmIT {
 
             UserRealm userRealm = server.getRealm();
             Collection<String> resultUsers = userRealm.listUsers();
-            assertThat(resultUsers.size(), is(users.size()));
+            assertThat(resultUsers).hasSize(users.size());
 
             users.put("test2", "pass2");
             users.put("test3", "pass3");
@@ -144,12 +141,12 @@ public class FileUserRealmIT {
 
             userRealm = server.getRealm();
             resultUsers = userRealm.listUsers();
-            assertThat(resultUsers.size(), is(users.size()));
+            assertThat(resultUsers).hasSize(users.size());
         }
     }
 
     @Test
-    public void testFileRelativePath() throws Exception {
+    void fileRelativePath() throws Exception {
         try (HttpProxyServer server = buildForTests("localhost", 0, new TestEndpointMapper("localhost", 0), tmpDir)) {
             Properties prop = new Properties();
             prop.setProperty("http.admin.enabled", "true");
@@ -178,10 +175,10 @@ public class FileUserRealmIT {
             server.startAdminInterface();
 
             UserRealm userRealm = server.getRealm();
-            assertNotNull(userRealm.login("test1", "pass1"));
-            assertNotNull(userRealm.login("test2", "pass2"));
+            assertThat(userRealm.login("test1", "pass1")).isNotNull();
+            assertThat(userRealm.login("test2", "pass2")).isNotNull();
 
-            assertNull(userRealm.login("test1", "wrongpass"));
+            assertThat(userRealm.login("test1", "wrongpass")).isNull();
 
             userPropertiesFile.delete();
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/users/FileUserRealmIT.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/users/FileUserRealmIT.java
@@ -87,7 +87,7 @@ public class FileUserRealmIT {
             UserRealm userRealm = server.getRealm();
             Collection<String> resultUsers = userRealm.listUsers();
 
-            assertThat(resultUsers).hasSize(users.size());
+            assertThat(resultUsers).containsExactlyInAnyOrderElementsOf(users.keySet());
             for (String username : users.keySet()) {
                 String login = userRealm.login(username, users.get(username));
 
@@ -124,7 +124,7 @@ public class FileUserRealmIT {
 
             UserRealm userRealm = server.getRealm();
             Collection<String> resultUsers = userRealm.listUsers();
-            assertThat(resultUsers).hasSize(users.size());
+            assertThat(resultUsers).containsExactlyInAnyOrderElementsOf(users.keySet());
 
             users.put("test2", "pass2");
             users.put("test3", "pass3");
@@ -141,7 +141,7 @@ public class FileUserRealmIT {
 
             userRealm = server.getRealm();
             resultUsers = userRealm.listUsers();
-            assertThat(resultUsers).hasSize(users.size());
+            assertThat(resultUsers).containsExactlyInAnyOrderElementsOf(users.keySet());
         }
     }
 

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/HttpUtilsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/HttpUtilsTest.java
@@ -1,17 +1,16 @@
 package org.carapaceproxy.utils;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import org.junit.jupiter.api.Test;
 
-public class HttpUtilsTest {
+class HttpUtilsTest {
 
     @Test
-    public void testStripHopByHopHeaders_standardHeaders() {
+    void stripHopByHopHeadersStandardHeaders() {
         final HttpHeaders headers = new DefaultHttpHeaders();
         headers.add(HttpHeaderNames.HOST, "example.com");
         headers.add(HttpHeaderNames.CONTENT_TYPE, "text/html");
@@ -28,27 +27,27 @@ public class HttpUtilsTest {
         HttpUtils.stripHopByHopHeaders(headers);
 
         // End-to-end headers must be preserved
-        assertThat(headers.get(HttpHeaderNames.HOST), is("example.com"));
-        assertThat(headers.get(HttpHeaderNames.CONTENT_TYPE), is("text/html"));
+        assertThat(headers.get(HttpHeaderNames.HOST)).isEqualTo("example.com");
+        assertThat(headers.get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("text/html");
 
         // Hop-by-hop headers must be stripped
-        assertThat(headers.get(HttpHeaderNames.CONNECTION), is(nullValue()));
-        assertThat(headers.get(HttpHeaderNames.KEEP_ALIVE), is(nullValue()));
-        assertThat(headers.get(HttpHeaderNames.UPGRADE), is(nullValue()));
-        assertThat(headers.get(HttpHeaderNames.TE), is(nullValue()));
-        assertThat(headers.get(HttpHeaderNames.TRAILER), is(nullValue()));
-        assertThat(headers.get(HttpHeaderNames.PROXY_AUTHENTICATE), is(nullValue()));
-        assertThat(headers.get(HttpHeaderNames.PROXY_AUTHORIZATION), is(nullValue()));
-        assertThat(headers.get("proxy-connection"), is(nullValue()));
+        assertThat(headers.get(HttpHeaderNames.CONNECTION)).isNull();
+        assertThat(headers.get(HttpHeaderNames.KEEP_ALIVE)).isNull();
+        assertThat(headers.get(HttpHeaderNames.UPGRADE)).isNull();
+        assertThat(headers.get(HttpHeaderNames.TE)).isNull();
+        assertThat(headers.get(HttpHeaderNames.TRAILER)).isNull();
+        assertThat(headers.get(HttpHeaderNames.PROXY_AUTHENTICATE)).isNull();
+        assertThat(headers.get(HttpHeaderNames.PROXY_AUTHORIZATION)).isNull();
+        assertThat(headers.get("proxy-connection")).isNull();
 
         // Transfer-Encoding is intentionally NOT stripped by stripHopByHopHeaders:
         // Reactor Netty's HTTP/2 codec enforces its removal at the wire level (RFC 9113 §8.2.2),
         // and stripping it here would break HTTP/1.1 chunked proxying.
-        assertThat(headers.get(HttpHeaderNames.TRANSFER_ENCODING), is("chunked"));
+        assertThat(headers.get(HttpHeaderNames.TRANSFER_ENCODING)).isEqualTo("chunked");
     }
 
     @Test
-    public void testStripHopByHopHeaders_dynamicNomination() {
+    void stripHopByHopHeadersDynamicNomination() {
         // RFC 7230 §6.1: any header listed in the Connection header value is also hop-by-hop
         final HttpHeaders headers = new DefaultHttpHeaders();
         headers.add(HttpHeaderNames.HOST, "example.com");
@@ -58,15 +57,15 @@ public class HttpUtilsTest {
 
         HttpUtils.stripHopByHopHeaders(headers);
 
-        assertThat(headers.get(HttpHeaderNames.HOST), is("example.com"));
+        assertThat(headers.get(HttpHeaderNames.HOST)).isEqualTo("example.com");
         // Both the Connection header itself and the dynamically nominated headers must be stripped
-        assertThat(headers.get(HttpHeaderNames.CONNECTION), is(nullValue()));
-        assertThat(headers.get("x-custom-connection-option"), is(nullValue()));
-        assertThat(headers.get("another-option"), is(nullValue()));
+        assertThat(headers.get(HttpHeaderNames.CONNECTION)).isNull();
+        assertThat(headers.get("x-custom-connection-option")).isNull();
+        assertThat(headers.get("another-option")).isNull();
     }
 
     @Test
-    public void testStripHopByHopHeaders_multipleConnectionValues() {
+    void stripHopByHopHeadersMultipleConnectionValues() {
         // Connection header may have multiple values across multiple header entries
         final HttpHeaders headers = new DefaultHttpHeaders(false);  // false = allow duplicate header names
         headers.add(HttpHeaderNames.HOST, "example.com");
@@ -77,14 +76,14 @@ public class HttpUtilsTest {
 
         HttpUtils.stripHopByHopHeaders(headers);
 
-        assertThat(headers.get(HttpHeaderNames.HOST), is("example.com"));
-        assertThat(headers.get(HttpHeaderNames.CONNECTION), is(nullValue()));
-        assertThat(headers.get("opt-a"), is(nullValue()));
-        assertThat(headers.get("opt-b"), is(nullValue()));
+        assertThat(headers.get(HttpHeaderNames.HOST)).isEqualTo("example.com");
+        assertThat(headers.get(HttpHeaderNames.CONNECTION)).isNull();
+        assertThat(headers.get("opt-a")).isNull();
+        assertThat(headers.get("opt-b")).isNull();
     }
 
     @Test
-    public void testStripHopByHopHeaders_noHopByHopHeaders() {
+    void stripHopByHopHeadersNoHopByHopHeaders() {
         // Headers with no hop-by-hop headers are left unchanged
         final HttpHeaders headers = new DefaultHttpHeaders();
         headers.add(HttpHeaderNames.HOST, "example.com");
@@ -93,15 +92,15 @@ public class HttpUtilsTest {
 
         HttpUtils.stripHopByHopHeaders(headers);
 
-        assertThat(headers.get(HttpHeaderNames.HOST), is("example.com"));
-        assertThat(headers.get(HttpHeaderNames.CONTENT_TYPE), is("application/json"));
-        assertThat(headers.get(HttpHeaderNames.CONTENT_LENGTH), is("42"));
+        assertThat(headers.get(HttpHeaderNames.HOST)).isEqualTo("example.com");
+        assertThat(headers.get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("application/json");
+        assertThat(headers.get(HttpHeaderNames.CONTENT_LENGTH)).isEqualTo("42");
     }
 
     @Test
-    public void testStripHopByHopHeaders_emptyHeaders() {
+    void stripHopByHopHeadersEmptyHeaders() {
         final HttpHeaders headers = new DefaultHttpHeaders();
         HttpUtils.stripHopByHopHeaders(headers);
-        assertThat(headers.isEmpty(), is(true));
+        assertThat(headers.isEmpty()).isTrue();
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/HttpUtilsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/HttpUtilsTest.java
@@ -101,6 +101,6 @@ class HttpUtilsTest {
     void stripHopByHopHeadersEmptyHeaders() {
         final HttpHeaders headers = new DefaultHttpHeaders();
         HttpUtils.stripHopByHopHeaders(headers);
-        assertThat(headers.isEmpty()).isTrue();
+        assertThat(headers).isEmpty();
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/utils/TestUtils.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/utils/TestUtils.java
@@ -19,7 +19,8 @@
  */
 package org.carapaceproxy.utils;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,9 +29,7 @@ import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.Key;
-import java.util.Arrays;
 import java.util.concurrent.Callable;
-import org.junit.jupiter.api.Assertions;
 
 /**
  * Utility for tests
@@ -63,13 +62,13 @@ public class TestUtils {
                 Thread.sleep(100);
             }
         } catch (InterruptedException ee) {
-            Assertions.fail("test interrupted!");
+            fail("test interrupted!");
             return;
         } catch (Exception ee) {
-            Assertions.fail("error while evalutaing condition:" + ee);
+            fail("error while evalutaing condition:" + ee);
             return;
         }
-        Assertions.fail("condition not met in time!");
+        fail("condition not met in time!");
     }
 
     public static String deployResource(String resource, File tmpDir) throws IOException {
@@ -83,66 +82,12 @@ public class TestUtils {
     public static int getFreePort() throws IOException {
         try (ServerSocket s = new ServerSocket(0);) {
             System.out.println("Got free ephemeral port " + s.getLocalPort());
-            assertTrue(s.getLocalPort() > 0);
+            assertThat(s.getLocalPort()).isPositive();
             return s.getLocalPort();
         }
     }
 
     public static void assertEqualsKey(Key key1, Key key2) {
-        assertTrue(Arrays.equals(key1.getEncoded(), key2.getEncoded()));
-    }
-
-    /**
-     * ** Copied from JUnit 4.13 ** *
-     */
-    public interface ThrowingRunnable {
-
-        void run() throws Throwable;
-    }
-
-    /**
-     * Asserts that {@code runnable} throws an exception of type {@code expectedThrowable} when executed. If it does not throw an exception, an {@link AssertionError} is thrown. If it throws the wrong
-     * type of exception, an {@code AssertionError} is thrown describing the mismatch; the exception that was actually thrown can be obtained by calling {@link
-     * AssertionError#getCause}.
-     *
-     * @param expectedThrowable the expected type of the exception
-     * @param runnable a function that is expected to throw an exception when executed
-     * @since 4.13
-     */
-    public static void assertThrows(Class<? extends Throwable> expectedThrowable, ThrowingRunnable runnable) {
-        expectThrows(expectedThrowable, runnable);
-    }
-
-    /**
-     * Asserts that {@code runnable} throws an exception of type {@code expectedThrowable} when executed. If it does, the exception object is returned. If it does not throw an exception, an
-     * {@link AssertionError} is thrown. If it throws the wrong type of exception, an {@code
-     * AssertionError} is thrown describing the mismatch; the exception that was actually thrown can be obtained by calling {@link AssertionError#getCause}.
-     *
-     * @param expectedThrowable the expected type of the exception
-     * @param runnable a function that is expected to throw an exception when executed
-     * @return the exception thrown by {@code runnable}
-     * @since 4.13
-     */
-    public static <T extends Throwable> T expectThrows(Class<T> expectedThrowable, ThrowingRunnable runnable) {
-        try {
-            runnable.run();
-        } catch (Throwable actualThrown) {
-            if (expectedThrowable.isInstance(actualThrown)) {
-                @SuppressWarnings("unchecked")
-                T retVal = (T) actualThrown;
-                return retVal;
-            } else {
-                String mismatchMessage = String.format("unexpected exception type thrown expected %s actual %s",
-                        expectedThrowable.getSimpleName(), actualThrown.getClass().getSimpleName());
-
-                // The AssertionError(String, Throwable) ctor is only available on JDK7.
-                AssertionError assertionError = new AssertionError(mismatchMessage);
-                assertionError.initCause(actualThrown);
-                throw assertionError;
-            }
-        }
-        String message = String.format("expected %s to be thrown, but nothing was thrown",
-                expectedThrowable.getSimpleName());
-        throw new AssertionError(message);
+        assertThat(key2.getEncoded()).isEqualTo(key1.getEncoded());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,7 @@
         <libs.mockito>5.20.0</libs.mockito>
         <libs.objenesis>3.3</libs.objenesis>
         <libs.assertj>3.27.7</libs.assertj>
+        <libs.jsonunit>6.2.0</libs.jsonunit>
     </properties>
 
     <dependencyManagement>
@@ -294,6 +295,11 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${libs.assertj}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.javacrumbs.json-unit</groupId>
+                <artifactId>json-unit-assertj</artifactId>
+                <version>${libs.jsonunit}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <libs.wiremock>3.13.1</libs.wiremock>
         <libs.mockito>5.20.0</libs.mockito>
         <libs.objenesis>3.3</libs.objenesis>
-        <libs.hamcrest>3.0</libs.hamcrest>
+        <libs.assertj>3.27.7</libs.assertj>
     </properties>
 
     <dependencyManagement>
@@ -291,9 +291,9 @@
             </dependency>
             <!-- Individual test dependencies -->
             <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest</artifactId>
-                <version>${libs.hamcrest}</version>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${libs.assertj}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>
@@ -525,9 +525,8 @@
                                         <!-- Excluding unnecessary annotations that are bundled in multiple versions by libraries -->
                                         <exclude>com.google.errorprone</exclude>
                                         <exclude>com.google.code.findbugs</exclude>
-                                        <!-- Clashes with org.hamcrest:hamcrest -->
-                                        <exclude>org.hamcrest:hamcrest-core</exclude>
-                                        <exclude>org.hamcrest:hamcrest-library</exclude>
+                                        <!-- AssertJ is the only assertion library: keep Hamcrest off the test classpath -->
+                                        <exclude>org.hamcrest:*</exclude>
                                         <!-- We want only SLF4J as logging APIs and Logback as logging backend -->
                                         <exclude>ch.qos.reload4j:*</exclude>
                                         <exclude>commons-logging:commons-logging</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -525,8 +525,6 @@
                                         <!-- Excluding unnecessary annotations that are bundled in multiple versions by libraries -->
                                         <exclude>com.google.errorprone</exclude>
                                         <exclude>com.google.code.findbugs</exclude>
-                                        <!-- AssertJ is the only assertion library: keep Hamcrest off the test classpath -->
-                                        <exclude>org.hamcrest:*</exclude>
                                         <!-- We want only SLF4J as logging APIs and Logback as logging backend -->
                                         <exclude>ch.qos.reload4j:*</exclude>
                                         <exclude>commons-logging:commons-logging</exclude>


### PR DESCRIPTION
Closes #645. Closes #403.

Three commits, meant to be merged with rebase rather than squashed.

The suite asserted in two vocabularies, JUnit's own assertions and Hamcrest matchers. Jupiter ships no `assertThat`, so #504 had to choose one anyway, and I chose AssertJ: one shape for everything, the subject first, and failure messages that show the value for free. Every test class in the module now asserts through it.

Three OpenRewrite recipes did the bulk of the rewrite, and I converted by hand what they left, mostly matchers nested inside another assertion:

- [MigrateHamcrestToAssertJ](https://docs.openrewrite.org/recipes/java/testing/hamcrest/migratehamcresttoassertj) for the matchers,
- [JUnitToAssertj](https://docs.openrewrite.org/recipes/java/testing/assertj/junittoassertj) for the plain asserts,
- [the AssertJ best practices composite](https://docs.openrewrite.org/recipes/java/testing/assertj/assertj-best-practices) to collapse weak assertions into clearer ones.

The JSON responses are what #403 asks about: those assertions matched a substring of the expected document, so they held only while the serializer kept the same property order. They now go through `json-unit-assertj`, which parses both sides and addresses fields by path.

That needed `herddb-mock` out of the way: `herddb-core` pulls it at compile scope, and its unrelocated copies of a few `json-path` classes made JsonUnit throw `IncompatibleClassChangeError`. Hamcrest stays on the test classpath, since `json-unit-core` depends on it.
