### PR TITLE
Harden the certificates lifecycle: idempotent challenge tokens, counted failures, quiet mutex

### DIFF
--- a/carapace-server/pom.xml
+++ b/carapace-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.carapaceproxy</groupId>
         <artifactId>carapace-parent</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/carapace-server/src/main/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandler.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandler.java
@@ -290,20 +290,26 @@ public class ZooKeeperGroupMembershipHandler implements GroupMembershipHandler, 
         InterProcessMutex mutex = mutexes.computeIfAbsent(mutexId, (mId) -> {
             return new InterProcessMutex(client, "/proxy/mutex/" + mutexId);
         });
+        boolean acquired = false;
         try {
-            boolean acquired = mutex.acquire(timeout, TimeUnit.SECONDS);
+            acquired = mutex.acquire(timeout, TimeUnit.SECONDS);
             if (!acquired) {
                 LOG.info("Failed to acquire lock for executeInMutex (mutexId: {}, peerId: {})", mutexId, peerId);
                 return;
             }
             runnable.run();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt(); // restore the flag for the caller
+            LOG.info("Interrupted while waiting for mutex (mutexId: {}, peerId: {})", mutexId, peerId);
         } catch (Exception e) {
-            LOG.error("Failed to acquire lock for executeInMutex (mutexId: {}, peerId: {})", mutexId, peerId, e);
+            LOG.error("Error while executing in mutex (mutexId: {}, peerId: {})", mutexId, peerId, e);
         } finally {
-            try {
-                mutex.release();
-            } catch (Exception e) {
-                LOG.error("Failed to release lock for executeInMutex (mutexId: {}, peerId: {})", mutexId, peerId, e);
+            if (acquired) {
+                try {
+                    mutex.release();
+                } catch (Exception e) {
+                    LOG.error("Failed to release lock for executeInMutex (mutexId: {}, peerId: {})", mutexId, peerId, e);
+                }
             }
         }
     }

