### PR TITLE
Rate-limit the ACME steps per DynamicCertificatesManager run

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/RuntimeServerConfiguration.java
@@ -142,6 +142,7 @@ public class RuntimeServerConfiguration {
     private String localCertificatesStorePath;
     private Set<String> localCertificatesStorePeersIds;
     private int maxAttempts = DEFAULT_MAX_CONNECTIONS_PER_ENDPOINT;
+    private int dynamicCertificatesManagerRateLimit = 300;
     private Set<String> alwaysCachedExtensions = Set.of("png", "gif", "jpg", "jpeg", "js", "css", "woff2", "webp");
 
     public RuntimeServerConfiguration() {
@@ -307,6 +308,8 @@ public class RuntimeServerConfiguration {
 
         maxAttempts = properties.getInt("dynamiccertificatesmanager.errors.maxattempts", maxAttempts);
         LOG.info("dynamiccertificatesmanager.errors.maxattempts={}", maxAttempts);
+        dynamicCertificatesManagerRateLimit = properties.getInt("dynamiccertificatesmanager.ratelimit", dynamicCertificatesManagerRateLimit);
+        LOG.info("dynamiccertificatesmanager.ratelimit={}", dynamicCertificatesManagerRateLimit);
 
         alwaysCachedExtensions = properties.getValues("cache.cachealways", alwaysCachedExtensions);
         LOG.info("cache.cachealways={}", alwaysCachedExtensions);

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
@@ -288,12 +288,22 @@ public class DynamicCertificatesManager implements Runnable {
                 .sorted(Entry.comparingByKey())
                 .map(Entry::getValue)
                 .toList();
+        final int rateLimit = getConfig().getDynamicCertificatesManagerRateLimit();
+        int acmeSteps = 0;
         for (CertificateData data : _certificates) {
             var updateCertificate = true;
             final var domain = data.getDomain();
             try {
                 // this has to be always fetch from db!
                 CertificateData cert = loadOrCreateDynamicCertificateForDomain(domain, data.getSubjectAltNames(), false, data.getDaysBeforeRenewal());
+                if (isAcmeStep(cert)) {
+                    // domains are sorted, so the first N take the slots and the window slides as they become AVAILABLE
+                    if (rateLimit > 0 && acmeSteps >= rateLimit) {
+                        LOG.debug("Rate limit of {} ACME steps per run reached, domain {} postponed to next run", rateLimit, domain);
+                        continue;
+                    }
+                    acmeSteps++;
+                }
                 switch (cert.getState()) {
                     // certificate waiting to be issues/renew
                     case WAITING -> startCertificateProcessing(domain, cert);
@@ -603,6 +613,20 @@ public class DynamicCertificatesManager implements Runnable {
 
     private RuntimeServerConfiguration getConfig() {
         return server.getCurrentConfiguration();
+    }
+
+    /**
+     * Tell whether the next lifecycle step of the certificate contacts the ACME server.
+     *
+     * @param cert the certificate as loaded from the store
+     * @return true if the step performs an ACME call (new order, challenge check, finalization, order check)
+     */
+    private boolean isAcmeStep(final CertificateData cert) {
+        return switch (cert.getState()) {
+            case WAITING, VERIFYING, VERIFIED, ORDERING -> true;
+            case DOMAIN_UNREACHABLE -> cert.getAttemptsCount() <= getConfig().getMaxAttempts();
+            default -> false;
+        };
     }
 
     /**

--- a/carapace-server/src/main/resources/conf/server.dynamic.properties
+++ b/carapace-server/src/main/resources/conf/server.dynamic.properties
@@ -87,6 +87,9 @@ ocspstaplingmanager.period=30
 dynamiccertificatesmanager.period=30
 # public/private keys size for generated certificates, in bytes (default 2048)
 #dynamiccertificatesmanager.keypairssize=
+# max number of certificates that may perform an ACME step (order, challenge, finalization) in the same run,
+# the others are postponed to the next run; 0 = unlimited (default 300)
+#dynamiccertificatesmanager.ratelimit=
 
 
 # Max Connections for backend

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
@@ -308,6 +308,70 @@ public class DynamicCertificatesManagerTest {
     }
 
     @Test
+    @Parameters({"0", "2"})
+    public void testRateLimitPerRun(int rateLimit) throws Exception {
+        // ACME mocking
+        ACMEClient ac = mock(ACMEClient.class);
+        Order o = mock(Order.class);
+        when(o.getLocation()).thenReturn(URI.create("https://localhost/index").toURL());
+        Login login = mock(Login.class);
+        when(login.bindOrder(any())).thenReturn(o);
+        when(ac.getLogin()).thenReturn(login);
+        when(ac.createOrderForDomain(any())).thenReturn(o);
+        Http01Challenge c = mock(Http01Challenge.class);
+        when(c.getToken()).thenReturn("");
+        when(c.getJSON()).thenReturn(JSON.parse("""
+                  {
+                      "url": "https://localhost/index",
+                      "type": "http-01",
+                      "token": "mytoken"
+                  }"""));
+        when(c.getAuthorization()).thenReturn("");
+        when(c.getError()).thenReturn(Optional.empty());
+        when(ac.getChallengesForOrder(any())).thenReturn(Map.of("domain", c));
+        when(ac.checkResponseForChallenge(any())).thenReturn(VALID);
+
+        HttpProxyServer parent = mock(HttpProxyServer.class);
+        when(parent.getListeners()).thenReturn(mock(Listeners.class));
+        DynamicCertificatesManager man = new DynamicCertificatesManager(parent);
+        man.attachGroupMembershipHandler(new NullGroupMembershipHandler());
+        Whitebox.setInternalState(man, ac);
+
+        // Store mocking: three certificates waiting to be ordered
+        ConfigurationStore store = mock(ConfigurationStore.class);
+        when(store.loadKeyPairForDomain(anyString())).thenReturn(KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE));
+        Properties props = new Properties();
+        String[] domains = {"localhost1", "localhost2", "localhost3"};
+        for (int i = 0; i < domains.length; i++) {
+            when(store.loadCertificateForDomain(eq(domains[i]))).thenReturn(new CertificateData(domains[i], null, WAITING));
+            props.setProperty("certificate." + i + ".hostname", domains[i]);
+            props.setProperty("certificate." + i + ".mode", "acme");
+        }
+        man.setConfigurationStore(store);
+
+        // Manager setup
+        props.setProperty("dynamiccertificatesmanager.ratelimit", String.valueOf(rateLimit));
+        RuntimeServerConfiguration conf = new RuntimeServerConfiguration();
+        conf.configure(new PropertiesConfigurationStore(props));
+        when(parent.getCurrentConfiguration()).thenReturn(conf);
+        man.reloadConfiguration(conf);
+
+        // first run: the first two domains (alphabetical order) take the slots, the third is postponed
+        man.run();
+        assertCertificateState("localhost1", VERIFYING, 0, man);
+        assertCertificateState("localhost2", VERIFYING, 0, man);
+        assertCertificateState("localhost3", rateLimit == 0 ? VERIFYING : WAITING, 0, man);
+        verify(store, times(rateLimit == 0 ? 3 : 2)).saveCertificate(any());
+
+        // second run: the two in-flight certificates still take the slots, the third is postponed again
+        man.run();
+        assertCertificateState("localhost1", VERIFIED, 0, man);
+        assertCertificateState("localhost2", VERIFIED, 0, man);
+        assertCertificateState("localhost3", rateLimit == 0 ? VERIFIED : WAITING, 0, man);
+        verify(store, times(rateLimit == 0 ? 6 : 4)).saveCertificate(any());
+    }
+
+    @Test
     // A) record not created -> request failed
     // B) record created but not ready -> request failed after LIMIT attempts
     // C) record created and ready -> VERIFYING


### PR DESCRIPTION
Every run of `DynamicCertificatesManager` advances each non-manual certificate by one step, and most steps are a call to the ACME server: a new order with its challenges, a challenge poll, the order finalization, the order poll. With hundreds of domains a single run grows long and gets close to the Let's Encrypt rate limits.

The new `dynamiccertificatesmanager.ratelimit` property caps how many certificates may perform an ACME step in the same run, 300 by default. The ones past the cap keep their state and are picked up on the next run. Steps that never reach the CA (a state change, the DNS propagation check) are not counted, nor is a `DOMAIN_UNREACHABLE` certificate that has exhausted its attempts, since it would otherwise hold a slot forever. Setting it to `0` restores the current unbounded behaviour.

Domains are processed in sorted order, so the first N take the slots and the window slides as they become available. A certificate that keeps failing at the head of the list holds its slot until `dynamiccertificatesmanager.errors.maxattempts` runs out; a round-robin cursor can replace the sort if that turns out to matter.

Targets `release/2.3`, to be forward-ported to `master`.