--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/HerdDBConfigurationStore.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/HerdDBConfigurationStore.java
@@ -144,8 +144,8 @@ public class HerdDBConfigurationStore implements ConfigurationStore {
     private static final String SELECT_FROM_ACME_CHALLENGE_TOKENS_TABLE = """
             SELECT data from %s WHERE id=?
             """.formatted(ACME_CHALLENGE_TOKENS_TABLE_NAME);
-    private static final String INSERT_INTO_ACME_CHALLENGE_TOKENS_TABLE = """
-            INSERT INTO %s(id, data) values (?, ?)
+    private static final String UPSERT_INTO_ACME_CHALLENGE_TOKENS_TABLE = """
+            UPSERT INTO %s(id, data) values (?, ?)
             """.formatted(ACME_CHALLENGE_TOKENS_TABLE_NAME);
     private static final String DELETE_FROM_ACME_CHALLENGE_TOKENS_TABLE = """
             DELETE from %s WHERE id=?
@@ -522,10 +522,10 @@ public class HerdDBConfigurationStore implements ConfigurationStore {
     @Override
     public void saveAcmeChallengeToken(String id, String data) {
         try (Connection con = datasource.getConnection();
-                PreparedStatement psInsert = con.prepareStatement(INSERT_INTO_ACME_CHALLENGE_TOKENS_TABLE)) {
-            psInsert.setString(1, id);
-            psInsert.setString(2, data);
-            psInsert.executeUpdate();
+                PreparedStatement psUpsert = con.prepareStatement(UPSERT_INTO_ACME_CHALLENGE_TOKENS_TABLE)) {
+            psUpsert.setString(1, id);
+            psUpsert.setString(2, data);
+            psUpsert.executeUpdate();
         } catch (Exception err) {
             LOG.error("Error while performing saving of ACME challenge token with id: {} data: {}", id, data, err);
             throw new ConfigurationStoreException(err);

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/AcmeFailureClassifier.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/AcmeFailureClassifier.java
@@ -1,0 +1,73 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package org.carapaceproxy.server.certificates;
+
+import java.net.URI;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.carapaceproxy.configstore.CertificateData;
+import org.shredzone.acme4j.exception.AcmeException;
+import org.shredzone.acme4j.exception.AcmeLazyLoadingException;
+import org.shredzone.acme4j.exception.AcmeNetworkException;
+import org.shredzone.acme4j.exception.AcmeProtocolException;
+import org.shredzone.acme4j.exception.AcmeRateLimitedException;
+import org.shredzone.acme4j.exception.AcmeServerException;
+
+/**
+ * Classification of the failures raised while talking to an ACME CA.
+ */
+final class AcmeFailureClassifier {
+
+    private static final Set<URI> TRANSIENT_ACME_PROBLEMS = Set.of(
+            URI.create("urn:ietf:params:acme:error:serverInternal"), // CA outage
+            URI.create("urn:ietf:params:acme:error:badNonce") // escaped acme4j's own retry loop
+    );
+    // matches the bare AcmeException("HTTP 503") thrown by acme4j (3.4.0 and 5.1.0 alike) on 5xx without a problem document
+    private static final Pattern HTTP_SERVER_ERROR = Pattern.compile("\\bHTTP 5\\d\\d\\b");
+
+    private AcmeFailureClassifier() {
+    }
+
+    /**
+     * Whether the failure is transient (network error, rate limiting, CA outage) and worth retrying in the same state.
+     * <p>
+     * Anything else has to be {@link CertificateData#error(String) counted on the certificate}:
+     * a CA rejection means the persisted state is no longer usable
+     * (e.g., a pending order belonging to a different CA after a provider change),
+     * and an unexpected local failure would otherwise retry the same broken state forever
+     * without ever surfacing to the user; counting caps both at the configured attempts.
+     * ACME4j may defer the server round-trip of bound resources, wrapping failures in {@link AcmeLazyLoadingException}.
+     *
+     * @param ex the failure raised while processing a certificate
+     * @return true if the failure is worth retrying in the same certificate state
+     */
+    static boolean isTransient(Exception ex) {
+        final var cause = ex instanceof AcmeLazyLoadingException lazy ? lazy.getCause() : ex;
+        return switch (cause) {
+            case AcmeNetworkException ignored -> true;
+            case AcmeRateLimitedException ignored -> true;
+            case AcmeServerException server -> TRANSIENT_ACME_PROBLEMS.contains(server.getType());
+            // a 5xx without a problem document (e.g., a CA outage) surfaces as a bare exception
+            case AcmeException e -> e.getMessage() != null && HTTP_SERVER_ERROR.matcher(e.getMessage()).find();
+            case AcmeProtocolException ignored -> false; // malformed CA response, retrying it won't help
+            default -> false;
+        };
+    }
+}

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
@@ -294,9 +294,10 @@ public class DynamicCertificatesManager implements Runnable {
         for (CertificateData data : _certificates) {
             var updateCertificate = true;
             final var domain = data.getDomain();
+            CertificateData cert = null;
             try {
                 // this has to be always fetch from db!
-                CertificateData cert = loadOrCreateDynamicCertificateForDomain(domain, data.getSubjectAltNames(), false, data.getDaysBeforeRenewal());
+                cert = loadOrCreateDynamicCertificateForDomain(domain, data.getSubjectAltNames(), false, data.getDaysBeforeRenewal());
                 if (isAcmeStep(cert)) {
                     // domains are sorted, so the first N take the slots and the window slides as they become AVAILABLE
                     if (rateLimit > 0 && acmeSteps >= rateLimit) {
@@ -385,6 +386,16 @@ public class DynamicCertificatesManager implements Runnable {
                 // RuntimeException included on purpose, as an escaped one would silently cancel the scheduled task;
                 // this would kill the renewal loop for every certificate
                 LOG.error("Error while handling dynamic certificate for domain {}", domain, ex);
+                if (cert != null && !AcmeFailureClassifier.isTransient(ex)) {
+                    cert.error(ex.getMessage() != null ? ex.getMessage() : ex.toString());
+                    try {
+                        store.saveCertificate(cert);
+                        flushCache = true;
+                    } catch (RuntimeException storeEx) {
+                        // same rationale as above: a db hiccup must not cancel the scheduled task
+                        LOG.error("Error while saving failed certificate for domain {}", domain, storeEx);
+                    }
+                }
             }
         }
         if (flushCache) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
@@ -313,6 +313,8 @@ public class DynamicCertificatesManager implements Runnable {
                     case DOMAIN_UNREACHABLE -> {
                         if (cert.getAttemptsCount() <= getConfig().getMaxAttempts()) {
                             startCertificateProcessing(domain, cert);
+                        } else {
+                            updateCertificate = false; // parked until a manual reset, nothing to persist
                         }
                     }
                     // waiting for dns propagation for all dns challenges
@@ -357,6 +359,8 @@ public class DynamicCertificatesManager implements Runnable {
                         if (cert.getAttemptsCount() <= getConfig().getMaxAttempts()){
                             LOG.info("Certificate issuing for domain: {} current status is FAILED, setting status=WAITING again.", domain);
                             cert.step(WAITING);
+                        } else {
+                            updateCertificate = false; // parked until a manual reset, nothing to persist
                         }
                     }
                     // certificate saved/available/not expired

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
@@ -66,6 +66,7 @@ import org.bouncycastle.util.io.pem.PemWriter;
 import org.carapaceproxy.cluster.GroupMembershipHandler;
 import org.carapaceproxy.configstore.CertificateData;
 import org.carapaceproxy.configstore.ConfigurationStore;
+import org.carapaceproxy.configstore.ConfigurationStoreException;
 import org.carapaceproxy.core.HttpProxyServer;
 import org.carapaceproxy.core.RuntimeServerConfiguration;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
@@ -377,7 +378,12 @@ public class DynamicCertificatesManager implements Runnable {
                     store.saveCertificate(cert);
                     flushCache = true;
                 }
-            } catch (AcmeException | IOException | GeneralSecurityException | IllegalStateException ex) {
+            } catch (ConfigurationStoreException ex) {
+                // a store failure is infra-transient: retried at the next cycle, not counted as a CA rejection
+                LOG.error("Store failure while handling dynamic certificate for domain {}", domain, ex);
+            } catch (AcmeException | IOException | GeneralSecurityException | RuntimeException ex) {
+                // RuntimeException included on purpose, as an escaped one would silently cancel the scheduled task;
+                // this would kill the renewal loop for every certificate
                 LOG.error("Error while handling dynamic certificate for domain {}", domain, ex);
             }
         }

--- a/carapace-server/src/test/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandlerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandlerTest.java
@@ -42,7 +42,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.LoggerFactory;
-import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
@@ -306,7 +305,6 @@ public class ZooKeeperGroupMembershipHandlerTest {
                             6000, false /*acl */, peerId2, Collections.EMPTY_MAP, new Properties())) {
                 peer1.start();
                 peer2.start();
-                errors.list.clear(); // drop the connection noise logged at startup
 
                 // peer1 holds the mutex from another thread (the Curator mutex is reentrant per thread)
                 CountDownLatch held = new CountDownLatch(1);
@@ -324,11 +322,14 @@ public class ZooKeeperGroupMembershipHandlerTest {
 
                 // peer2 times out: nothing runs and nothing is released
                 AtomicBoolean ran = new AtomicBoolean();
-                peer2.executeInMutex("m", 1, () -> ran.set(true));
-                assertFalse(ran.get());
-                assertEquals(List.of(), errors.list.stream().filter(e -> e.getLevel() == Level.ERROR).toList());
-                release.countDown();
-                holder.join();
+                try {
+                    peer2.executeInMutex("m", 1, () -> ran.set(true));
+                    assertFalse(ran.get());
+                    assertEquals(0, logged(errors, "Failed to release lock").size());
+                } finally {
+                    release.countDown();
+                    holder.join();
+                }
 
                 // a failing runnable is logged as such and the mutex is released for the next caller
                 peer1.executeInMutex("m", 10, () -> {
@@ -336,12 +337,14 @@ public class ZooKeeperGroupMembershipHandlerTest {
                 });
                 peer2.executeInMutex("m", 1, () -> ran.set(true));
                 assertTrue(ran.get());
-                List<ILoggingEvent> logged = errors.list.stream().filter(e -> e.getLevel() == Level.ERROR).toList();
-                assertEquals(1, logged.size());
-                assertTrue(logged.get(0).getFormattedMessage().startsWith("Error while executing in mutex"));
+                assertEquals(1, logged(errors, "Error while executing in mutex").size());
             }
         } finally {
             logger.detachAppender(errors);
         }
+    }
+
+    private static List<ILoggingEvent> logged(ListAppender<ILoggingEvent> appender, String messagePrefix) {
+        return appender.list.stream().filter(e -> e.getFormattedMessage().startsWith(messagePrefix)).toList();
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandlerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/cluster/impl/ZooKeeperGroupMembershipHandlerTest.java
@@ -24,11 +24,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.curator.test.TestingServer;
 import org.carapaceproxy.cluster.GroupMembershipHandler;
 import org.carapaceproxy.utils.TestUtils;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import java.util.HashMap;
@@ -38,6 +41,11 @@ import lombok.NoArgsConstructor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.LoggerFactory;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 
 public class ZooKeeperGroupMembershipHandlerTest {
 
@@ -281,6 +289,59 @@ public class ZooKeeperGroupMembershipHandlerTest {
                     assertNull(info);
                 }
             }
+        }
+    }
+
+    @Test
+    public void testExecuteInMutex() throws Exception {
+        Logger logger = (Logger) LoggerFactory.getLogger(ZooKeeperGroupMembershipHandler.class);
+        ListAppender<ILoggingEvent> errors = new ListAppender<>();
+        errors.start();
+        logger.addAppender(errors);
+        try (TestingServer testingServer = new TestingServer(2229, tmpDir.newFolder())) {
+            testingServer.start();
+            try (ZooKeeperGroupMembershipHandler peer1 = new ZooKeeperGroupMembershipHandler(testingServer.getConnectString(),
+                    6000, false /*acl */, peerId1, Collections.EMPTY_MAP, new Properties());
+                    ZooKeeperGroupMembershipHandler peer2 = new ZooKeeperGroupMembershipHandler(testingServer.getConnectString(),
+                            6000, false /*acl */, peerId2, Collections.EMPTY_MAP, new Properties())) {
+                peer1.start();
+                peer2.start();
+                errors.list.clear(); // drop the connection noise logged at startup
+
+                // peer1 holds the mutex from another thread (the Curator mutex is reentrant per thread)
+                CountDownLatch held = new CountDownLatch(1);
+                CountDownLatch release = new CountDownLatch(1);
+                Thread holder = new Thread(() -> peer1.executeInMutex("m", 10, () -> {
+                    held.countDown();
+                    try {
+                        release.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }));
+                holder.start();
+                held.await();
+
+                // peer2 times out: nothing runs and nothing is released
+                AtomicBoolean ran = new AtomicBoolean();
+                peer2.executeInMutex("m", 1, () -> ran.set(true));
+                assertFalse(ran.get());
+                assertEquals(List.of(), errors.list.stream().filter(e -> e.getLevel() == Level.ERROR).toList());
+                release.countDown();
+                holder.join();
+
+                // a failing runnable is logged as such and the mutex is released for the next caller
+                peer1.executeInMutex("m", 10, () -> {
+                    throw new IllegalStateException("boom");
+                });
+                peer2.executeInMutex("m", 1, () -> ran.set(true));
+                assertTrue(ran.get());
+                List<ILoggingEvent> logged = errors.list.stream().filter(e -> e.getLevel() == Level.ERROR).toList();
+                assertEquals(1, logged.size());
+                assertTrue(logged.get(0).getFormattedMessage().startsWith("Error while executing in mutex"));
+            }
+        } finally {
+            logger.detachAppender(errors);
         }
     }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/ConfigurationStoreTest.java
@@ -289,6 +289,9 @@ public class ConfigurationStoreTest {
         store.saveAcmeChallengeToken("token-id", "token-data");
         store.saveAcmeChallengeToken("token-id2", "token-data2");
         assertEquals("token-data", store.loadAcmeChallengeToken("token-id"));
+        // saving an existing token must overwrite it, not fail on the primary key
+        store.saveAcmeChallengeToken("token-id", "token-data-updated");
+        assertEquals("token-data-updated", store.loadAcmeChallengeToken("token-id"));
         assertEquals("token-data2", store.loadAcmeChallengeToken("token-id2"));
         store.deleteAcmeChallengeToken("token-id");
         assertNull(store.loadAcmeChallengeToken("token-id"));

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/AcmeFailureClassifierTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/AcmeFailureClassifierTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.carapaceproxy.server.certificates;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import org.junit.Test;
+import org.shredzone.acme4j.Order;
+import org.shredzone.acme4j.Problem;
+import org.shredzone.acme4j.exception.AcmeException;
+import org.shredzone.acme4j.exception.AcmeLazyLoadingException;
+import org.shredzone.acme4j.exception.AcmeNetworkException;
+import org.shredzone.acme4j.exception.AcmeProtocolException;
+import org.shredzone.acme4j.exception.AcmeRateLimitedException;
+import org.shredzone.acme4j.exception.AcmeServerException;
+import org.shredzone.acme4j.toolbox.JSON;
+
+public class AcmeFailureClassifierTest {
+
+    @Test
+    public void testRejections() throws Exception {
+        // the persisted state is unusable, retrying it won't help
+        assertFalse(AcmeFailureClassifier.isTransient(new AcmeException("unknown order")));
+        assertFalse(AcmeFailureClassifier.isTransient(new AcmeProtocolException("malformed CA response")));
+        assertFalse(AcmeFailureClassifier.isTransient(new AcmeLazyLoadingException(
+                Order.class, URI.create("https://localhost/order").toURL(), new AcmeException("unknown order"))));
+        assertFalse(AcmeFailureClassifier.isTransient(
+                new AcmeServerException(problemOfType("urn:ietf:params:acme:error:unauthorized"))));
+    }
+
+    @Test
+    public void testTransientFailures() throws Exception {
+        // worth retrying in the same state
+        assertTrue(AcmeFailureClassifier.isTransient(new AcmeNetworkException(new IOException("io"))));
+        assertTrue(AcmeFailureClassifier.isTransient(new AcmeRateLimitedException(
+                problemOfType("urn:ietf:params:acme:error:rateLimited"), null, List.of())));
+        assertTrue(AcmeFailureClassifier.isTransient(
+                new AcmeServerException(problemOfType("urn:ietf:params:acme:error:serverInternal"))));
+        assertTrue(AcmeFailureClassifier.isTransient(
+                new AcmeServerException(problemOfType("urn:ietf:params:acme:error:badNonce"))));
+        // a 5xx without a problem document, e.g., from a load balancer
+        assertTrue(AcmeFailureClassifier.isTransient(new AcmeException("HTTP 503")));
+        // unwrapping a lazily-loaded resource failure preserves the transient classification
+        assertTrue(AcmeFailureClassifier.isTransient(new AcmeLazyLoadingException(
+                Order.class,
+                URI.create("https://localhost/order").toURL(),
+                new AcmeNetworkException(new IOException("connection reset")))));
+        // a message-less failure must not blow up the message match
+        assertFalse(AcmeFailureClassifier.isTransient(new AcmeException((String) null)));
+    }
+
+    @Test
+    public void testNonAcmeFailures() {
+        // an unexpected local failure must be counted too, or it would retry invisibly forever
+        assertFalse(AcmeFailureClassifier.isTransient(new IllegalStateException("boom")));
+    }
+
+    private static Problem problemOfType(String type) throws Exception {
+        return new Problem(JSON.parse("{\"type\": \"" + type + "\"}"), URI.create("https://localhost/order").toURL());
+    }
+}

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.shredzone.acme4j.Status.INVALID;
 import static org.shredzone.acme4j.Status.VALID;
+import java.io.IOException;
 import java.net.URI;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
@@ -79,6 +80,7 @@ import org.shredzone.acme4j.challenge.Dns01Challenge;
 import org.shredzone.acme4j.challenge.Http01Challenge;
 import org.shredzone.acme4j.connector.Connection;
 import org.shredzone.acme4j.exception.AcmeException;
+import org.shredzone.acme4j.exception.AcmeNetworkException;
 import org.shredzone.acme4j.toolbox.JSON;
 import org.shredzone.acme4j.util.KeyPairUtils;
 import org.shredzone.acme4j.Problem;
@@ -783,4 +785,58 @@ public class DynamicCertificatesManagerTest {
         }
     }
 
+    @Test
+    @Parameters({"stale", "transient", "store"})
+    public void testPendingOrderPollFailure(String failureCase) throws Exception {
+        // ACME mocking: the pending order cannot be polled back from the CA
+        ACMEClient ac = mock(ACMEClient.class);
+        Login login = mock(Login.class);
+        Order order = mock(Order.class);
+        when(login.bindOrder(any())).thenReturn(order);
+        when(ac.getLogin()).thenReturn(login);
+        doThrow(switch (failureCase) {
+            case "transient" -> new AcmeNetworkException(new IOException("connection reset"));
+            case "store" -> new ConfigurationStoreException(new IOException("db down"));
+            // e.g., the order belongs to a different CA after a provider change
+            default -> new AcmeException("unknown order");
+        }).when(ac).checkResponseForOrder(any());
+
+        HttpProxyServer parent = mock(HttpProxyServer.class);
+        when(parent.getListeners()).thenReturn(mock(Listeners.class));
+        DynamicCertificatesManager man = new DynamicCertificatesManager(parent);
+        man.attachGroupMembershipHandler(new NullGroupMembershipHandler());
+        Whitebox.setInternalState(man, ac);
+
+        // Store mocking
+        ConfigurationStore store = mock(ConfigurationStore.class);
+        String domain = "localhost";
+        CertificateData cd = new CertificateData(domain, null, ORDERING);
+        cd.setPendingOrderLocation(URI.create("https://old-ca.example.com/order/1").toURL());
+        when(store.loadCertificateForDomain(eq(domain))).thenReturn(cd);
+        man.setConfigurationStore(store);
+
+        // Manager setup
+        Properties props = new Properties();
+        props.setProperty("certificate.1.hostname", domain);
+        props.setProperty("certificate.1.mode", "acme");
+        props.setProperty("dynamiccertificatesmanager.errors.maxattempts", String.valueOf(MAX_ATTEMPTS));
+        RuntimeServerConfiguration conf = new RuntimeServerConfiguration();
+        conf.configure(new PropertiesConfigurationStore(props));
+        when(parent.getCurrentConfiguration()).thenReturn(conf);
+        man.reloadConfiguration(conf);
+
+        man.run();
+
+        if (failureCase.equals("stale")) {
+            // failure counted, so the certificate falls back to WAITING and a fresh order
+            assertCertificateState(domain, REQUEST_FAILED, 1, man);
+            assertEquals("unknown order", man.getCertificateDataForDomain(domain).getMessage());
+            man.run();
+            assertCertificateState(domain, WAITING, 1, man);
+        } else {
+            // transient ACME and store failures alike: state untouched and nothing persisted, retried at the next cycle
+            assertCertificateState(domain, ORDERING, 0, man);
+            verify(store, never()).saveCertificate(any());
+        }
+    }
 }

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
@@ -35,11 +35,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -48,6 +50,8 @@ import static org.shredzone.acme4j.Status.VALID;
 import java.net.URI;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
+import java.sql.SQLException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +62,7 @@ import junitparams.Parameters;
 import org.carapaceproxy.cluster.impl.NullGroupMembershipHandler;
 import org.carapaceproxy.configstore.CertificateData;
 import org.carapaceproxy.configstore.ConfigurationStore;
+import org.carapaceproxy.configstore.ConfigurationStoreException;
 import org.carapaceproxy.configstore.PropertiesConfigurationStore;
 import org.carapaceproxy.core.HttpProxyServer;
 import org.carapaceproxy.core.Listeners;
@@ -369,6 +374,59 @@ public class DynamicCertificatesManagerTest {
         assertCertificateState("localhost2", VERIFIED, 0, man);
         assertCertificateState("localhost3", rateLimit == 0 ? VERIFIED : WAITING, 0, man);
         verify(store, times(rateLimit == 0 ? 6 : 4)).saveCertificate(any());
+    }
+
+    @Test
+    public void testStoreFailureDoesNotAbortTheRun() throws Exception {
+        // ACME mocking: one order per domain, whose http-01 challenge token is the domain itself
+        ACMEClient ac = mock(ACMEClient.class);
+        when(ac.createOrderForDomain(any())).thenAnswer(invocation -> {
+            String domain = invocation.<Collection<String>>getArgument(0).iterator().next();
+            Order o = mock(Order.class);
+            when(o.getLocation()).thenReturn(URI.create("https://localhost/order/" + domain).toURL());
+            return o;
+        });
+        when(ac.getChallengesForOrder(any())).thenAnswer(invocation -> {
+            String domain = invocation.<Order>getArgument(0).getLocation().getPath().substring("/order/".length());
+            Http01Challenge c = mock(Http01Challenge.class);
+            when(c.getToken()).thenReturn(domain);
+            when(c.getJSON()).thenReturn(JSON.parse("{\"url\": \"https://localhost/index\", \"type\": \"http-01\", \"token\": \"" + domain + "\"}"));
+            when(c.getAuthorization()).thenReturn("");
+            return Map.of(domain, c);
+        });
+
+        HttpProxyServer parent = mock(HttpProxyServer.class);
+        when(parent.getListeners()).thenReturn(mock(Listeners.class));
+        DynamicCertificatesManager man = new DynamicCertificatesManager(parent);
+        man.attachGroupMembershipHandler(new NullGroupMembershipHandler());
+        Whitebox.setInternalState(man, ac);
+
+        // Store mocking: three certificates waiting to be ordered, the store fails on the first domain's token only
+        ConfigurationStore store = mock(ConfigurationStore.class);
+        when(store.loadKeyPairForDomain(anyString())).thenReturn(KeyPairUtils.createKeyPair(DEFAULT_KEYPAIRS_SIZE));
+        doThrow(new ConfigurationStoreException(new SQLException("duplicate key"))).when(store).saveAcmeChallengeToken(eq("localhost1"), any());
+        Properties props = new Properties();
+        String[] domains = {"localhost1", "localhost2", "localhost3"};
+        for (int i = 0; i < domains.length; i++) {
+            when(store.loadCertificateForDomain(eq(domains[i]))).thenReturn(new CertificateData(domains[i], null, WAITING));
+            props.setProperty("certificate." + i + ".hostname", domains[i]);
+            props.setProperty("certificate." + i + ".mode", "acme");
+        }
+        man.setConfigurationStore(store);
+
+        // Manager setup
+        RuntimeServerConfiguration conf = new RuntimeServerConfiguration();
+        conf.configure(new PropertiesConfigurationStore(props));
+        when(parent.getCurrentConfiguration()).thenReturn(conf);
+        man.reloadConfiguration(conf);
+
+        // every domain is attempted, the failing one is not saved, the following ones (alphabetical order) still progress
+        man.run();
+        verify(store, times(3)).saveAcmeChallengeToken(any(), any());
+        assertCertificateState("localhost2", VERIFYING, 0, man);
+        assertCertificateState("localhost3", VERIFYING, 0, man);
+        verify(store, times(2)).saveCertificate(any());
+        verify(store, never()).saveCertificate(argThat(cd -> cd.getDomain().equals("localhost1")));
     }
 
     @Test

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerTest.java
@@ -250,7 +250,8 @@ public class DynamicCertificatesManagerTest {
                     man.getCertificateDataForDomain(d1).getMessage()
             );
             man.run();
-            verify(store, times(++saveCounter)).saveCertificate(any());
+            // a certificate parked past the attempts limit is left alone, nothing is saved
+            verify(store, times(maxedOutTrials ? saveCounter : ++saveCounter)).saveCertificate(any());
             assertCertificateState(d1, maxedOutTrials ? REQUEST_FAILED : WAITING, expectedCycleCount, man);
             return;
         } else { // VERIFYING
@@ -260,7 +261,8 @@ public class DynamicCertificatesManagerTest {
             if (runCase.equals("order_finalization_error")) {
                 assertCertificateState(d1, REQUEST_FAILED, ++expectedCycleCount, man);
                 man.run();
-                verify(store, times(++saveCounter)).saveCertificate(any());
+                // a certificate parked past the attempts limit is left alone, nothing is saved
+                verify(store, times(maxedOutTrials ? saveCounter : ++saveCounter)).saveCertificate(any());
                 assertCertificateState(d1, maxedOutTrials ? REQUEST_FAILED : WAITING, expectedCycleCount, man);
                 return;
             } else {
@@ -282,7 +284,8 @@ public class DynamicCertificatesManagerTest {
         );
         man.run();
         if (runCase.equals("order_response_error")) { // REQUEST_FAILED
-            verify(store, times(++saveCounter)).saveCertificate(any());
+            // a certificate parked past the attempts limit is left alone, nothing is saved
+            verify(store, times(maxedOutTrials ? saveCounter : ++saveCounter)).saveCertificate(any());
             assertCertificateState(d1, maxedOutTrials ? REQUEST_FAILED : WAITING, expectedCycleCount, man);
         } else { // AVAILABLE
             DynamicCertificateState state = man.getStateOfCertificate(d1);
@@ -838,5 +841,50 @@ public class DynamicCertificatesManagerTest {
             assertCertificateState(domain, ORDERING, 0, man);
             verify(store, never()).saveCertificate(any());
         }
+    }
+
+    @Test
+    public void testParkedCertificatesAreNotSaved() throws Exception {
+        HttpProxyServer parent = mock(HttpProxyServer.class);
+        when(parent.getListeners()).thenReturn(mock(Listeners.class));
+        DynamicCertificatesManager man = new DynamicCertificatesManager(parent);
+        man.attachGroupMembershipHandler(new NullGroupMembershipHandler());
+        Whitebox.setInternalState(man, mock(ACMEClient.class));
+
+        // Store mocking: two certificates parked past the attempts limit, one still within it
+        ConfigurationStore store = mock(ConfigurationStore.class);
+        CertificateData unreachable = new CertificateData("localhost1", null, DOMAIN_UNREACHABLE);
+        unreachable.setAttemptsCount(MAX_ATTEMPTS + 1);
+        CertificateData failed = new CertificateData("localhost2", null, REQUEST_FAILED);
+        failed.setAttemptsCount(MAX_ATTEMPTS + 1);
+        CertificateData retriable = new CertificateData("localhost3", null, REQUEST_FAILED);
+        retriable.setAttemptsCount(MAX_ATTEMPTS);
+        Properties props = new Properties();
+        int i = 0;
+        for (CertificateData cd : List.of(unreachable, failed, retriable)) {
+            when(store.loadCertificateForDomain(eq(cd.getDomain()))).thenReturn(cd);
+            props.setProperty("certificate." + i + ".hostname", cd.getDomain());
+            props.setProperty("certificate." + i + ".mode", "acme");
+            i++;
+        }
+        man.setConfigurationStore(store);
+
+        // Manager setup
+        props.setProperty("dynamiccertificatesmanager.errors.maxattempts", String.valueOf(MAX_ATTEMPTS));
+        RuntimeServerConfiguration conf = new RuntimeServerConfiguration();
+        conf.configure(new PropertiesConfigurationStore(props));
+        when(parent.getCurrentConfiguration()).thenReturn(conf);
+        man.reloadConfiguration(conf);
+
+        man.run();
+
+        // parked certificates are left alone: nothing to persist, no cluster-wide reload
+        assertCertificateState("localhost1", DOMAIN_UNREACHABLE, MAX_ATTEMPTS + 1, man);
+        assertCertificateState("localhost2", REQUEST_FAILED, MAX_ATTEMPTS + 1, man);
+        verify(store, never()).saveCertificate(unreachable);
+        verify(store, never()).saveCertificate(failed);
+        // the one within the limit is retried as before
+        assertCertificateState("localhost3", WAITING, MAX_ATTEMPTS, man);
+        verify(store, times(1)).saveCertificate(retriable);
     }
 }

--- a/carapace-ui/pom.xml
+++ b/carapace-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.carapaceproxy</groupId>
         <artifactId>carapace-parent</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.carapaceproxy</groupId>
     <artifactId>carapace-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.3.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Carapace :: Parent</name>


### PR DESCRIPTION
Four fixes to `DynamicCertificatesManager` and its cluster mutex, found while triaging a 2.3.0 rollout with about a thousand ACME certificates. Each is its own commit.

**Challenge tokens are now upserted.** `saveAcmeChallengeToken` did a plain `INSERT` into `acme_challenge_tokens`. The CA reuses a pending authorization, and with it the same token, when the same domain is ordered again within a few days, so the second order hit the primary key with `DuplicatePrimaryKeyException`. The resulting `ConfigurationStoreException` is a `RuntimeException`, which the lifecycle loop did not catch: the run died there and every domain after it in alphabetical order was never processed again. HerdDB supports `UPSERT INTO` natively, so the statement just changes keyword. The loop now also catches `RuntimeException` (a store failure is logged and retried at the next cycle, not counted against the certificate), so one broken domain can no longer take the others down with it. `master` has the same `INSERT` and needs the first half of this commit.

**Non-transient failures are counted on the certificate.** Partial backport of issue #536 → PR #620: `AcmeFailureClassifier` and its test are taken verbatim, and the lifecycle catch now moves the certificate to `REQUEST_FAILED` and increments its attempts unless the failure is transient (network error, rate limit, CA outage, bare 5xx, store failure). Before this a CA rejection or a stale order was logged and retried identically every period, forever, without ever surfacing in the UI. After `dynamiccertificatesmanager.errors.maxattempts` the domain stays parked until a reset. This is a behaviour change worth knowing about when reviewing. Not needed on `master`.

**The cluster mutex is released only when it was acquired.** `executeInMutex` released in `finally` even after a failed `acquire`, so every node that is not the current leader logged `IllegalMonitorStateException` at ERROR on each period. A failing runnable was also logged as a lock acquisition failure; it now has its own message.

**Certificates parked past the attempts limit are left alone.** A `DOMAIN_UNREACHABLE` or `REQUEST_FAILED` certificate beyond the limit was still saved on every run, and that save flagged the run as changed: a single dead domain in the configuration made every node reload all certificates from the database each period, with the full `RELOADED` log for each of them.

Each commit comes with a regression test that fails on `release/2.3` as it is. The mutex test captures the handler's log with a Logback `ListAppender`, since the bug only shows up as a logged exception.

The last commit is the development version bump of `release/2.3` to `2.3.1-SNAPSHOT`, cherry-picked from PR #652 so that this branch builds as the next patch release.

Targets `release/2.3`. Forward-port to `master`: the `UPSERT` from the first commit, and the third and fourth commits as clean cherry-picks.
